### PR TITLE
Toki v2.1.3: fix launch crash in packaged app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.1.3 - 2026-07-12
+
+### Fixed
+
+- Fixed a launch crash in the released app: resources are now resolved via `Bundle.main` from `Contents/Resources` instead of the SwiftPM `Bundle.module` accessor, which fatal-errored because its resource bundle can't sit at the code-signed app root.
+
 ## 2.1.2 - 2026-07-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version 2.1.2" src="https://img.shields.io/badge/version-2.1.2-2f80ed">
+  <img alt="Version 2.1.3" src="https://img.shields.io/badge/version-2.1.3-2f80ed">
   <img alt="macOS 14+" src="https://img.shields.io/badge/macOS-14%2B-111111">
   <img alt="Swift 6" src="https://img.shields.io/badge/Swift-6-f05138">
   <a href="https://github.com/aashutoshrathi/toki"><img alt="Contribute on GitHub" src="https://img.shields.io/badge/contribute-GitHub-24292e?logo=github"></a>

--- a/Sources/Toki/Config/Constants.swift
+++ b/Sources/Toki/Config/Constants.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-let appVersion = "2.1.2"
+let appVersion = "2.1.3"
 let appUserAgent = "Toki/\(appVersion)"
 let defaultConfigPath = "~/.toki/config.json"
 let defaultStatePath = "~/.toki/usage-state.json"

--- a/homebrew/toki.rb
+++ b/homebrew/toki.rb
@@ -3,7 +3,7 @@
 # This file belongs in a tap repo (aashutoshrathi/homebrew-tap) under Casks/toki.rb.
 # scripts/update-cask.sh regenerates the version + sha256 after each release.
 cask "toki" do
-  version "2.1.2"
+  version "2.1.3"
   # update-cask.sh replaces this after each release
   sha256 "PLACEHOLDER_SHA256"
 

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -53,7 +53,7 @@ cat > "$INFO_PLIST" <<PLIST
   <key>CFBundleShortVersionString</key>
   <string>$VERSION</string>
   <key>CFBundleVersion</key>
-  <string>7</string>
+  <string>8</string>
   <key>LSMinimumSystemVersion</key>
   <string>14.0</string>
   <key>LSUIElement</key>


### PR DESCRIPTION
## Toki v2.1.3

A build-only fix release: v2.1.2 shipped a DMG that crashed on launch. This makes the packaged app start cleanly.

### The crash

The released app crashed immediately with:

```
resource_bundle_accessor.swift:12: Fatal error: could not load resource bundle
```

SwiftPM's generated `Bundle.module` accessor looks for its resource bundle at the `.app` root (`Toki.app/Toki_Toki.bundle`). But codesign rejects a bundle at the root ("unsealed contents present in the bundle root"), so it has to live under `Contents/`. Those two requirements are irreconcilable - wherever the bundle went, one of them broke.

### The fix

`ProviderLogo` was the only `Bundle.module` consumer, and it already falls back to the raw SVGs that `package-release.sh` copies into `Contents/Resources`. Dropping the single `Bundle.module` reference removes the fatal accessor from the code path entirely (dead-code-stripped from the binary) and resolves logos via `Bundle.main`. No bundle at the root, codesign is happy, no crash.

### Verified locally (full release pipeline)

- `package-release.sh` → universal build + codesign + DMG
- Signature valid (`--deep --strict`); app root contains only `Contents/`
- Mounted the DMG, extracted the `.app`, and **launched it - stays up, no crash, zero fatal output**
- All six provider-logo SVGs present at `Bundle.main.resourceURL`
- `fatalError` string count in the shipped binary: 0

Bumps to 2.1.3, build 8.
