### PR TITLE
Toki v2.1.0 - `get smart --amend`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.1.0 - 2026-07-11
+
+### Added
+
+- Smart recommendation panel that suggests the healthiest AI coding account to use next.
+- One-click best-account switching for Claude Code accounts discovered through `claude-swap`.
+- Native low-quota and session-warning notifications with DND mode, cooldowns, and local event history.
+- Local usage history retained in `~/.toki/usage-state.json`.
+- Session mode for tracking quota burn during focused coding work.
+- Settings tab for notifications, DND, thresholds, history retention, and menu bar display mode.
+- Menu bar display modes for smart, lowest, Claude, Codex, combined, or account-count status.
+
 ## 2.0.5 - 2026-07-08
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Smart recommendation panel that suggests the healthiest AI coding account to use next.
-- One-click best-account switching for Claude Code accounts discovered through `claude-swap`.
+- One-click switch to the recommended Claude Code account from the overview (Claude Code accounts only, via `claude-swap`).
 - Native low-quota and session-warning notifications with DND mode, cooldowns, and local event history.
 - Local usage history retained in `~/.toki/usage-state.json`.
 - Session mode for tracking quota burn during focused coding work.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   <img alt="Version 2.1.0" src="https://img.shields.io/badge/version-2.1.0-2f80ed">
   <img alt="macOS 14+" src="https://img.shields.io/badge/macOS-14%2B-111111">
   <img alt="Swift 6" src="https://img.shields.io/badge/Swift-6-f05138">
+  <a href="https://github.com/aashutoshrathi/toki"><img alt="Contribute on GitHub" src="https://img.shields.io/badge/contribute-GitHub-24292e?logo=github"></a>
 </p>
 
 <p align="center">
@@ -39,7 +40,7 @@ Toki stays local. Credentials are read from your Mac, your configured commands, 
 - Claude Code 5-hour and 7-day utilization, reset timing, and spend data when available.
 - Codex usage and rate-limit display through the local Codex app-server.
 - Smart recommendation panel for which coding account to use next.
-- One-click best-account switching for Claude Code accounts discovered through `claude-swap`.
+- One-click switch to the recommended Claude Code account, straight from the overview (Claude Code accounts only, via `claude-swap`).
 - Native low-quota notifications with cooldowns, DND mode, and local event history.
 - Local usage history so recent quota movement is visible without opening provider tools.
 - Session mode for tracking quota burn during a focused coding run.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version 2.0.1" src="https://img.shields.io/badge/version-2.0.1-2f80ed">
+  <img alt="Version 2.1.0" src="https://img.shields.io/badge/version-2.1.0-2f80ed">
   <img alt="macOS 14+" src="https://img.shields.io/badge/macOS-14%2B-111111">
   <img alt="Swift 6" src="https://img.shields.io/badge/Swift-6-f05138">
 </p>
@@ -38,6 +38,12 @@ Toki stays local. Credentials are read from your Mac, your configured commands, 
 - Inactive Claude account lookup from macOS Keychain service `claude-swap`.
 - Claude Code 5-hour and 7-day utilization, reset timing, and spend data when available.
 - Codex usage and rate-limit display through the local Codex app-server.
+- Smart recommendation panel for which coding account to use next.
+- One-click best-account switching for Claude Code accounts discovered through `claude-swap`.
+- Native low-quota notifications with cooldowns, DND mode, and local event history.
+- Local usage history so recent quota movement is visible without opening provider tools.
+- Session mode for tracking quota burn during a focused coding run.
+- Menu bar display modes for smart, lowest, Claude, Codex, combined, or account-count status.
 - Inline account aliases so long emails can become readable names.
 - Switch button for inactive Claude Code accounts via `claude-swap --switch-to`.
 - Optional manual ledgers for consumer plans where exact provider APIs are not available.
@@ -131,6 +137,20 @@ Minimal Claude Code plus Codex config:
 
 `refreshMinutes` defaults to `5`. API-backed providers refresh stale-while-revalidate style: Toki keeps the last visible usage while refreshing in the background. Automatic refreshes pace Claude Code API calls at 7.5 minutes to reduce early `429` responses, while Codex uses the 5-minute cadence. Opening the popover or pressing reload can refresh sooner, but still keeps a 1-minute minimum between provider API calls. If a provider returns `429`, Toki keeps showing the last good usage snapshot.
 
+### Smart Recommendations, Notifications, and History
+
+Toki keeps v2.1 preferences, notification cooldowns, event history, usage history, and session state in:
+
+```text
+~/.toki/usage-state.json
+```
+
+The Settings tab controls native notifications, DND mode, low-quota threshold, session warning threshold, notification cooldown, history retention, and the menu bar display mode. DND mode suppresses macOS notification delivery but still records events so you can audit what would have fired.
+
+The recommendation panel picks the healthiest available account from live snapshots. For Claude Code multi-account setups, it can switch to the recommended inactive account through the same configured `claude-swap --switch-to` path used by account rows.
+
+Session mode records starting quota for visible accounts, then shows burn during the current coding session and logs session warning events when quota drops sharply or crosses the configured warning threshold.
+
 ### Environment Overrides
 
 ```sh
@@ -206,6 +226,7 @@ Toki keeps backwards-compatible config fallbacks for the old TokenBar name, but 
 - `Claude Code usage unavailable`: Anthropic did not return usage data for that account. Try refreshing later or check the account in Claude Code.
 - `Codex usage unavailable`: confirm `codex login` has created `~/.codex/auth.json`, then refresh Toki.
 - Switch fails: run `claude-swap --switch-to <slot>` in Terminal to inspect the underlying error.
+- Notifications do not appear: open the Events tab to check whether DND or cooldowns suppressed delivery, then confirm macOS notification permission for Toki.
 
 ## License
 

--- a/Sources/Toki/API/UsageFetcher.swift
+++ b/Sources/Toki/API/UsageFetcher.swift
@@ -148,19 +148,15 @@ enum UsageFetcher {
         case .claudeCode:
             let snapshots = previousByID.values
                 .filter { $0.provider == .claudeCode && ($0.id == account.id || $0.id.hasPrefix("claude-")) }
-                .filter { !isLoadingSnapshot($0) }
+                .filter { !$0.isLoadingPlaceholder }
                 .sorted { $0.id < $1.id }
             return snapshots.isEmpty ? nil : snapshots
         default:
-            guard let snapshot = previousByID[account.id], !isLoadingSnapshot(snapshot) else {
+            guard let snapshot = previousByID[account.id], !snapshot.isLoadingPlaceholder else {
                 return nil
             }
             return [snapshot]
         }
-    }
-
-    private static func isLoadingSnapshot(_ snapshot: AccountSnapshot) -> Bool {
-        snapshot.primary == "Refreshing" && snapshot.metrics.isEmpty && snapshot.remainingRatio == nil
     }
 
     private static func containsRateLimit(_ snapshots: [AccountSnapshot]) -> Bool {

--- a/Sources/Toki/API/UsageFetcher.swift
+++ b/Sources/Toki/API/UsageFetcher.swift
@@ -148,11 +148,19 @@ enum UsageFetcher {
         case .claudeCode:
             let snapshots = previousByID.values
                 .filter { $0.provider == .claudeCode && ($0.id == account.id || $0.id.hasPrefix("claude-")) }
+                .filter { !isLoadingSnapshot($0) }
                 .sorted { $0.id < $1.id }
             return snapshots.isEmpty ? nil : snapshots
         default:
-            return previousByID[account.id].map { [$0] }
+            guard let snapshot = previousByID[account.id], !isLoadingSnapshot(snapshot) else {
+                return nil
+            }
+            return [snapshot]
         }
+    }
+
+    private static func isLoadingSnapshot(_ snapshot: AccountSnapshot) -> Bool {
+        snapshot.primary == "Refreshing" && snapshot.metrics.isEmpty && snapshot.remainingRatio == nil
     }
 
     private static func containsRateLimit(_ snapshots: [AccountSnapshot]) -> Bool {

--- a/Sources/Toki/App/AppDelegate.swift
+++ b/Sources/Toki/App/AppDelegate.swift
@@ -28,8 +28,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         popover.delegate = self
 
         Task { @MainActor in
-            for await snapshots in store.$snapshots.values {
-                let entries = menuBarEntries(for: snapshots)
+            for await entries in store.$statusEntries.values {
                 updateStatusItem(entries: entries.isEmpty ? menuBarPlaceholderEntries() : entries)
             }
         }

--- a/Sources/Toki/Config/Constants.swift
+++ b/Sources/Toki/Config/Constants.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-let appVersion = "2.0.5"
+let appVersion = "2.1.0"
 let appUserAgent = "Toki/\(appVersion)"
 let defaultConfigPath = "~/.toki/config.json"
 let defaultStatePath = "~/.toki/usage-state.json"

--- a/Sources/Toki/Models/AccountSnapshot.swift
+++ b/Sources/Toki/Models/AccountSnapshot.swift
@@ -23,12 +23,18 @@ struct AccountSnapshot: Identifiable, Hashable {
     var emoji: String?
     var colorHex: String?
 
+    static let loadingPrimary = "Refreshing"
+
+    var isLoadingPlaceholder: Bool {
+        primary == AccountSnapshot.loadingPrimary && metrics.isEmpty && remainingRatio == nil
+    }
+
     static func loading(for account: AccountConfig) -> AccountSnapshot {
         AccountSnapshot(
             id: account.id,
             name: account.name,
             provider: account.provider,
-            primary: "Refreshing",
+            primary: loadingPrimary,
             subtitle: account.provider.displayName,
             remainingRatio: nil,
             progressRatio: nil,

--- a/Sources/Toki/Models/ClaudeCodeModels.swift
+++ b/Sources/Toki/Models/ClaudeCodeModels.swift
@@ -58,9 +58,8 @@ struct ClaudeCodeUsage {
         if let sevenDay = data["seven_day"] as? [String: Any] {
             appendWindow("7d", sevenDay)
         }
-        if let extraUsage = data["extra_usage"] as? [String: Any],
-           (extraUsage["is_enabled"] as? Bool) == true {
-            appendSpend(extraUsage)
+        if let extraUsage = data["extra_usage"] as? [String: Any] {
+            appendExtraUsage(extraUsage)
         }
     }
 
@@ -89,19 +88,24 @@ struct ClaudeCodeUsage {
         metrics.append(MetricLine(label: label, value: value))
     }
 
-    private mutating func appendSpend(_ extraUsage: [String: Any]) {
-        guard let usedCents = optionalNumber(extraUsage["used_credits"]),
-              let limitCents = optionalNumber(extraUsage["monthly_limit"]),
-              let utilization = optionalNumber(extraUsage["utilization"]) else {
+    private mutating func appendExtraUsage(_ extraUsage: [String: Any]) {
+        guard (extraUsage["is_enabled"] as? Bool) == true else {
+            metrics.append(MetricLine(label: "Extra", value: "Disabled"))
             return
         }
 
+        guard let usedCents = optionalNumber(extraUsage["used_credits"]),
+              let limitCents = optionalNumber(extraUsage["monthly_limit"]),
+              let utilization = optionalNumber(extraUsage["utilization"]) else {
+            metrics.append(MetricLine(label: "Extra", value: "Enabled"))
+            return
+        }
         var value = "\(formatUSD(usedCents / 100)) / \(formatUSD(limitCents / 100))"
         value += " - \(Int(utilization.rounded()))%"
         if let reset = resetDescription(extraUsage["resets_at"]) {
             value += " - resets \(reset)"
         }
-        metrics.append(MetricLine(label: "Spend", value: value))
+        metrics.append(MetricLine(label: "Extra", value: value))
     }
 }
 
@@ -115,4 +119,5 @@ struct MenuBarStatusEntry: Identifiable {
     var id: Provider { provider }
     var provider: Provider
     var value: String
+    var leadingText: String? = nil
 }

--- a/Sources/Toki/Models/SmartRecommendation.swift
+++ b/Sources/Toki/Models/SmartRecommendation.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct SmartRecommendation: Equatable {
+    var title: String
+    var detail: String
+    var accountID: String?
+    var switchTarget: String?
+    var switchCommand: String?
+    var severity: RecommendationSeverity
+}
+
+enum RecommendationSeverity: Equatable {
+    case good
+    case warning
+    case critical
+    case neutral
+}

--- a/Sources/Toki/Models/UsageState.swift
+++ b/Sources/Toki/Models/UsageState.swift
@@ -4,6 +4,7 @@ struct UsageState: Codable {
     var accounts: [String: AccountUsageState] = [:]
     var apiLastCalledAt: [String: Date] = [:]
     var notificationLastSentAt: [String: Date] = [:]
+    var eventLastRecordedAt: [String: Date] = [:]
     var preferences = AppPreferences()
     var events: [TokiEvent] = []
     var history: [UsageHistoryEntry] = []
@@ -13,6 +14,7 @@ struct UsageState: Codable {
         case accounts
         case apiLastCalledAt
         case notificationLastSentAt
+        case eventLastRecordedAt
         case preferences
         case events
         case history
@@ -23,6 +25,7 @@ struct UsageState: Codable {
         accounts: [String: AccountUsageState] = [:],
         apiLastCalledAt: [String: Date] = [:],
         notificationLastSentAt: [String: Date] = [:],
+        eventLastRecordedAt: [String: Date] = [:],
         preferences: AppPreferences = AppPreferences(),
         events: [TokiEvent] = [],
         history: [UsageHistoryEntry] = [],
@@ -31,6 +34,7 @@ struct UsageState: Codable {
         self.accounts = accounts
         self.apiLastCalledAt = apiLastCalledAt
         self.notificationLastSentAt = notificationLastSentAt
+        self.eventLastRecordedAt = eventLastRecordedAt
         self.preferences = preferences
         self.events = events
         self.history = history
@@ -42,6 +46,7 @@ struct UsageState: Codable {
         accounts = try container.decodeIfPresent([String: AccountUsageState].self, forKey: .accounts) ?? [:]
         apiLastCalledAt = try container.decodeIfPresent([String: Date].self, forKey: .apiLastCalledAt) ?? [:]
         notificationLastSentAt = try container.decodeIfPresent([String: Date].self, forKey: .notificationLastSentAt) ?? [:]
+        eventLastRecordedAt = try container.decodeIfPresent([String: Date].self, forKey: .eventLastRecordedAt) ?? [:]
         preferences = try container.decodeIfPresent(AppPreferences.self, forKey: .preferences) ?? AppPreferences()
         events = try container.decodeIfPresent([TokiEvent].self, forKey: .events) ?? []
         history = try container.decodeIfPresent([UsageHistoryEntry].self, forKey: .history) ?? []

--- a/Sources/Toki/Models/UsageState.swift
+++ b/Sources/Toki/Models/UsageState.swift
@@ -3,7 +3,6 @@ import Foundation
 struct UsageState: Codable {
     var accounts: [String: AccountUsageState] = [:]
     var apiLastCalledAt: [String: Date] = [:]
-    var notificationLastSentAt: [String: Date] = [:]
     var eventLastRecordedAt: [String: Date] = [:]
     var preferences = AppPreferences()
     var events: [TokiEvent] = []
@@ -13,7 +12,6 @@ struct UsageState: Codable {
     enum CodingKeys: String, CodingKey {
         case accounts
         case apiLastCalledAt
-        case notificationLastSentAt
         case eventLastRecordedAt
         case preferences
         case events
@@ -24,7 +22,6 @@ struct UsageState: Codable {
     init(
         accounts: [String: AccountUsageState] = [:],
         apiLastCalledAt: [String: Date] = [:],
-        notificationLastSentAt: [String: Date] = [:],
         eventLastRecordedAt: [String: Date] = [:],
         preferences: AppPreferences = AppPreferences(),
         events: [TokiEvent] = [],
@@ -33,7 +30,6 @@ struct UsageState: Codable {
     ) {
         self.accounts = accounts
         self.apiLastCalledAt = apiLastCalledAt
-        self.notificationLastSentAt = notificationLastSentAt
         self.eventLastRecordedAt = eventLastRecordedAt
         self.preferences = preferences
         self.events = events
@@ -45,7 +41,6 @@ struct UsageState: Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         accounts = try container.decodeIfPresent([String: AccountUsageState].self, forKey: .accounts) ?? [:]
         apiLastCalledAt = try container.decodeIfPresent([String: Date].self, forKey: .apiLastCalledAt) ?? [:]
-        notificationLastSentAt = try container.decodeIfPresent([String: Date].self, forKey: .notificationLastSentAt) ?? [:]
         eventLastRecordedAt = try container.decodeIfPresent([String: Date].self, forKey: .eventLastRecordedAt) ?? [:]
         preferences = try container.decodeIfPresent(AppPreferences.self, forKey: .preferences) ?? AppPreferences()
         events = try container.decodeIfPresent([TokiEvent].self, forKey: .events) ?? []

--- a/Sources/Toki/Models/UsageState.swift
+++ b/Sources/Toki/Models/UsageState.swift
@@ -3,25 +3,129 @@ import Foundation
 struct UsageState: Codable {
     var accounts: [String: AccountUsageState] = [:]
     var apiLastCalledAt: [String: Date] = [:]
+    var notificationLastSentAt: [String: Date] = [:]
+    var preferences = AppPreferences()
+    var events: [TokiEvent] = []
+    var history: [UsageHistoryEntry] = []
+    var session: SessionState?
 
     enum CodingKeys: String, CodingKey {
         case accounts
         case apiLastCalledAt
+        case notificationLastSentAt
+        case preferences
+        case events
+        case history
+        case session
     }
 
-    init(accounts: [String: AccountUsageState] = [:], apiLastCalledAt: [String: Date] = [:]) {
+    init(
+        accounts: [String: AccountUsageState] = [:],
+        apiLastCalledAt: [String: Date] = [:],
+        notificationLastSentAt: [String: Date] = [:],
+        preferences: AppPreferences = AppPreferences(),
+        events: [TokiEvent] = [],
+        history: [UsageHistoryEntry] = [],
+        session: SessionState? = nil
+    ) {
         self.accounts = accounts
         self.apiLastCalledAt = apiLastCalledAt
+        self.notificationLastSentAt = notificationLastSentAt
+        self.preferences = preferences
+        self.events = events
+        self.history = history
+        self.session = session
     }
 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         accounts = try container.decodeIfPresent([String: AccountUsageState].self, forKey: .accounts) ?? [:]
         apiLastCalledAt = try container.decodeIfPresent([String: Date].self, forKey: .apiLastCalledAt) ?? [:]
+        notificationLastSentAt = try container.decodeIfPresent([String: Date].self, forKey: .notificationLastSentAt) ?? [:]
+        preferences = try container.decodeIfPresent(AppPreferences.self, forKey: .preferences) ?? AppPreferences()
+        events = try container.decodeIfPresent([TokiEvent].self, forKey: .events) ?? []
+        history = try container.decodeIfPresent([UsageHistoryEntry].self, forKey: .history) ?? []
+        session = try container.decodeIfPresent(SessionState.self, forKey: .session)
     }
 }
 
 struct AccountUsageState: Codable {
     var used: Double
     var lastResetAt: Date?
+}
+
+enum MenuBarDisplayMode: String, Codable, CaseIterable, Identifiable {
+    case smart
+    case lowest
+    case activeClaude
+    case codex
+    case combined
+    case accounts
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .smart: return "Smart"
+        case .lowest: return "Lowest"
+        case .activeClaude: return "Claude"
+        case .codex: return "Codex"
+        case .combined: return "Claude + Codex"
+        case .accounts: return "Accounts"
+        }
+    }
+}
+
+struct AppPreferences: Codable, Equatable {
+    var notificationsEnabled = true
+    var dndEnabled = false
+    var lowQuotaThreshold = 0.20
+    var notificationCooldownMinutes = 90
+    var menuBarMode = MenuBarDisplayMode.smart
+    var historyRetentionDays = 14
+    var sessionWarningThreshold = 0.15
+
+    enum CodingKeys: String, CodingKey {
+        case notificationsEnabled
+        case dndEnabled
+        case lowQuotaThreshold
+        case notificationCooldownMinutes
+        case menuBarMode
+        case historyRetentionDays
+        case sessionWarningThreshold
+    }
+}
+
+enum TokiEventKind: String, Codable {
+    case lowQuota
+    case recovered
+    case switchAccount
+    case session
+    case notification
+    case refresh
+}
+
+struct TokiEvent: Codable, Identifiable, Hashable {
+    var id = UUID()
+    var timestamp = Date()
+    var kind: TokiEventKind
+    var title: String
+    var detail: String
+    var deliveredNotification: Bool
+}
+
+struct UsageHistoryEntry: Codable, Identifiable, Hashable {
+    var id = UUID()
+    var timestamp = Date()
+    var accountID: String
+    var accountName: String
+    var provider: Provider
+    var remainingRatio: Double?
+    var primary: String
+}
+
+struct SessionState: Codable, Equatable {
+    var startedAt: Date
+    var startingRemainingRatios: [String: Double]
+    var startingPrimaries: [String: String]
 }

--- a/Sources/Toki/Store/UsageStore.swift
+++ b/Sources/Toki/Store/UsageStore.swift
@@ -406,14 +406,16 @@ final class UsageStore: ObservableObject {
 
     private func notifyOrRecord(key: String, kind: TokiEventKind, title: String, detail: String, at date: Date) {
         let cooldown = TimeInterval(max(preferences.notificationCooldownMinutes, 5) * 60)
-        if let last = usageState.notificationLastSentAt[key],
+        if let last = usageState.eventLastRecordedAt[key],
            date.timeIntervalSince(last) < cooldown {
-            appendEvent(kind: kind, title: title, detail: "Cooldown: \(detail)", deliveredNotification: false, at: date)
             return
         }
 
-        usageState.notificationLastSentAt[key] = date
         let canDeliver = preferences.notificationsEnabled && !preferences.dndEnabled
+        usageState.eventLastRecordedAt[key] = date
+        if canDeliver {
+            usageState.notificationLastSentAt[key] = date
+        }
         appendEvent(
             kind: kind,
             title: title,

--- a/Sources/Toki/Store/UsageStore.swift
+++ b/Sources/Toki/Store/UsageStore.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import SwiftUI
+@preconcurrency import UserNotifications
 
 @MainActor
 final class UsageStore: ObservableObject {
@@ -10,6 +11,19 @@ final class UsageStore: ObservableObject {
     @Published var configError: String?
     @Published var debugMode = false
     @Published var debugLog: [DebugLogEntry] = []
+    @Published var preferences = AppPreferences()
+    @Published var events: [TokiEvent] = []
+    @Published var history: [UsageHistoryEntry] = []
+    @Published var session: SessionState?
+    @Published var recommendation = SmartRecommendation(
+        title: "Loading",
+        detail: "Checking account quota.",
+        accountID: nil,
+        switchTarget: nil,
+        switchCommand: nil,
+        severity: .neutral
+    )
+    @Published var statusEntries: [MenuBarStatusEntry] = menuBarPlaceholderEntries()
 
     private var config: AppConfig?
     private var usageState = UsageState()
@@ -28,9 +42,11 @@ final class UsageStore: ObservableObject {
         do {
             config = try ConfigLoader.load()
             usageState = StateLoader.load()
+            syncPublishedState()
             applyScheduledResets()
             configError = nil
             snapshots = config?.accounts.map(AccountSnapshot.loading) ?? []
+            updateDerivedState(for: snapshots)
             scheduleRefresh()
             refresh(keepsExistingSnapshots: true, minimumRefreshInterval: 60)
         } catch {
@@ -50,6 +66,7 @@ final class UsageStore: ObservableObject {
                     isError: true
                 )
             ]
+            updateDerivedState(for: snapshots)
         }
     }
 
@@ -87,11 +104,15 @@ final class UsageStore: ObservableObject {
             for snapshot in sorted where snapshot.isError {
                 logDebug("  [\(snapshot.id)] \(snapshot.name): \(snapshot.subtitle)")
             }
+            recordHistory(for: sorted, at: response.fetchedAt)
+            evaluateEventsAndNotifications(for: sorted, previous: previousSnapshots, at: response.fetchedAt)
+            pruneState(now: response.fetchedAt)
+            StateLoader.save(usageState)
             withAnimation(.spring(response: 0.32, dampingFraction: 0.86)) {
                 snapshots = sorted
             }
             lastUpdated = Date()
-            statusText = menuBarStatus(for: sorted)
+            updateDerivedState(for: sorted)
         }
     }
 
@@ -158,6 +179,64 @@ final class UsageStore: ObservableObject {
         }
     }
 
+    func updatePreferences(_ next: AppPreferences) {
+        preferences = next
+        usageState.preferences = next
+        StateLoader.save(usageState)
+        updateDerivedState(for: snapshots)
+    }
+
+    func setDND(_ isEnabled: Bool) {
+        var next = preferences
+        next.dndEnabled = isEnabled
+        updatePreferences(next)
+        appendEvent(
+            kind: .notification,
+            title: isEnabled ? "DND enabled" : "DND disabled",
+            detail: isEnabled ? "Notifications will be recorded but not delivered." : "Notifications can be delivered again.",
+            deliveredNotification: false
+        )
+    }
+
+    func startSession() {
+        let ratios = Dictionary(uniqueKeysWithValues: snapshots.compactMap { snapshot in
+            snapshot.remainingRatio.map { (snapshot.id, $0) }
+        })
+        let primaries = Dictionary(uniqueKeysWithValues: snapshots.map { ($0.id, $0.primary) })
+        let next = SessionState(startedAt: Date(), startingRemainingRatios: ratios, startingPrimaries: primaries)
+        session = next
+        usageState.session = next
+        StateLoader.save(usageState)
+        appendEvent(kind: .session, title: "Session started", detail: "Toki is tracking quota burn for this coding session.", deliveredNotification: false)
+    }
+
+    func endSession() {
+        guard let session else { return }
+        let summary = sessionSummary(for: session)
+        self.session = nil
+        usageState.session = nil
+        StateLoader.save(usageState)
+        appendEvent(kind: .session, title: "Session ended", detail: summary, deliveredNotification: false)
+    }
+
+    func clearEvents() {
+        events = []
+        usageState.events = []
+        StateLoader.save(usageState)
+    }
+
+    func switchBestAccount() {
+        let current = smartRecommendation(for: snapshots)
+        guard let target = current.switchTarget else { return }
+        appendEvent(
+            kind: .switchAccount,
+            title: "Smart switch",
+            detail: "Switching to \(current.title.replacingOccurrences(of: "Switch to ", with: "")).",
+            deliveredNotification: false
+        )
+        switchClaudeAccount(target: target, command: current.switchCommand)
+    }
+
     func switchClaudeAccount(target: String, command: String?) {
         statusText = "Switching"
         let currentSnapshots = snapshots
@@ -170,9 +249,11 @@ final class UsageStore: ObservableObject {
 
             switch result {
             case .success:
+                appendEvent(kind: .switchAccount, title: "Account switched", detail: "Claude Code switched to \(target).", deliveredNotification: false)
                 reloadConfig()
             case .failure(let error):
                 statusText = "Switch failed"
+                appendEvent(kind: .switchAccount, title: "Switch failed", detail: error.localizedDescription, deliveredNotification: false)
                 snapshots = currentSnapshots.map { snapshot in
                     guard snapshot.switchTarget == target else { return snapshot }
                     var failed = snapshot
@@ -182,6 +263,17 @@ final class UsageStore: ObservableObject {
                 }
             }
         }
+    }
+
+    func sessionBurnLines() -> [MetricLine] {
+        guard let session else { return [] }
+        let byID = Dictionary(uniqueKeysWithValues: snapshots.map { ($0.id, $0) })
+        return session.startingRemainingRatios.compactMap { accountID, startingRatio in
+            guard let snapshot = byID[accountID], let current = snapshot.remainingRatio else { return nil }
+            let burned = max(0, startingRatio - current)
+            return MetricLine(label: snapshot.name, value: "\(percentText(burned)) burned")
+        }
+        .sorted { $0.label < $1.label }
     }
 
     private func scheduleRefresh() {
@@ -228,5 +320,156 @@ final class UsageStore: ObservableObject {
         } else {
             debugLogHandler = nil
         }
+    }
+
+    private func syncPublishedState() {
+        preferences = usageState.preferences
+        events = usageState.events.sorted { $0.timestamp > $1.timestamp }
+        history = usageState.history.sorted { $0.timestamp > $1.timestamp }
+        session = usageState.session
+    }
+
+    private func updateDerivedState(for snapshots: [AccountSnapshot]) {
+        recommendation = smartRecommendation(for: snapshots)
+        statusEntries = menuBarEntries(for: snapshots, mode: preferences.menuBarMode)
+        if statusEntries.isEmpty {
+            statusEntries = menuBarPlaceholderEntries()
+        }
+        statusText = menuBarStatus(for: snapshots, mode: preferences.menuBarMode)
+        syncPublishedState()
+    }
+
+    private func recordHistory(for snapshots: [AccountSnapshot], at date: Date) {
+        let candidates = snapshots.filter { !$0.isError && $0.remainingRatio != nil }
+        for snapshot in candidates {
+            let last = usageState.history
+                .filter { $0.accountID == snapshot.id }
+                .max { $0.timestamp < $1.timestamp }
+            let shouldAppend = last == nil
+                || date.timeIntervalSince(last?.timestamp ?? .distantPast) >= 15 * 60
+                || abs((last?.remainingRatio ?? 0) - (snapshot.remainingRatio ?? 0)) >= 0.02
+            guard shouldAppend else { continue }
+            usageState.history.append(UsageHistoryEntry(
+                timestamp: date,
+                accountID: snapshot.id,
+                accountName: snapshot.name,
+                provider: snapshot.provider,
+                remainingRatio: snapshot.remainingRatio,
+                primary: snapshot.primary
+            ))
+        }
+    }
+
+    private func evaluateEventsAndNotifications(for snapshots: [AccountSnapshot], previous: [AccountSnapshot], at date: Date) {
+        let previousByID = Dictionary(uniqueKeysWithValues: previous.map { ($0.id, $0) })
+        for snapshot in snapshots where !snapshot.isError {
+            guard let ratio = snapshot.remainingRatio else { continue }
+            let previousRatio = previousByID[snapshot.id]?.remainingRatio
+            if ratio <= preferences.lowQuotaThreshold,
+               previousRatio == nil || (previousRatio ?? 1) > preferences.lowQuotaThreshold {
+                notifyOrRecord(
+                    key: "lowQuota:\(snapshot.id)",
+                    kind: .lowQuota,
+                    title: "\(snapshot.name) is low",
+                    detail: "\(snapshot.name) has \(percentText(ratio)) quota remaining.",
+                    at: date
+                )
+            } else if ratio >= preferences.lowQuotaThreshold + 0.20,
+                      let previousRatio,
+                      previousRatio <= preferences.lowQuotaThreshold {
+                notifyOrRecord(
+                    key: "recovered:\(snapshot.id)",
+                    kind: .recovered,
+                    title: "\(snapshot.name) recovered",
+                    detail: "\(snapshot.name) is back to \(percentText(ratio)) remaining.",
+                    at: date
+                )
+            }
+        }
+
+        guard let session else { return }
+        for snapshot in snapshots where !snapshot.isError {
+            guard let current = snapshot.remainingRatio,
+                  let starting = session.startingRemainingRatios[snapshot.id] else { continue }
+            let burned = starting - current
+            if current <= preferences.sessionWarningThreshold || burned >= 0.30 {
+                notifyOrRecord(
+                    key: "session:\(snapshot.id)",
+                    kind: .session,
+                    title: "Session quota warning",
+                    detail: "\(snapshot.name) has \(percentText(current)) left after burning \(percentText(max(0, burned))).",
+                    at: date
+                )
+            }
+        }
+    }
+
+    private func notifyOrRecord(key: String, kind: TokiEventKind, title: String, detail: String, at date: Date) {
+        let cooldown = TimeInterval(max(preferences.notificationCooldownMinutes, 5) * 60)
+        if let last = usageState.notificationLastSentAt[key],
+           date.timeIntervalSince(last) < cooldown {
+            appendEvent(kind: kind, title: title, detail: "Cooldown: \(detail)", deliveredNotification: false, at: date)
+            return
+        }
+
+        usageState.notificationLastSentAt[key] = date
+        let canDeliver = preferences.notificationsEnabled && !preferences.dndEnabled
+        appendEvent(
+            kind: kind,
+            title: title,
+            detail: canDeliver ? detail : "DND: \(detail)",
+            deliveredNotification: canDeliver,
+            at: date
+        )
+        guard canDeliver else { return }
+        deliverNotification(title: title, detail: detail)
+    }
+
+    private func deliverNotification(title: String, detail: String) {
+        let center = UNUserNotificationCenter.current()
+        center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
+            guard granted else { return }
+            let content = UNMutableNotificationContent()
+            content.title = title
+            content.body = detail
+            content.sound = .default
+            let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
+            center.add(request)
+        }
+    }
+
+    private func appendEvent(
+        kind: TokiEventKind,
+        title: String,
+        detail: String,
+        deliveredNotification: Bool,
+        at date: Date = Date()
+    ) {
+        usageState.events.append(TokiEvent(
+            timestamp: date,
+            kind: kind,
+            title: title,
+            detail: detail,
+            deliveredNotification: deliveredNotification
+        ))
+        pruneState(now: date)
+        StateLoader.save(usageState)
+        syncPublishedState()
+    }
+
+    private func pruneState(now: Date) {
+        let retention = TimeInterval(max(preferences.historyRetentionDays, 1) * 24 * 60 * 60)
+        usageState.history = usageState.history
+            .filter { now.timeIntervalSince($0.timestamp) <= retention }
+            .suffix(720)
+        usageState.events = Array(usageState.events.suffix(160))
+    }
+
+    private func sessionSummary(for session: SessionState) -> String {
+        let elapsed = formatDuration(seconds: Date().timeIntervalSince(session.startedAt))
+        let lines = sessionBurnLines()
+        guard !lines.isEmpty else { return "Tracked for \(elapsed)." }
+        let top = lines.prefix(2).map { "\($0.label): \($0.value)" }.joined(separator: ", ")
+        return "Tracked for \(elapsed). \(top)."
     }
 }

--- a/Sources/Toki/Store/UsageStore.swift
+++ b/Sources/Toki/Store/UsageStore.swift
@@ -411,32 +411,57 @@ final class UsageStore: ObservableObject {
             return
         }
 
-        let canDeliver = preferences.notificationsEnabled && !preferences.dndEnabled
+        let canAttemptDelivery = preferences.notificationsEnabled && !preferences.dndEnabled
         usageState.eventLastRecordedAt[key] = date
-        if canDeliver {
-            usageState.notificationLastSentAt[key] = date
+        guard canAttemptDelivery else {
+            appendEvent(
+                kind: kind,
+                title: title,
+                detail: preferences.dndEnabled ? "DND: \(detail)" : "Notifications disabled: \(detail)",
+                deliveredNotification: false,
+                at: date
+            )
+            return
         }
-        appendEvent(
-            kind: kind,
-            title: title,
-            detail: canDeliver ? detail : "DND: \(detail)",
-            deliveredNotification: canDeliver,
-            at: date
-        )
-        guard canDeliver else { return }
-        deliverNotification(title: title, detail: detail)
+
+        deliverNotification(title: title, detail: detail) { delivered, failureDetail in
+            if delivered {
+                self.usageState.notificationLastSentAt[key] = date
+            }
+            self.appendEvent(
+                kind: kind,
+                title: title,
+                detail: delivered ? detail : "Not delivered: \(failureDetail ?? detail)",
+                deliveredNotification: delivered,
+                at: date
+            )
+        }
     }
 
-    private func deliverNotification(title: String, detail: String) {
+    private func deliverNotification(
+        title: String,
+        detail: String,
+        completion: @escaping @MainActor (Bool, String?) -> Void
+    ) {
         let center = UNUserNotificationCenter.current()
-        center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
-            guard granted else { return }
+        center.requestAuthorization(options: [.alert, .sound]) { granted, error in
+            if let error {
+                Task { @MainActor in completion(false, error.localizedDescription) }
+                return
+            }
+            guard granted else {
+                Task { @MainActor in completion(false, "notification permission denied") }
+                return
+            }
+
             let content = UNMutableNotificationContent()
             content.title = title
             content.body = detail
             content.sound = .default
             let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
-            center.add(request)
+            center.add(request) { error in
+                Task { @MainActor in completion(error == nil, error?.localizedDescription) }
+            }
         }
     }
 

--- a/Sources/Toki/Store/UsageStore.swift
+++ b/Sources/Toki/Store/UsageStore.swift
@@ -7,7 +7,6 @@ import SwiftUI
 final class UsageStore: ObservableObject {
     @Published var snapshots: [AccountSnapshot] = []
     @Published var lastUpdated: Date?
-    @Published var statusText = "Loading"
     @Published var configError: String?
     @Published var debugMode = false
     @Published var debugLog: [DebugLogEntry] = []
@@ -29,6 +28,8 @@ final class UsageStore: ObservableObject {
     private var usageState = UsageState()
     private var timer: Timer?
     private var isRefreshing = false
+    private var eventGeneration = 0
+    private var notificationAuthorization: Bool?
 
     init() {
         reloadConfig()
@@ -52,7 +53,6 @@ final class UsageStore: ObservableObject {
         } catch {
             config = nil
             configError = error.localizedDescription
-            statusText = "Config needed"
             snapshots = [
                 AccountSnapshot(
                     id: "config-error",
@@ -76,7 +76,6 @@ final class UsageStore: ObservableObject {
             return
         }
         isRefreshing = true
-        statusText = "Refreshing"
         logDebug("Refresh started")
         if !keepsExistingSnapshots || snapshots.isEmpty {
             snapshots = config.accounts.map(AccountSnapshot.loading)
@@ -220,25 +219,37 @@ final class UsageStore: ObservableObject {
     }
 
     func clearEvents() {
+        eventGeneration += 1
         events = []
         usageState.events = []
+        usageState.eventLastRecordedAt = [:]
         StateLoader.save(usageState)
     }
 
     func switchBestAccount() {
-        let current = smartRecommendation(for: snapshots)
+        let current = recommendation
         guard let target = current.switchTarget else { return }
         appendEvent(
             kind: .switchAccount,
             title: "Smart switch",
-            detail: "Switching to \(current.title.replacingOccurrences(of: "Switch to ", with: "")).",
+            detail: "Switching to \(recommendedAccountName(from: current)).",
             deliveredNotification: false
         )
         switchClaudeAccount(target: target, command: current.switchCommand)
     }
 
+    private func recommendedAccountName(from recommendation: SmartRecommendation) -> String {
+        if let accountID = recommendation.accountID,
+           let snapshot = snapshots.first(where: { $0.id == accountID }) {
+            return snapshot.name
+        }
+        return recommendation.title
+            .replacingOccurrences(of: "Switch to ", with: "")
+            .replacingOccurrences(of: "Use ", with: "")
+            .replacingOccurrences(of: " now", with: "")
+    }
+
     func switchClaudeAccount(target: String, command: String?) {
-        statusText = "Switching"
         let currentSnapshots = snapshots
         Task {
             let result = await Task.detached {
@@ -252,7 +263,6 @@ final class UsageStore: ObservableObject {
                 appendEvent(kind: .switchAccount, title: "Account switched", detail: "Claude Code switched to \(target).", deliveredNotification: false)
                 reloadConfig()
             case .failure(let error):
-                statusText = "Switch failed"
                 appendEvent(kind: .switchAccount, title: "Switch failed", detail: error.localizedDescription, deliveredNotification: false)
                 snapshots = currentSnapshots.map { snapshot in
                     guard snapshot.switchTarget == target else { return snapshot }
@@ -335,7 +345,6 @@ final class UsageStore: ObservableObject {
         if statusEntries.isEmpty {
             statusEntries = menuBarPlaceholderEntries()
         }
-        statusText = menuBarStatus(for: snapshots, mode: preferences.menuBarMode)
         syncPublishedState()
     }
 
@@ -424,10 +433,9 @@ final class UsageStore: ObservableObject {
             return
         }
 
+        let generation = eventGeneration
         deliverNotification(title: title, detail: detail) { delivered, failureDetail in
-            if delivered {
-                self.usageState.notificationLastSentAt[key] = date
-            }
+            guard generation == self.eventGeneration else { return }
             self.appendEvent(
                 kind: kind,
                 title: title,
@@ -443,10 +451,9 @@ final class UsageStore: ObservableObject {
         detail: String,
         completion: @escaping @MainActor (Bool, String?) -> Void
     ) {
-        let center = UNUserNotificationCenter.current()
-        center.requestAuthorization(options: [.alert, .sound]) { granted, error in
+        resolveNotificationAuthorization { granted, error in
             if let error {
-                Task { @MainActor in completion(false, error.localizedDescription) }
+                Task { @MainActor in completion(false, error) }
                 return
             }
             guard granted else {
@@ -459,9 +466,24 @@ final class UsageStore: ObservableObject {
             content.body = detail
             content.sound = .default
             let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
-            center.add(request) { error in
+            UNUserNotificationCenter.current().add(request) { error in
                 Task { @MainActor in completion(error == nil, error?.localizedDescription) }
             }
+        }
+    }
+
+    private func resolveNotificationAuthorization(completion: @escaping @Sendable (Bool, String?) -> Void) {
+        if notificationAuthorization == true {
+            completion(true, nil)
+            return
+        }
+        // Only cache a granted result. A denied/undetermined state is re-checked so
+        // enabling notifications in System Settings takes effect without a restart.
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { [weak self] granted, error in
+            if error == nil && granted {
+                Task { @MainActor in self?.notificationAuthorization = true }
+            }
+            completion(error == nil && granted, error?.localizedDescription)
         }
     }
 
@@ -486,9 +508,9 @@ final class UsageStore: ObservableObject {
 
     private func pruneState(now: Date) {
         let retention = TimeInterval(max(preferences.historyRetentionDays, 1) * 24 * 60 * 60)
-        usageState.history = usageState.history
+        usageState.history = Array(usageState.history
             .filter { now.timeIntervalSince($0.timestamp) <= retention }
-            .suffix(720)
+            .suffix(720))
         usageState.events = Array(usageState.events.suffix(160))
     }
 

--- a/Sources/Toki/Utilities/BusinessLogic.swift
+++ b/Sources/Toki/Utilities/BusinessLogic.swift
@@ -51,6 +51,11 @@ func menuBarStatus(for snapshots: [AccountSnapshot], mode: MenuBarDisplayMode = 
 }
 
 func menuBarEntries(for snapshots: [AccountSnapshot], mode: MenuBarDisplayMode = .smart) -> [MenuBarStatusEntry] {
+    if allTrackedQuotaExhausted(snapshots) {
+        let suggestion = currentBreakSuggestion()
+        return [MenuBarStatusEntry(provider: .manual, value: suggestion.menuBarText, leadingText: suggestion.emoji)]
+    }
+
     switch mode {
     case .smart:
         return smartMenuBarEntries(for: snapshots)
@@ -117,6 +122,18 @@ func smartRecommendation(for snapshots: [AccountSnapshot]) -> SmartRecommendatio
         )
     }
 
+    if allTrackedQuotaExhausted(snapshots) {
+        let suggestion = currentBreakSuggestion()
+        return SmartRecommendation(
+            title: suggestion.title,
+            detail: "All tracked coding quota is empty. \(suggestion.detail)",
+            accountID: nil,
+            switchTarget: nil,
+            switchCommand: nil,
+            severity: .critical
+        )
+    }
+
     let ratio = best.remainingRatio ?? 0
     if ratio <= 0.15 {
         return SmartRecommendation(
@@ -157,6 +174,42 @@ func smartRecommendation(for snapshots: [AccountSnapshot]) -> SmartRecommendatio
 func percentText(_ ratio: Double) -> String {
     "\(Int((max(0, min(1, ratio)) * 100).rounded()))%"
 }
+
+func allTrackedQuotaExhausted(_ snapshots: [AccountSnapshot]) -> Bool {
+    let tracked = snapshots.filter { !$0.isError && $0.remainingRatio != nil }
+    guard !tracked.isEmpty else { return false }
+    return tracked.allSatisfy { ($0.remainingRatio ?? 1) <= 0.01 }
+}
+
+struct BreakSuggestion {
+    var title: String
+    var detail: String
+    var menuBarText: String
+    var emoji: String
+}
+
+func currentBreakSuggestion(now: Date = Date()) -> BreakSuggestion {
+    breakSuggestions[breakSuggestionIndex(for: now)]
+}
+
+private func breakSuggestionIndex(for date: Date) -> Int {
+    let hour = Calendar.current.component(.hour, from: date)
+    let day = Calendar.current.ordinality(of: .day, in: .year, for: date) ?? 0
+    return abs(day + hour) % breakSuggestions.count
+}
+
+private let breakSuggestions = [
+    BreakSuggestion(title: "Take a walk", detail: "Take a walk, mate. Ten minutes away from the screen is a valid productivity tool.", menuBarText: "Take a walk, mate", emoji: "🚶"),
+    BreakSuggestion(title: "Drink water", detail: "Drink some water and let the next idea arrive without a loading spinner.", menuBarText: "Drink water", emoji: "💧"),
+    BreakSuggestion(title: "Stretch a bit", detail: "Stand up, stretch your shoulders, and give your neck a tiny ceasefire.", menuBarText: "Stretch a bit", emoji: "🙆"),
+    BreakSuggestion(title: "Make tea", detail: "Make tea or coffee and come back when the quota gods are less dramatic.", menuBarText: "Make tea", emoji: "☕️"),
+    BreakSuggestion(title: "Look outside", detail: "Look out a window for a minute. The pixels will still be here.", menuBarText: "Look outside", emoji: "🌤️"),
+    BreakSuggestion(title: "Tidy desk", detail: "Clear one small thing from your desk. Future you gets a cleaner runway.", menuBarText: "Tidy desk", emoji: "🧹"),
+    BreakSuggestion(title: "Breathe slowly", detail: "Take five slow breaths. Debugging is better when your nervous system is not on fire.", menuBarText: "Breathe slowly", emoji: "🫁"),
+    BreakSuggestion(title: "Rest your eyes", detail: "Rest your eyes for 60 seconds and let the afterimage of the code fade.", menuBarText: "Rest eyes", emoji: "😌"),
+    BreakSuggestion(title: "Write a note", detail: "Write down the next thing you wanted to ask. Save the thought before the quota resets.", menuBarText: "Write a note", emoji: "📝"),
+    BreakSuggestion(title: "Check posture", detail: "Reset your posture, unclench your jaw, and pretend ergonomics is a feature.", menuBarText: "Check posture", emoji: "🪑")
+]
 
 func svgPath(_ raw: String, in rect: CGRect, viewBox: CGSize) -> Path {
     let tokens = raw.replacingOccurrences(of: "Z", with: " Z ")
@@ -226,4 +279,3 @@ func svgPath(_ raw: String, in rect: CGRect, viewBox: CGSize) -> Path {
 
     return path
 }
-

--- a/Sources/Toki/Utilities/BusinessLogic.swift
+++ b/Sources/Toki/Utilities/BusinessLogic.swift
@@ -44,13 +44,32 @@ func sortedByAvailability(_ snapshots: [AccountSnapshot]) -> [AccountSnapshot] {
         .map(\.element)
 }
 
-func menuBarStatus(for snapshots: [AccountSnapshot]) -> String {
-    let entries = menuBarEntries(for: snapshots)
+func menuBarStatus(for snapshots: [AccountSnapshot], mode: MenuBarDisplayMode = .smart) -> String {
+    let entries = menuBarEntries(for: snapshots, mode: mode)
     guard !entries.isEmpty else { return "Toki --" }
     return entries.map { "\($0.value)" }.joined(separator: "  ")
 }
 
-func menuBarEntries(for snapshots: [AccountSnapshot]) -> [MenuBarStatusEntry] {
+func menuBarEntries(for snapshots: [AccountSnapshot], mode: MenuBarDisplayMode = .smart) -> [MenuBarStatusEntry] {
+    switch mode {
+    case .smart:
+        return smartMenuBarEntries(for: snapshots)
+    case .lowest:
+        return lowestMenuBarEntries(for: snapshots)
+    case .activeClaude:
+        return snapshots.first { $0.provider.isClaudeAccount && $0.switchTarget == nil && !$0.isError }
+            .map { [menuBarEntry(for: $0)] } ?? []
+    case .codex:
+        return snapshots.first { $0.provider == .codex && !$0.isError }
+            .map { [menuBarEntry(for: $0)] } ?? []
+    case .combined:
+        return smartMenuBarEntries(for: snapshots)
+    case .accounts:
+        return [MenuBarStatusEntry(provider: .manual, value: "\(snapshots.filter { !$0.isError }.count)")]
+    }
+}
+
+private func smartMenuBarEntries(for snapshots: [AccountSnapshot]) -> [MenuBarStatusEntry] {
     let activeClaude = snapshots.first {
         $0.provider.isClaudeAccount && $0.switchTarget == nil && !$0.isError
     }
@@ -66,6 +85,13 @@ func menuBarEntries(for snapshots: [AccountSnapshot]) -> [MenuBarStatusEntry] {
     return segments.map(menuBarEntry)
 }
 
+private func lowestMenuBarEntries(for snapshots: [AccountSnapshot]) -> [MenuBarStatusEntry] {
+    snapshots
+        .filter { !$0.isError && $0.remainingRatio != nil }
+        .min { ($0.remainingRatio ?? 1) < ($1.remainingRatio ?? 1) }
+        .map { [menuBarEntry(for: $0)] } ?? []
+}
+
 func menuBarPlaceholderEntries() -> [MenuBarStatusEntry] {
     [
         MenuBarStatusEntry(provider: .claudeCode, value: "--"),
@@ -76,6 +102,60 @@ func menuBarPlaceholderEntries() -> [MenuBarStatusEntry] {
 func menuBarEntry(for snapshot: AccountSnapshot) -> MenuBarStatusEntry {
     let value = snapshot.remainingRatio.map { "\(Int(($0 * 100).rounded()))%" } ?? "--"
     return MenuBarStatusEntry(provider: snapshot.provider, value: value)
+}
+
+func smartRecommendation(for snapshots: [AccountSnapshot]) -> SmartRecommendation {
+    let usable = snapshots.filter { !$0.isError && $0.remainingRatio != nil }
+    guard let best = usable.max(by: { ($0.remainingRatio ?? 0) < ($1.remainingRatio ?? 0) }) else {
+        return SmartRecommendation(
+            title: "Connect an account",
+            detail: "Toki needs at least one live usage source before it can recommend where to work.",
+            accountID: nil,
+            switchTarget: nil,
+            switchCommand: nil,
+            severity: .neutral
+        )
+    }
+
+    let ratio = best.remainingRatio ?? 0
+    if ratio <= 0.15 {
+        return SmartRecommendation(
+            title: "All coding fuel is low",
+            detail: "Best available is \(best.name) at \(percentText(ratio)). Consider waiting for the next reset.",
+            accountID: best.id,
+            switchTarget: best.switchTarget,
+            switchCommand: best.switchCommand,
+            severity: .critical
+        )
+    }
+
+    if let activeClaude = usable.first(where: { $0.provider.isClaudeAccount && $0.switchTarget == nil }),
+       let bestClaude = usable.filter({ $0.provider.isClaudeAccount }).max(by: { ($0.remainingRatio ?? 0) < ($1.remainingRatio ?? 0) }),
+       bestClaude.id != activeClaude.id,
+       (bestClaude.remainingRatio ?? 0) - (activeClaude.remainingRatio ?? 0) >= 0.20 {
+        return SmartRecommendation(
+            title: "Switch to \(bestClaude.name)",
+            detail: "\(bestClaude.name) has \(percentText(bestClaude.remainingRatio ?? 0)) left versus \(percentText(activeClaude.remainingRatio ?? 0)) on the active Claude account.",
+            accountID: bestClaude.id,
+            switchTarget: bestClaude.switchTarget,
+            switchCommand: bestClaude.switchCommand,
+            severity: .warning
+        )
+    }
+
+    let severity: RecommendationSeverity = ratio <= 0.35 ? .warning : .good
+    return SmartRecommendation(
+        title: "Use \(best.name) now",
+        detail: "\(best.name) has the healthiest available quota at \(percentText(ratio)) remaining.",
+        accountID: best.id,
+        switchTarget: best.switchTarget,
+        switchCommand: best.switchCommand,
+        severity: severity
+    )
+}
+
+func percentText(_ ratio: Double) -> String {
+    "\(Int((max(0, min(1, ratio)) * 100).rounded()))%"
 }
 
 func svgPath(_ raw: String, in rect: CGRect, viewBox: CGSize) -> Path {
@@ -146,5 +226,4 @@ func svgPath(_ raw: String, in rect: CGRect, viewBox: CGSize) -> Path {
 
     return path
 }
-
 

--- a/Sources/Toki/Utilities/BusinessLogic.swift
+++ b/Sources/Toki/Utilities/BusinessLogic.swift
@@ -44,12 +44,6 @@ func sortedByAvailability(_ snapshots: [AccountSnapshot]) -> [AccountSnapshot] {
         .map(\.element)
 }
 
-func menuBarStatus(for snapshots: [AccountSnapshot], mode: MenuBarDisplayMode = .smart) -> String {
-    let entries = menuBarEntries(for: snapshots, mode: mode)
-    guard !entries.isEmpty else { return "Toki --" }
-    return entries.map { "\($0.value)" }.joined(separator: "  ")
-}
-
 func menuBarEntries(for snapshots: [AccountSnapshot], mode: MenuBarDisplayMode = .smart) -> [MenuBarStatusEntry] {
     if allTrackedQuotaExhausted(snapshots) {
         let suggestion = currentBreakSuggestion()
@@ -105,7 +99,7 @@ func menuBarPlaceholderEntries() -> [MenuBarStatusEntry] {
 }
 
 func menuBarEntry(for snapshot: AccountSnapshot) -> MenuBarStatusEntry {
-    let value = snapshot.remainingRatio.map { "\(Int(($0 * 100).rounded()))%" } ?? "--"
+    let value = snapshot.remainingRatio.map(percentText) ?? "--"
     return MenuBarStatusEntry(provider: snapshot.provider, value: value)
 }
 
@@ -146,13 +140,13 @@ func smartRecommendation(for snapshots: [AccountSnapshot]) -> SmartRecommendatio
         )
     }
 
-    if let activeClaude = usable.first(where: { $0.provider.isClaudeAccount && $0.switchTarget == nil }),
-       let bestClaude = usable.filter({ $0.provider.isClaudeAccount }).max(by: { ($0.remainingRatio ?? 0) < ($1.remainingRatio ?? 0) }),
+    if let activeClaude = usable.first(where: { $0.provider == .claudeCode && $0.switchTarget == nil }),
+       let bestClaude = usable.filter({ $0.provider == .claudeCode }).max(by: { ($0.remainingRatio ?? 0) < ($1.remainingRatio ?? 0) }),
        bestClaude.id != activeClaude.id,
        (bestClaude.remainingRatio ?? 0) - (activeClaude.remainingRatio ?? 0) >= 0.20 {
         return SmartRecommendation(
             title: "Switch to \(bestClaude.name)",
-            detail: "\(bestClaude.name) has \(percentText(bestClaude.remainingRatio ?? 0)) left versus \(percentText(activeClaude.remainingRatio ?? 0)) on the active Claude account.",
+            detail: "\(bestClaude.name) has \(percentText(bestClaude.remainingRatio ?? 0)) left versus \(percentText(activeClaude.remainingRatio ?? 0)) on the active Claude Code account.",
             accountID: bestClaude.id,
             switchTarget: bestClaude.switchTarget,
             switchCommand: bestClaude.switchCommand,

--- a/Sources/Toki/Utilities/Layout.swift
+++ b/Sources/Toki/Utilities/Layout.swift
@@ -9,5 +9,5 @@ func popoverHeight() -> CGFloat {
 }
 
 func accountListHeight() -> CGFloat {
-    max(240, popoverHeight() - 78)
+    max(130, popoverHeight() - 258)
 }

--- a/Sources/Toki/Utilities/Layout.swift
+++ b/Sources/Toki/Utilities/Layout.swift
@@ -9,5 +9,5 @@ func popoverHeight() -> CGFloat {
 }
 
 func accountListHeight() -> CGFloat {
-    max(130, popoverHeight() - 258)
+    max(170, popoverHeight() - 202)
 }

--- a/Sources/Toki/Views/Components.swift
+++ b/Sources/Toki/Views/Components.swift
@@ -17,6 +17,8 @@ struct StatBlock: View {
                 Text(title)
                     .font(.system(size: 10, weight: .semibold))
                     .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
                 Text(value)
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(.primary)

--- a/Sources/Toki/Views/Components.swift
+++ b/Sources/Toki/Views/Components.swift
@@ -2,10 +2,17 @@ import SwiftUI
 
 // MARK: - StatBlock
 
+struct StatBlockAction {
+    var systemImage: String
+    var help: String
+    var perform: () -> Void
+}
+
 struct StatBlock: View {
     var title: String
     var value: String
     var systemImage: String
+    var action: StatBlockAction?
 
     var body: some View {
         HStack(spacing: 6) {
@@ -26,6 +33,18 @@ struct StatBlock: View {
                     .minimumScaleFactor(0.75)
             }
             Spacer(minLength: 0)
+            if let action {
+                Button(action: action.perform) {
+                    Image(systemName: action.systemImage)
+                        .font(.system(size: 11, weight: .semibold))
+                }
+                .buttonStyle(.plain)
+                .frame(width: 22, height: 22)
+                .background(Color.primary.opacity(0.08), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+                .help(action.help)
+                .accessibilityLabel(action.help)
+                .pointerOnHover()
+            }
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 7)

--- a/Sources/Toki/Views/MenuBarStatusView.swift
+++ b/Sources/Toki/Views/MenuBarStatusView.swift
@@ -7,7 +7,12 @@ struct MenuBarStatusView: View {
         HStack(spacing: 8) {
             ForEach(entries) { entry in
                 HStack(spacing: 4) {
-                    ProviderLogo(provider: entry.provider, size: 13)
+                    if let leadingText = entry.leadingText {
+                        Text(leadingText)
+                            .font(.system(size: 12, weight: .regular))
+                    } else {
+                        ProviderLogo(provider: entry.provider, size: 13)
+                    }
                     Text(entry.value)
                         .font(.system(size: 13, weight: .regular, design: .monospaced))
                         .foregroundStyle(.primary)

--- a/Sources/Toki/Views/MenuContentView.swift
+++ b/Sources/Toki/Views/MenuContentView.swift
@@ -26,7 +26,6 @@ struct MenuContentView: View {
         VStack(alignment: .leading, spacing: 10) {
             header
             overview
-            recommendationPanel
             sessionPanel
             tabBar
             if let configError = store.configError {
@@ -120,9 +119,9 @@ struct MenuContentView: View {
 
     private var overview: some View {
         HStack(spacing: 8) {
-            StatBlock(title: "Accounts", value: "\(store.snapshots.count)", systemImage: "person.2")
+            StatBlock(title: "Recommended", value: recommendedAgentText, systemImage: "sparkles")
             StatBlock(title: "Lowest", value: lowestRemainingText, systemImage: "gauge.with.dots.needle.bottom.50percent")
-            StatBlock(title: store.preferences.dndEnabled ? "DND" : "Alerts", value: store.preferences.dndEnabled ? "On" : "Ready", systemImage: store.preferences.dndEnabled ? "moon.zzz" : "bell")
+            StatBlock(title: "Status", value: store.preferences.dndEnabled ? "DND" : "Ready", systemImage: store.preferences.dndEnabled ? "moon.zzz" : "bell")
         }
     }
 
@@ -131,41 +130,20 @@ struct MenuContentView: View {
         return "\(Int((ratio * 100).rounded()))%"
     }
 
-    private var recommendationPanel: some View {
-        HStack(alignment: .center, spacing: 8) {
-            Image(systemName: recommendationIcon)
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(recommendationColor)
-                .frame(width: 18)
-            VStack(alignment: .leading, spacing: 2) {
-                Text(store.recommendation.title)
-                    .font(.system(size: 12, weight: .semibold))
-                    .lineLimit(1)
-                Text(store.recommendation.detail)
-                    .font(.system(size: 10, weight: .regular))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
-            }
-            Spacer(minLength: 8)
-            if store.recommendation.switchTarget != nil {
-                Button {
-                    store.switchBestAccount()
-                } label: {
-                    Image(systemName: "arrow.triangle.2.circlepath")
-                }
-                .buttonStyle(.plain)
-                .frame(width: 25, height: 25)
-                .background(Color.primary.opacity(0.06), in: RoundedRectangle(cornerRadius: 7, style: .continuous))
-                .help("Switch to recommended Claude account")
-                .pointerOnHover()
-            }
+    private var recommendedAgentText: String {
+        if let accountID = store.recommendation.accountID,
+           let snapshot = store.snapshots.first(where: { $0.id == accountID }) {
+            return snapshot.name
         }
-        .padding(8)
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(recommendationColor.opacity(0.25), lineWidth: 1)
-        )
+
+        if store.recommendation.title == "Connect an account" {
+            return "Connect"
+        }
+
+        return store.recommendation.title
+            .replacingOccurrences(of: "Use ", with: "")
+            .replacingOccurrences(of: "Switch to ", with: "")
+            .replacingOccurrences(of: " now", with: "")
     }
 
     private var sessionPanel: some View {
@@ -272,24 +250,6 @@ struct MenuContentView: View {
             return "Running for \(elapsed)."
         }
         return "\(elapsed), \(first.value)"
-    }
-
-    private var recommendationIcon: String {
-        switch store.recommendation.severity {
-        case .good: return "checkmark.circle.fill"
-        case .warning: return "exclamationmark.triangle.fill"
-        case .critical: return "xmark.octagon.fill"
-        case .neutral: return "sparkles"
-        }
-    }
-
-    private var recommendationColor: Color {
-        switch store.recommendation.severity {
-        case .good: return .green
-        case .warning: return .orange
-        case .critical: return .red
-        case .neutral: return .blue
-        }
     }
 
     private var debugPanel: some View {

--- a/Sources/Toki/Views/MenuContentView.swift
+++ b/Sources/Toki/Views/MenuContentView.swift
@@ -2,34 +2,37 @@ import SwiftUI
 
 struct MenuContentView: View {
     @ObservedObject var store: UsageStore
+    @State private var selectedTab: TokiTab = .accounts
+
+    private enum TokiTab: String, CaseIterable, Identifiable {
+        case accounts = "Accounts"
+        case history = "History"
+        case events = "Events"
+        case settings = "Settings"
+
+        var id: String { rawValue }
+
+        var systemImage: String {
+            switch self {
+            case .accounts: return "person.2"
+            case .history: return "chart.line.uptrend.xyaxis"
+            case .events: return "bell.badge"
+            case .settings: return "slider.horizontal.3"
+            }
+        }
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             header
             overview
+            recommendationPanel
+            sessionPanel
+            tabBar
             if let configError = store.configError {
                 ErrorBanner(message: configError)
             }
-            ScrollViewReader { proxy in
-                ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 8) {
-                        ForEach(store.snapshots) { snapshot in
-                            AccountCard(snapshot: snapshot, store: store) { id in
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
-                                    withAnimation(.spring(response: 0.28, dampingFraction: 0.88)) {
-                                        proxy.scrollTo(id, anchor: .top)
-                                    }
-                                }
-                            }
-                            .id(snapshot.id)
-                            .transition(.move(edge: .top).combined(with: .opacity))
-                        }
-                    }
-                    .padding(.trailing, 2)
-                    .animation(.spring(response: 0.32, dampingFraction: 0.86), value: store.snapshots.map(\.id))
-                }
-                .frame(maxHeight: accountListHeight())
-            }
+            tabContent
 
             if store.debugMode {
                 debugPanel
@@ -119,12 +122,174 @@ struct MenuContentView: View {
         HStack(spacing: 8) {
             StatBlock(title: "Accounts", value: "\(store.snapshots.count)", systemImage: "person.2")
             StatBlock(title: "Lowest", value: lowestRemainingText, systemImage: "gauge.with.dots.needle.bottom.50percent")
+            StatBlock(title: store.preferences.dndEnabled ? "DND" : "Alerts", value: store.preferences.dndEnabled ? "On" : "Ready", systemImage: store.preferences.dndEnabled ? "moon.zzz" : "bell")
         }
     }
 
     private var lowestRemainingText: String {
         guard let ratio = store.snapshots.compactMap(\.remainingRatio).min() else { return "--" }
         return "\(Int((ratio * 100).rounded()))%"
+    }
+
+    private var recommendationPanel: some View {
+        HStack(alignment: .center, spacing: 8) {
+            Image(systemName: recommendationIcon)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(recommendationColor)
+                .frame(width: 18)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(store.recommendation.title)
+                    .font(.system(size: 12, weight: .semibold))
+                    .lineLimit(1)
+                Text(store.recommendation.detail)
+                    .font(.system(size: 10, weight: .regular))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+            }
+            Spacer(minLength: 8)
+            if store.recommendation.switchTarget != nil {
+                Button {
+                    store.switchBestAccount()
+                } label: {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                }
+                .buttonStyle(.plain)
+                .frame(width: 25, height: 25)
+                .background(Color.primary.opacity(0.06), in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+                .help("Switch to recommended Claude account")
+                .pointerOnHover()
+            }
+        }
+        .padding(8)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(recommendationColor.opacity(0.25), lineWidth: 1)
+        )
+    }
+
+    private var sessionPanel: some View {
+        HStack(spacing: 8) {
+            Image(systemName: store.session == nil ? "timer" : "timer.circle.fill")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(store.session == nil ? Color.secondary : Color.blue)
+                .frame(width: 18)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(store.session == nil ? "Session mode" : "Session active")
+                    .font(.system(size: 11, weight: .semibold))
+                Text(sessionDetail)
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer()
+            Button {
+                store.session == nil ? store.startSession() : store.endSession()
+            } label: {
+                Image(systemName: store.session == nil ? "play.fill" : "stop.fill")
+            }
+            .buttonStyle(.plain)
+            .frame(width: 25, height: 25)
+            .background(Color.primary.opacity(0.06), in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+            .help(store.session == nil ? "Start session tracking" : "End session tracking")
+            .pointerOnHover()
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 7)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(Color.primary.opacity(0.07), lineWidth: 1)
+        )
+    }
+
+    private var tabBar: some View {
+        HStack(spacing: 4) {
+            ForEach(TokiTab.allCases) { tab in
+                Button {
+                    selectedTab = tab
+                } label: {
+                    Image(systemName: tab.systemImage)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.plain)
+                .font(.system(size: 12, weight: .semibold))
+                .frame(height: 28)
+                .foregroundStyle(selectedTab == tab ? .primary : .secondary)
+                .background(selectedTab == tab ? Color.primary.opacity(0.10) : Color.clear, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+                .help(tab.rawValue)
+                .pointerOnHover()
+            }
+        }
+        .padding(3)
+        .background(Color.primary.opacity(0.05), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    @ViewBuilder
+    private var tabContent: some View {
+        switch selectedTab {
+        case .accounts:
+            accountList
+        case .history:
+            HistoryPanel(store: store)
+        case .events:
+            EventPanel(store: store)
+        case .settings:
+            SettingsPanel(store: store)
+        }
+    }
+
+    private var accountList: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 8) {
+                    ForEach(store.snapshots) { snapshot in
+                        AccountCard(snapshot: snapshot, store: store) { id in
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
+                                withAnimation(.spring(response: 0.28, dampingFraction: 0.88)) {
+                                    proxy.scrollTo(id, anchor: .top)
+                                }
+                            }
+                        }
+                        .id(snapshot.id)
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                    }
+                }
+                .padding(.trailing, 2)
+                .animation(.spring(response: 0.32, dampingFraction: 0.86), value: store.snapshots.map(\.id))
+            }
+            .frame(maxHeight: accountListHeight())
+        }
+    }
+
+    private var sessionDetail: String {
+        guard let session = store.session else {
+            return "Track burn rate while you work."
+        }
+        let elapsed = formatDuration(seconds: Date().timeIntervalSince(session.startedAt))
+        let lines = store.sessionBurnLines()
+        guard let first = lines.first else {
+            return "Running for \(elapsed)."
+        }
+        return "\(elapsed), \(first.value)"
+    }
+
+    private var recommendationIcon: String {
+        switch store.recommendation.severity {
+        case .good: return "checkmark.circle.fill"
+        case .warning: return "exclamationmark.triangle.fill"
+        case .critical: return "xmark.octagon.fill"
+        case .neutral: return "sparkles"
+        }
+    }
+
+    private var recommendationColor: Color {
+        switch store.recommendation.severity {
+        case .good: return .green
+        case .warning: return .orange
+        case .critical: return .red
+        case .neutral: return .blue
+        }
     }
 
     private var debugPanel: some View {

--- a/Sources/Toki/Views/MenuContentView.swift
+++ b/Sources/Toki/Views/MenuContentView.swift
@@ -119,7 +119,8 @@ struct MenuContentView: View {
 
     private var overview: some View {
         HStack(spacing: 8) {
-            StatBlock(title: "Recommended", value: recommendedAgentText, systemImage: "sparkles")
+            StatBlock(title: "Use", value: recommendedAgentText, systemImage: "sparkles")
+                .help("Recommended account")
             StatBlock(title: "Lowest", value: lowestRemainingText, systemImage: "gauge.with.dots.needle.bottom.50percent")
             StatBlock(title: "Status", value: store.preferences.dndEnabled ? "DND" : "Ready", systemImage: store.preferences.dndEnabled ? "moon.zzz" : "bell")
         }

--- a/Sources/Toki/Views/MenuContentView.swift
+++ b/Sources/Toki/Views/MenuContentView.swift
@@ -210,13 +210,13 @@ struct MenuContentView: View {
                     selectedTab = tab
                 } label: {
                     Image(systemName: tab.systemImage)
-                        .frame(maxWidth: .infinity)
+                        .frame(maxWidth: .infinity, minHeight: 28)
+                        .contentShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+                        .background(selectedTab == tab ? Color.primary.opacity(0.10) : Color.clear, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
                 }
                 .buttonStyle(.plain)
                 .font(.system(size: 12, weight: .semibold))
-                .frame(height: 28)
                 .foregroundStyle(selectedTab == tab ? .primary : .secondary)
-                .background(selectedTab == tab ? Color.primary.opacity(0.10) : Color.clear, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
                 .help(tab.rawValue)
                 .pointerOnHover()
             }

--- a/Sources/Toki/Views/MenuContentView.swift
+++ b/Sources/Toki/Views/MenuContentView.swift
@@ -119,16 +119,26 @@ struct MenuContentView: View {
 
     private var overview: some View {
         HStack(spacing: 8) {
-            StatBlock(title: "Use", value: recommendedAgentText, systemImage: "sparkles")
+            StatBlock(title: "Use", value: recommendedAgentText, systemImage: "sparkles", action: smartSwitchAction)
                 .help("Recommended account")
             StatBlock(title: "Lowest", value: lowestRemainingText, systemImage: "gauge.with.dots.needle.bottom.50percent")
             StatBlock(title: "Status", value: store.preferences.dndEnabled ? "DND" : "Ready", systemImage: store.preferences.dndEnabled ? "moon.zzz" : "bell")
         }
     }
 
+    private var smartSwitchAction: StatBlockAction? {
+        guard store.recommendation.switchTarget != nil else { return nil }
+        return StatBlockAction(
+            systemImage: "arrow.triangle.2.circlepath",
+            help: "Switch Claude Code to \(recommendedAgentText)"
+        ) {
+            store.switchBestAccount()
+        }
+    }
+
     private var lowestRemainingText: String {
         guard let ratio = store.snapshots.compactMap(\.remainingRatio).min() else { return "--" }
-        return "\(Int((ratio * 100).rounded()))%"
+        return percentText(ratio)
     }
 
     private var recommendedAgentText: String {
@@ -171,6 +181,7 @@ struct MenuContentView: View {
             .frame(width: 25, height: 25)
             .background(Color.primary.opacity(0.06), in: RoundedRectangle(cornerRadius: 7, style: .continuous))
             .help(store.session == nil ? "Start session tracking" : "End session tracking")
+            .accessibilityLabel(store.session == nil ? "Start session tracking" : "End session tracking")
             .pointerOnHover()
         }
         .padding(.horizontal, 8)
@@ -197,6 +208,7 @@ struct MenuContentView: View {
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(selectedTab == tab ? .primary : .secondary)
                 .help(tab.rawValue)
+                .accessibilityLabel(tab.rawValue)
                 .pointerOnHover()
             }
         }

--- a/Sources/Toki/Views/SmartPanels.swift
+++ b/Sources/Toki/Views/SmartPanels.swift
@@ -1,0 +1,259 @@
+import SwiftUI
+
+struct HistoryPanel: View {
+    @ObservedObject var store: UsageStore
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 8) {
+                if store.history.isEmpty {
+                    EmptyPanel(systemImage: "chart.line.uptrend.xyaxis", title: "No history yet", detail: "Toki records local quota snapshots after refreshes.")
+                } else {
+                    ForEach(store.history.prefix(80)) { entry in
+                        HStack(alignment: .center, spacing: 8) {
+                            ProviderLogo(provider: entry.provider, size: 16)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(entry.accountName)
+                                    .font(.system(size: 12, weight: .semibold))
+                                    .lineLimit(1)
+                                Text(entry.timestamp, format: .dateTime.month(.abbreviated).day().hour().minute())
+                                    .font(.system(size: 10))
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            VStack(alignment: .trailing, spacing: 2) {
+                                Text(entry.remainingRatio.map(percentText) ?? "--")
+                                    .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                                    .foregroundStyle(entry.remainingRatio.map(historyColor) ?? .secondary)
+                                Text(entry.primary)
+                                    .font(.system(size: 9))
+                                    .foregroundStyle(.tertiary)
+                                    .lineLimit(1)
+                            }
+                        }
+                        .padding(8)
+                        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                .stroke(Color.primary.opacity(0.07), lineWidth: 1)
+                        )
+                    }
+                }
+            }
+            .padding(.trailing, 2)
+        }
+        .frame(maxHeight: accountListHeight())
+    }
+
+    private func historyColor(_ ratio: Double) -> Color {
+        if ratio <= 0.15 { return .red }
+        if ratio <= 0.40 { return .orange }
+        return .primary
+    }
+}
+
+struct EventPanel: View {
+    @ObservedObject var store: UsageStore
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Button {
+                    store.setDND(!store.preferences.dndEnabled)
+                } label: {
+                    Label(store.preferences.dndEnabled ? "DND On" : "DND Off", systemImage: store.preferences.dndEnabled ? "moon.zzz.fill" : "bell")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .help("Toggle do not disturb")
+                .pointerOnHover()
+
+                Spacer()
+
+                Button {
+                    store.clearEvents()
+                } label: {
+                    Image(systemName: "trash")
+                }
+                .buttonStyle(.plain)
+                .frame(width: 25, height: 25)
+                .background(Color.primary.opacity(0.06), in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+                .help("Clear event history")
+                .pointerOnHover()
+            }
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 8) {
+                    if store.events.isEmpty {
+                        EmptyPanel(systemImage: "bell.badge", title: "No events yet", detail: "Low quota, session, switch, and notification events appear here.")
+                    } else {
+                        ForEach(store.events) { event in
+                            HStack(alignment: .top, spacing: 8) {
+                                Image(systemName: icon(for: event))
+                                    .font(.system(size: 13, weight: .semibold))
+                                    .foregroundStyle(color(for: event))
+                                    .frame(width: 18)
+                                VStack(alignment: .leading, spacing: 3) {
+                                    HStack(spacing: 6) {
+                                        Text(event.title)
+                                            .font(.system(size: 12, weight: .semibold))
+                                            .lineLimit(1)
+                                        if event.deliveredNotification {
+                                            Image(systemName: "bell.fill")
+                                                .font(.system(size: 9))
+                                                .foregroundStyle(.blue)
+                                        }
+                                    }
+                                    Text(event.detail)
+                                        .font(.system(size: 10))
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(2)
+                                    Text(event.timestamp, format: .dateTime.month(.abbreviated).day().hour().minute())
+                                        .font(.system(size: 9))
+                                        .foregroundStyle(.tertiary)
+                                }
+                                Spacer()
+                            }
+                            .padding(8)
+                            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                    .stroke(Color.primary.opacity(0.07), lineWidth: 1)
+                            )
+                        }
+                    }
+                }
+                .padding(.trailing, 2)
+            }
+        }
+        .frame(maxHeight: accountListHeight())
+    }
+
+    private func icon(for event: TokiEvent) -> String {
+        switch event.kind {
+        case .lowQuota: return "exclamationmark.triangle.fill"
+        case .recovered: return "checkmark.circle.fill"
+        case .switchAccount: return "arrow.triangle.2.circlepath"
+        case .session: return "timer"
+        case .notification: return event.deliveredNotification ? "bell.fill" : "bell.slash"
+        case .refresh: return "arrow.clockwise"
+        }
+    }
+
+    private func color(for event: TokiEvent) -> Color {
+        switch event.kind {
+        case .lowQuota: return .orange
+        case .recovered: return .green
+        case .switchAccount: return .blue
+        case .session: return .purple
+        case .notification: return event.deliveredNotification ? .blue : .secondary
+        case .refresh: return .secondary
+        }
+    }
+}
+
+struct SettingsPanel: View {
+    @ObservedObject var store: UsageStore
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 10) {
+                Toggle("Notifications", isOn: binding(\.notificationsEnabled))
+                    .toggleStyle(.switch)
+
+                Toggle("Do not disturb", isOn: binding(\.dndEnabled))
+                    .toggleStyle(.switch)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Low quota threshold \(Int(store.preferences.lowQuotaThreshold * 100))%")
+                        .font(.system(size: 11, weight: .semibold))
+                    Slider(value: binding(\.lowQuotaThreshold), in: 0.05...0.50, step: 0.05)
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Session warning \(Int(store.preferences.sessionWarningThreshold * 100))%")
+                        .font(.system(size: 11, weight: .semibold))
+                    Slider(value: binding(\.sessionWarningThreshold), in: 0.05...0.40, step: 0.05)
+                }
+
+                Stepper("Cooldown \(store.preferences.notificationCooldownMinutes)m", value: intBinding(\.notificationCooldownMinutes), in: 5...360, step: 5)
+
+                Stepper("History \(store.preferences.historyRetentionDays)d", value: intBinding(\.historyRetentionDays), in: 1...60, step: 1)
+
+                Picker("Menu bar", selection: binding(\.menuBarMode)) {
+                    ForEach(MenuBarDisplayMode.allCases) { mode in
+                        Text(mode.label).tag(mode)
+                    }
+                }
+
+                Divider()
+
+                Button {
+                    ConfigLoader.openInDefaultEditor()
+                } label: {
+                    Label("Open JSON config", systemImage: "gearshape")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .pointerOnHover()
+            }
+            .font(.system(size: 12))
+            .padding(8)
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(Color.primary.opacity(0.07), lineWidth: 1)
+            )
+        }
+        .frame(maxHeight: accountListHeight())
+    }
+
+    private func binding<Value>(_ keyPath: WritableKeyPath<AppPreferences, Value>) -> Binding<Value> {
+        Binding(
+            get: { store.preferences[keyPath: keyPath] },
+            set: { value in
+                var next = store.preferences
+                next[keyPath: keyPath] = value
+                store.updatePreferences(next)
+            }
+        )
+    }
+
+    private func intBinding(_ keyPath: WritableKeyPath<AppPreferences, Int>) -> Binding<Int> {
+        Binding(
+            get: { store.preferences[keyPath: keyPath] },
+            set: { value in
+                var next = store.preferences
+                next[keyPath: keyPath] = value
+                store.updatePreferences(next)
+            }
+        )
+    }
+}
+
+struct EmptyPanel: View {
+    var systemImage: String
+    var title: String
+    var detail: String
+
+    var body: some View {
+        VStack(spacing: 6) {
+            Image(systemName: systemImage)
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundStyle(.secondary)
+            Text(title)
+                .font(.system(size: 12, weight: .semibold))
+            Text(detail)
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(18)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(Color.primary.opacity(0.07), lineWidth: 1)
+        )
+    }
+}

--- a/Sources/Toki/Views/SmartPanels.swift
+++ b/Sources/Toki/Views/SmartPanels.swift
@@ -79,6 +79,7 @@ struct EventPanel: View {
                 .frame(width: 25, height: 25)
                 .background(Color.primary.opacity(0.06), in: RoundedRectangle(cornerRadius: 7, style: .continuous))
                 .help("Clear event history")
+                .accessibilityLabel("Clear event history")
                 .pointerOnHover()
             }
 
@@ -102,6 +103,7 @@ struct EventPanel: View {
                                             Image(systemName: "bell.fill")
                                                 .font(.system(size: 9))
                                                 .foregroundStyle(.blue)
+                                                .accessibilityHidden(true)
                                         }
                                     }
                                     Text(event.detail)
@@ -161,17 +163,20 @@ struct SettingsPanel: View {
                 Toggle("Notifications", isOn: binding(\.notificationsEnabled))
                     .toggleStyle(.switch)
 
-                Toggle("Do not disturb", isOn: binding(\.dndEnabled))
-                    .toggleStyle(.switch)
+                Toggle("Do not disturb", isOn: Binding(
+                    get: { store.preferences.dndEnabled },
+                    set: { store.setDND($0) }
+                ))
+                .toggleStyle(.switch)
 
                 VStack(alignment: .leading, spacing: 6) {
-                    Text("Low quota threshold \(Int(store.preferences.lowQuotaThreshold * 100))%")
+                    Text("Low quota threshold \(percentText(store.preferences.lowQuotaThreshold))")
                         .font(.system(size: 11, weight: .semibold))
                     Slider(value: binding(\.lowQuotaThreshold), in: 0.05...0.50, step: 0.05)
                 }
 
                 VStack(alignment: .leading, spacing: 6) {
-                    Text("Session warning \(Int(store.preferences.sessionWarningThreshold * 100))%")
+                    Text("Session warning \(percentText(store.preferences.sessionWarningThreshold))")
                         .font(.system(size: 11, weight: .semibold))
                     Slider(value: binding(\.sessionWarningThreshold), in: 0.05...0.40, step: 0.05)
                 }

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -36,7 +36,7 @@ cat > "$CONTENTS_DIR/Info.plist" <<PLIST
   <key>CFBundleShortVersionString</key>
   <string>$VERSION</string>
   <key>CFBundleVersion</key>
-  <string>5</string>
+  <string>6</string>
   <key>LSMinimumSystemVersion</key>
   <string>14.0</string>
   <key>LSUIElement</key>

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -53,7 +53,7 @@ cat > "$INFO_PLIST" <<PLIST
   <key>CFBundleShortVersionString</key>
   <string>$VERSION</string>
   <key>CFBundleVersion</key>
-  <string>5</string>
+  <string>6</string>
   <key>LSMinimumSystemVersion</key>
   <string>14.0</string>
   <key>LSUIElement</key>


### PR DESCRIPTION
## Summary

This PR prepares Toki v2.1.0, a smarter menu-bar release focused on helping users decide which AI coding account to use, understand recent quota movement, avoid notification spam, and get clearer local status from Claude Code and Codex.

## What Changed

### Smart Account Guidance

- Added a smart recommendation model that evaluates live account snapshots and suggests the healthiest account to use next.
- Added one-click best-account switching for inactive Claude Code accounts discovered through `claude-swap`.
- Added exhausted-quota behavior: when every tracked quota-bearing provider is empty, Toki recommends a rotating break suggestion instead of pretending another account is available.
- Updated the menu bar to show a break prompt such as `Take a walk, mate` with an emoji when all tracked quota is exhausted.

### Notification And Event History

- Added local event history for low quota, recovery, DND, session, notification, and switch events.
- Added DND mode so notifications can be recorded without spamming the user.
- Added notification cooldown tracking to avoid repeated alert/event noise.
- Fixed notification audit accuracy so events are marked delivered only after macOS accepts the notification request.

### Usage History And Session Mode

- Added local usage history snapshots in `~/.toki/usage-state.json` with bounded retention.
- Added session mode to capture starting quota and report quota burn during a focused coding session.
- Added session warning events when quota drops below the configured warning threshold or burns quickly.

### Popover And Menu Bar Polish

- Added tabs for Accounts, History, Events, and Settings.
- Added Settings controls for notifications, DND, low-quota threshold, session warning threshold, cooldown, history retention, and menu bar display mode.
- Added menu bar display modes for smart, lowest, Claude, Codex, combined, and account-count views.
- Compacted the overview row to `Use`, `Lowest`, and `Status` to preserve vertical space.
- Expanded tab button hit targets so the full segment is clickable, not just the icon.
- Adjusted popover content height now that the recommendation panel is folded into the overview row.

### Claude Code And Codex Behavior

- Prevented loading placeholders from being reused as cached refresh results, fixing cases where Claude could stay stuck on `Refreshing` after restart.
- Made Claude Code `extra_usage` clearer in expanded metrics as `Extra`, including disabled/enabled fallback states.
- Kept percentages honest: recommendations only use providers with real `remainingRatio` data.

### Release Metadata And Docs

- Bumped app version to `2.1.0` and bundle build to `6`.
- Updated README and CHANGELOG with v2.1.0 features and behavior.

## Validation

- `swift build`
- `scripts/build-app.sh`
- `plutil -p .build/Toki.app/Contents/Info.plist`

## Release

- Release tag: `v2.1.0`
- Release name: `v2.1.0 - get smart --amend`
