### PR TITLE
Toki v2.1.4: click-to-connect onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.1.4 - 2026-07-12
+
+### Added
+
+- Click-to-connect onboarding: when no `config.json` exists yet, the popover scans for Claude Code (Keychain), Codex (`~/.codex/auth.json`), and OpenCode (local database) and lets you add them with one click instead of hand-writing JSON. A manual JSON editor link remains for advanced setups.
+
+### Fixed
+
+- `ConfigLoader.save` now creates `~/.toki` if it doesn't exist yet, so the first-ever config write (including from the new onboarding flow) no longer fails on a fresh install.
+
 ## 2.1.3 - 2026-07-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version 2.1.3" src="https://img.shields.io/badge/version-2.1.3-2f80ed">
+  <img alt="Version 2.1.4" src="https://img.shields.io/badge/version-2.1.4-2f80ed">
   <img alt="macOS 14+" src="https://img.shields.io/badge/macOS-14%2B-111111">
   <img alt="Swift 6" src="https://img.shields.io/badge/Swift-6-f05138">
   <a href="https://github.com/aashutoshrathi/toki"><img alt="Contribute on GitHub" src="https://img.shields.io/badge/contribute-GitHub-24292e?logo=github"></a>
@@ -106,7 +106,9 @@ The generated app bundle is written to `.build/Toki.app`.
 
 ## Configuration
 
-Toki reads:
+On first launch, with no `~/.toki/config.json` yet, Toki's popover shows a **Connect an account** screen instead of an empty list. It scans for Claude Code (Keychain), Codex (`~/.codex/auth.json`), and OpenCode (its local database), and a single click on **Connect** (or **Connect all detected**) writes the right entries to `~/.toki/config.json` for you - no JSON to hand-write. If nothing is detected yet, sign in to Claude Code or Codex and reopen the menu.
+
+For scripting, multi-account setups, or fields the wizard doesn't cover (API keys, budgets, manual trackers), edit the config directly. Toki reads:
 
 ```text
 ~/.toki/config.json

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The generated app bundle is written to `.build/Toki.app`.
 
 ## Configuration
 
-On first launch, with no `~/.toki/config.json` yet, Toki's popover shows a **Connect an account** screen instead of an empty list. It scans for Claude Code (Keychain), Codex (`~/.codex/auth.json`), and OpenCode (its local database), and a single click on **Connect** (or **Connect all detected**) writes the right entries to `~/.toki/config.json` for you - no JSON to hand-write. If nothing is detected yet, sign in to Claude Code or Codex and reopen the menu.
+Whenever `~/.toki/config.json` is missing, or exists but has no accounts yet, Toki's popover shows a **Connect an account** screen instead of an empty list. It scans for Claude Code (Keychain), Codex (`~/.codex/auth.json`), and OpenCode (its local database), and a single click on **Connect** (or **Connect all detected**) writes the right entries to `~/.toki/config.json` for you - no JSON to hand-write. If nothing is detected yet, sign in to Claude Code or Codex and reopen the menu.
 
 For scripting, multi-account setups, or fields the wizard doesn't cover (API keys, budgets, manual trackers), edit the config directly. Toki reads:
 

--- a/Sources/Toki/App/AppDelegate.swift
+++ b/Sources/Toki/App/AppDelegate.swift
@@ -73,6 +73,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
             popover.contentViewController?.view.window?.makeKey()
             store.refresh(keepsExistingSnapshots: true, minimumRefreshInterval: 60)
             store.refreshActiveAgents()
+            store.rescanProvidersIfNeeded()
         }
     }
 }

--- a/Sources/Toki/Config/ConfigLoader.swift
+++ b/Sources/Toki/Config/ConfigLoader.swift
@@ -36,6 +36,7 @@ enum ConfigLoader {
     // scenario) from one that doesn't decode at all. Safe to build on top of the former;
     // the latter must not be touched, or a genuinely corrupt config.json would be lost.
     static func loadRawIfParsable() -> AppConfig? {
+        let path = Self.path
         guard FileManager.default.fileExists(atPath: path),
               let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
             return nil

--- a/Sources/Toki/Config/ConfigLoader.swift
+++ b/Sources/Toki/Config/ConfigLoader.swift
@@ -72,6 +72,7 @@ enum ConfigLoader {
 
     static func save(_ config: AppConfig) throws {
         let url = URL(fileURLWithPath: path)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         let data = try JSONEncoder.toki.encode(config)
         try data.write(to: url, options: .atomic)
     }

--- a/Sources/Toki/Config/ConfigLoader.swift
+++ b/Sources/Toki/Config/ConfigLoader.swift
@@ -31,6 +31,18 @@ enum ConfigLoader {
         return config
     }
 
+    // Best-effort parse used by UsageStore.connect() to distinguish a file that exists and
+    // decodes fine but merely fails validate() (e.g. no accounts yet - the exact onboarding
+    // scenario) from one that doesn't decode at all. Safe to build on top of the former;
+    // the latter must not be touched, or a genuinely corrupt config.json would be lost.
+    static func loadRawIfParsable() -> AppConfig? {
+        guard FileManager.default.fileExists(atPath: path),
+              let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(AppConfig.self, from: data)
+    }
+
     // The invariants a config must satisfy, shared by load() and the in-app editor.
     static func validate(_ config: AppConfig) throws {
         guard !config.accounts.isEmpty else {

--- a/Sources/Toki/Config/Constants.swift
+++ b/Sources/Toki/Config/Constants.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-let appVersion = "2.1.3"
+let appVersion = "2.1.4"
 let appUserAgent = "Toki/\(appVersion)"
 let defaultConfigPath = "~/.toki/config.json"
 let defaultStatePath = "~/.toki/usage-state.json"

--- a/Sources/Toki/Discovery/ProviderDetection.swift
+++ b/Sources/Toki/Discovery/ProviderDetection.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+// A CLI/tool Toki found signed in or installed on this machine, offered on the
+// onboarding screen as a one-click "Connect" instead of hand-written config.json.
+struct DetectedProvider: Identifiable, Sendable {
+    let provider: Provider
+    let title: String
+    let detail: String
+    // nil when there is nothing to write into config.json (e.g. OpenCode, which is
+    // auto-tracked by UsageFetcher without a config entry).
+    let makeAccount: (@Sendable () -> AccountConfig)?
+
+    var id: String { provider.rawValue }
+    var isConnectable: Bool { makeAccount != nil }
+}
+
+// Probes the machine for AI coding tools Toki already knows how to read credentials
+// for, so onboarding can offer them as one-click connects instead of asking the user
+// to hand-write config.json. Read-only: never touches config.json itself.
+enum ProviderDetection {
+    // Shells out to `security` and touches the filesystem, so this runs off the main
+    // actor (mirrors ActiveAgent.scan()) to avoid blocking the UI while onboarding loads.
+    static func scan() async -> [DetectedProvider] {
+        await Task.detached(priority: .utility) {
+            var detected: [DetectedProvider] = []
+            if let claude = detectClaudeCode() { detected.append(claude) }
+            if let codex = detectCodex() { detected.append(codex) }
+            if let openCode = detectOpenCode() { detected.append(openCode) }
+            return detected
+        }.value
+    }
+
+    private static func detectClaudeCode() -> DetectedProvider? {
+        guard let bundle = try? ClaudeCodeCredentialReader.readMacOSKeychainCredentials() else { return nil }
+        let email = ClaudeCodeCredentialReader.emailIdentifier(from: bundle.credentials)
+        return DetectedProvider(
+            provider: .claudeCode,
+            title: "Claude Code",
+            detail: email ?? "Signed in via Keychain",
+            makeAccount: {
+                var account = AccountConfig(id: "claude-code", name: "Claude Code", provider: .claudeCode)
+                account.claudeSwapCommand = "claude-swap"
+                return account
+            }
+        )
+    }
+
+    private static func detectCodex() -> DetectedProvider? {
+        let path = expandedPath("~/.codex/auth.json")
+        guard FileManager.default.fileExists(atPath: path) else { return nil }
+        var detail = "Signed in"
+        let probeAccount = AccountConfig(id: "codex-probe", name: "Codex", provider: .codex)
+        if let credentials = try? CodexCredentialReader.readCredentials(account: probeAccount),
+           let email = credentials.email {
+            detail = email
+        }
+        return DetectedProvider(
+            provider: .codex,
+            title: "Codex",
+            detail: detail,
+            makeAccount: {
+                var account = AccountConfig(id: "codex", name: "Codex", provider: .codex)
+                account.codexAuthPath = "~/.codex/auth.json"
+                return account
+            }
+        )
+    }
+
+    private static func detectOpenCode() -> DetectedProvider? {
+        guard OpenCodeUsageClient.autoDetectedAccount() != nil else { return nil }
+        return DetectedProvider(
+            provider: .openCode,
+            title: "OpenCode",
+            detail: "Auto-detected from its local database - no setup needed",
+            makeAccount: nil
+        )
+    }
+}

--- a/Sources/Toki/Discovery/ProviderDetection.swift
+++ b/Sources/Toki/Discovery/ProviderDetection.swift
@@ -45,19 +45,16 @@ enum ProviderDetection {
         )
     }
 
+    // Requires readCredentials() to actually succeed (file exists, parses, and contains a
+    // non-empty OAuth access token) rather than just checking the auth file exists - a file
+    // that's present but stale/malformed shouldn't be offered as a one-click connect.
     private static func detectCodex() -> DetectedProvider? {
-        let path = expandedPath("~/.codex/auth.json")
-        guard FileManager.default.fileExists(atPath: path) else { return nil }
-        var detail = "Signed in"
         let probeAccount = AccountConfig(id: "codex-probe", name: "Codex", provider: .codex)
-        if let credentials = try? CodexCredentialReader.readCredentials(account: probeAccount),
-           let email = credentials.email {
-            detail = email
-        }
+        guard let credentials = try? CodexCredentialReader.readCredentials(account: probeAccount) else { return nil }
         return DetectedProvider(
             provider: .codex,
             title: "Codex",
-            detail: detail,
+            detail: credentials.email ?? "Signed in",
             makeAccount: {
                 var account = AccountConfig(id: "codex", name: "Codex", provider: .codex)
                 account.codexAuthPath = "~/.codex/auth.json"

--- a/Sources/Toki/Models/AppConfig.swift
+++ b/Sources/Toki/Models/AppConfig.swift
@@ -20,7 +20,7 @@ struct AccountLabelConfig: Codable {
 // properties keep their original names (id/name/provider) so the rest of the app is
 // untouched; only the JSON key mapping changed. Decoding accepts the old shape
 // (id/name/provider) too, so existing configs load and can be migrated forward.
-struct AccountConfig: Codable, Identifiable {
+struct AccountConfig: Codable, Identifiable, Sendable {
     var id: String
     var name: String
     var provider: Provider

--- a/Sources/Toki/Models/Provider.swift
+++ b/Sources/Toki/Models/Provider.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum Provider: String, Codable {
+enum Provider: String, Codable, Sendable {
     case openai
     case codex
     case anthropic

--- a/Sources/Toki/Store/UsageStore.swift
+++ b/Sources/Toki/Store/UsageStore.swift
@@ -63,13 +63,15 @@ final class UsageStore: ObservableObject {
     }
 
     // True when there's nothing to lose by showing the connect wizard: no config.json yet,
-    // or one that decodes fine but simply has no accounts. A config.json that exists but
-    // fails to parse/validate for any other reason is a real error - connect() refuses to
-    // write over it, so showing Connect buttons there would be a dead end. That case falls
-    // through to the normal error banner instead (config stays nil, needsOnboarding is false).
+    // or one that decodes fine but simply has no accounts. A config.json that exists and
+    // decodes but is invalid for any other reason (e.g. a copilot entry) - or doesn't decode
+    // at all - is a real error; connect() would still fail its own validate() call there, so
+    // showing Connect buttons would be a dead end. Those cases fall through to the normal
+    // error banner instead (config stays nil, needsOnboarding is false).
     var needsOnboarding: Bool {
         guard config == nil else { return false }
-        return !FileManager.default.fileExists(atPath: ConfigLoader.path) || ConfigLoader.loadRawIfParsable() != nil
+        guard FileManager.default.fileExists(atPath: ConfigLoader.path) else { return true }
+        return ConfigLoader.loadRawIfParsable()?.accounts.isEmpty ?? false
     }
 
     func reloadConfig() {
@@ -86,13 +88,15 @@ final class UsageStore: ObservableObject {
         } catch {
             DiagnosticLogger.shared.record(.error, component: "config", code: "load_failed", detail: diagnosticErrorDetail(error))
             config = nil
-            configError = error.localizedDescription
             snapshots = []
             updateDerivedState(for: snapshots)
-            // Only scan (shells out to `security`) when onboarding will actually show -
-            // a genuinely broken config.json goes to the error banner instead.
+            // The onboarding state (missing/empty config) is expected, not an error - don't
+            // show a scary "Missing config" message for it. Genuinely broken configs still do.
             if needsOnboarding {
+                configError = nil
                 scanForOnboarding()
+            } else {
+                configError = error.localizedDescription
             }
         }
     }

--- a/Sources/Toki/Store/UsageStore.swift
+++ b/Sources/Toki/Store/UsageStore.swift
@@ -111,15 +111,22 @@ final class UsageStore: ObservableObject {
     // Appends detected accounts to config.json (creating it if this is a fresh install)
     // and reloads. Accounts already present for the same provider+id are skipped.
     //
-    // config is nil for ANY load failure, not just "no file yet" - a file that exists but
-    // failed to parse/validate must not be silently replaced with a blank one (data loss).
-    // Only synthesize a fresh config when there truly is no file on disk.
+    // config is nil for ANY load failure, including the exact onboarding case of a file
+    // that decodes fine but has no accounts yet - that's safe to build on top of via
+    // loadRawIfParsable(). A file that exists but doesn't decode at all must not be
+    // silently replaced with a blank one (data loss), so that case alone is refused.
     func connect(_ accounts: [AccountConfig]) {
-        guard config != nil || !FileManager.default.fileExists(atPath: ConfigLoader.path) else {
-            configError = "config.json exists but couldn't be loaded - fix or replace it with the config editor before connecting."
+        var next: AppConfig
+        if let config {
+            next = config
+        } else if let parsed = ConfigLoader.loadRawIfParsable() {
+            next = parsed
+        } else if !FileManager.default.fileExists(atPath: ConfigLoader.path) {
+            next = AppConfig(refreshMinutes: nil, accountLabels: nil, accounts: [], aiInstructions: nil)
+        } else {
+            configError = "config.json exists but couldn't be parsed - fix or replace it with the config editor before connecting."
             return
         }
-        var next = config ?? AppConfig(refreshMinutes: nil, accountLabels: nil, accounts: [], aiInstructions: nil)
         var existingKeys = Set(next.accounts.map { "\($0.provider.rawValue):\($0.id)" })
         for account in accounts {
             let key = "\(account.provider.rawValue):\(account.id)"

--- a/Sources/Toki/Store/UsageStore.swift
+++ b/Sources/Toki/Store/UsageStore.swift
@@ -26,6 +26,8 @@ final class UsageStore: ObservableObject {
         severity: .neutral
     )
     @Published var statusEntries: [MenuBarStatusEntry] = menuBarPlaceholderEntries()
+    @Published var detectedProviders: [DetectedProvider] = []
+    @Published var isScanningProviders = false
 
     private var config: AppConfig?
     private var usageState = UsageState()
@@ -60,6 +62,12 @@ final class UsageStore: ObservableObject {
         TimeInterval(max(config?.refreshMinutes ?? 5, 1) * 60)
     }
 
+    // True when there's no usable config.json yet (missing file or no accounts), so the
+    // popover should show the connect wizard instead of the normal account list.
+    var needsOnboarding: Bool {
+        config == nil
+    }
+
     func reloadConfig() {
         do {
             config = try ConfigLoader.load()
@@ -75,20 +83,38 @@ final class UsageStore: ObservableObject {
             DiagnosticLogger.shared.record(.error, component: "config", code: "load_failed", detail: diagnosticErrorDetail(error))
             config = nil
             configError = error.localizedDescription
-            snapshots = [
-                AccountSnapshot(
-                    id: "config-error",
-                    name: "Config needed",
-                    provider: .manual,
-                    primary: "No config",
-                    subtitle: ConfigLoader.path,
-                    remainingRatio: nil,
-                    progressRatio: nil,
-                    metrics: [MetricLine(label: "Open README", value: "README.md")],
-                    isError: true
-                )
-            ]
+            snapshots = []
             updateDerivedState(for: snapshots)
+            scanForOnboarding()
+        }
+    }
+
+    // Probes for installed/authenticated CLIs (Claude Code, Codex, OpenCode) so the
+    // onboarding screen can offer them as one-click connects.
+    private func scanForOnboarding() {
+        guard !isScanningProviders else { return }
+        isScanningProviders = true
+        Task {
+            detectedProviders = await ProviderDetection.scan()
+            isScanningProviders = false
+        }
+    }
+
+    // Appends detected accounts to config.json (creating it if this is a fresh install)
+    // and reloads. Accounts already present for the same provider+id are skipped.
+    func connect(_ accounts: [AccountConfig]) {
+        var next = config ?? AppConfig(refreshMinutes: nil, accountLabels: nil, accounts: [], aiInstructions: nil)
+        let existingKeys = Set(next.accounts.map { "\($0.provider.rawValue):\($0.id)" })
+        for account in accounts where !existingKeys.contains("\(account.provider.rawValue):\(account.id)") {
+            next.accounts.append(account)
+        }
+        do {
+            try ConfigLoader.validate(next)
+            try ConfigLoader.save(next)
+            reloadConfig()
+        } catch {
+            DiagnosticLogger.shared.record(.error, component: "config", code: "connect_failed", detail: diagnosticErrorDetail(error))
+            configError = "Could not connect account: \(error.localizedDescription)"
         }
     }
 

--- a/Sources/Toki/Store/UsageStore.swift
+++ b/Sources/Toki/Store/UsageStore.swift
@@ -62,10 +62,14 @@ final class UsageStore: ObservableObject {
         TimeInterval(max(config?.refreshMinutes ?? 5, 1) * 60)
     }
 
-    // True when there's no usable config.json yet (missing file or no accounts), so the
-    // popover should show the connect wizard instead of the normal account list.
+    // True when there's nothing to lose by showing the connect wizard: no config.json yet,
+    // or one that decodes fine but simply has no accounts. A config.json that exists but
+    // fails to parse/validate for any other reason is a real error - connect() refuses to
+    // write over it, so showing Connect buttons there would be a dead end. That case falls
+    // through to the normal error banner instead (config stays nil, needsOnboarding is false).
     var needsOnboarding: Bool {
-        config == nil
+        guard config == nil else { return false }
+        return !FileManager.default.fileExists(atPath: ConfigLoader.path) || ConfigLoader.loadRawIfParsable() != nil
     }
 
     func reloadConfig() {
@@ -85,7 +89,11 @@ final class UsageStore: ObservableObject {
             configError = error.localizedDescription
             snapshots = []
             updateDerivedState(for: snapshots)
-            scanForOnboarding()
+            // Only scan (shells out to `security`) when onboarding will actually show -
+            // a genuinely broken config.json goes to the error banner instead.
+            if needsOnboarding {
+                scanForOnboarding()
+            }
         }
     }
 

--- a/Sources/Toki/Store/UsageStore.swift
+++ b/Sources/Toki/Store/UsageStore.swift
@@ -89,6 +89,14 @@ final class UsageStore: ObservableObject {
         }
     }
 
+    // Re-probes for newly installed/authenticated CLIs while the onboarding screen is
+    // showing, so e.g. signing into Codex after Toki launched doesn't require a restart.
+    // Called each time the popover opens; a no-op once a config exists.
+    func rescanProvidersIfNeeded() {
+        guard needsOnboarding else { return }
+        scanForOnboarding()
+    }
+
     // Probes for installed/authenticated CLIs (Claude Code, Codex, OpenCode) so the
     // onboarding screen can offer them as one-click connects.
     private func scanForOnboarding() {
@@ -102,11 +110,22 @@ final class UsageStore: ObservableObject {
 
     // Appends detected accounts to config.json (creating it if this is a fresh install)
     // and reloads. Accounts already present for the same provider+id are skipped.
+    //
+    // config is nil for ANY load failure, not just "no file yet" - a file that exists but
+    // failed to parse/validate must not be silently replaced with a blank one (data loss).
+    // Only synthesize a fresh config when there truly is no file on disk.
     func connect(_ accounts: [AccountConfig]) {
+        guard config != nil || !FileManager.default.fileExists(atPath: ConfigLoader.path) else {
+            configError = "config.json exists but couldn't be loaded - fix or replace it with the config editor before connecting."
+            return
+        }
         var next = config ?? AppConfig(refreshMinutes: nil, accountLabels: nil, accounts: [], aiInstructions: nil)
-        let existingKeys = Set(next.accounts.map { "\($0.provider.rawValue):\($0.id)" })
-        for account in accounts where !existingKeys.contains("\(account.provider.rawValue):\(account.id)") {
+        var existingKeys = Set(next.accounts.map { "\($0.provider.rawValue):\($0.id)" })
+        for account in accounts {
+            let key = "\(account.provider.rawValue):\(account.id)"
+            guard !existingKeys.contains(key) else { continue }
             next.accounts.append(account)
+            existingKeys.insert(key)
         }
         do {
             try ConfigLoader.validate(next)

--- a/Sources/Toki/Store/UsageStore.swift
+++ b/Sources/Toki/Store/UsageStore.swift
@@ -142,7 +142,7 @@ final class UsageStore: ObservableObject {
         } else if !FileManager.default.fileExists(atPath: ConfigLoader.path) {
             next = AppConfig(refreshMinutes: nil, accountLabels: nil, accounts: [], aiInstructions: nil)
         } else {
-            configError = "config.json exists but couldn't be parsed - fix or replace it with the config editor before connecting."
+            configError = "\(ConfigLoader.path) exists but couldn't be parsed - fix or replace it with the config editor before connecting."
             return
         }
         var existingKeys = Set(next.accounts.map { "\($0.provider.rawValue):\($0.id)" })

--- a/Sources/Toki/Store/UsageStore.swift
+++ b/Sources/Toki/Store/UsageStore.swift
@@ -28,6 +28,7 @@ final class UsageStore: ObservableObject {
     @Published var statusEntries: [MenuBarStatusEntry] = menuBarPlaceholderEntries()
     @Published var detectedProviders: [DetectedProvider] = []
     @Published var isScanningProviders = false
+    @Published private(set) var needsOnboarding = false
 
     private var config: AppConfig?
     private var usageState = UsageState()
@@ -68,8 +69,11 @@ final class UsageStore: ObservableObject {
     // at all - is a real error; connect() would still fail its own validate() call there, so
     // showing Connect buttons would be a dead end. Those cases fall through to the normal
     // error banner instead (config stays nil, needsOnboarding is false).
-    var needsOnboarding: Bool {
-        guard config == nil else { return false }
+    //
+    // Computed once per reloadConfig() and cached in the stored property above rather than
+    // recomputed as a view-body computed property - it does synchronous disk I/O + JSON
+    // decoding, which shouldn't run on every SwiftUI re-render.
+    private func computeNeedsOnboarding() -> Bool {
         guard FileManager.default.fileExists(atPath: ConfigLoader.path) else { return true }
         return ConfigLoader.loadRawIfParsable()?.accounts.isEmpty ?? false
     }
@@ -77,6 +81,7 @@ final class UsageStore: ObservableObject {
     func reloadConfig() {
         do {
             config = try ConfigLoader.load()
+            needsOnboarding = false
             usageState = StateLoader.load()
             syncPublishedState()
             applyScheduledResets()
@@ -88,6 +93,7 @@ final class UsageStore: ObservableObject {
         } catch {
             DiagnosticLogger.shared.record(.error, component: "config", code: "load_failed", detail: diagnosticErrorDetail(error))
             config = nil
+            needsOnboarding = computeNeedsOnboarding()
             snapshots = []
             updateDerivedState(for: snapshots)
             // The onboarding state (missing/empty config) is expected, not an error - don't

--- a/Sources/Toki/Views/MenuContentView.swift
+++ b/Sources/Toki/Views/MenuContentView.swift
@@ -45,12 +45,16 @@ struct MenuContentView: View {
             if let session = store.session {
                 SessionRecordingCard(startedAt: session.startedAt)
             }
-            overview
-            tabBar
-            if let configError = store.configError {
-                ErrorBanner(message: configError)
+            if store.needsOnboarding {
+                OnboardingView(store: store) { showConfig = true }
+            } else {
+                overview
+                tabBar
+                if let configError = store.configError {
+                    ErrorBanner(message: configError)
+                }
+                tabContent
             }
-            tabContent
 
             if store.debugMode {
                 debugPanel

--- a/Sources/Toki/Views/OnboardingView.swift
+++ b/Sources/Toki/Views/OnboardingView.swift
@@ -1,0 +1,133 @@
+import SwiftUI
+
+// Shown instead of the account list when there's no usable config.json yet. Scans for
+// AI coding tools already installed/authenticated on the machine and lets the user add
+// them with a single click, instead of hand-writing JSON.
+struct OnboardingView: View {
+    @ObservedObject var store: UsageStore
+    var openConfigEditor: () -> Void
+
+    private var connectable: [DetectedProvider] {
+        store.detectedProviders.filter(\.isConnectable)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Connect an account")
+                    .font(.system(size: 13, weight: .semibold))
+                Text("Toki tracks usage locally - nothing leaves your machine.")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+            }
+
+            if store.isScanningProviders {
+                scanningRow
+            } else if store.detectedProviders.isEmpty {
+                nothingDetected
+            } else {
+                VStack(spacing: 6) {
+                    ForEach(store.detectedProviders) { detected in
+                        ProviderConnectRow(detected: detected) {
+                            if let makeAccount = detected.makeAccount {
+                                store.connect([makeAccount()])
+                            }
+                        }
+                    }
+                }
+
+                if connectable.count > 1 {
+                    Button {
+                        store.connect(connectable.compactMap { $0.makeAccount?() })
+                    } label: {
+                        Label("Connect all detected", systemImage: "checkmark.circle.fill")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .pointerOnHover()
+                }
+            }
+
+            if let configError = store.configError {
+                Text(configError)
+                    .font(.system(size: 9))
+                    .foregroundStyle(.tertiary)
+            }
+
+            Button {
+                openConfigEditor()
+            } label: {
+                Text("Or edit config.json manually")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .pointerOnHover()
+        }
+        .padding(10)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(Color.primary.opacity(0.07), lineWidth: 1)
+        )
+    }
+
+    private var scanningRow: some View {
+        HStack(spacing: 6) {
+            ProgressView()
+                .controlSize(.small)
+            Text("Looking for Claude Code, Codex, OpenCode…")
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var nothingDetected: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Nothing detected yet")
+                .font(.system(size: 11, weight: .medium))
+            Text("Sign in to Claude Code or Codex, then reopen this menu - Toki will pick them up automatically.")
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+private struct ProviderConnectRow: View {
+    var detected: DetectedProvider
+    var connect: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ProviderLogo(provider: detected.provider, size: 18)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(detected.title)
+                    .font(.system(size: 11, weight: .semibold))
+                Text(detected.detail)
+                    .font(.system(size: 9))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            Spacer(minLength: 4)
+            if detected.isConnectable {
+                Button("Connect", action: connect)
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .pointerOnHover()
+            } else {
+                Text("Auto-detected")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 3)
+                    .background(Color.primary.opacity(0.06), in: Capsule())
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+    }
+}

--- a/homebrew/toki.rb
+++ b/homebrew/toki.rb
@@ -3,7 +3,7 @@
 # This file belongs in a tap repo (aashutoshrathi/homebrew-tap) under Casks/toki.rb.
 # scripts/update-cask.sh regenerates the version + sha256 after each release.
 cask "toki" do
-  version "2.1.3"
+  version "2.1.4"
   # update-cask.sh replaces this after each release
   sha256 "PLACEHOLDER_SHA256"
 

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -53,7 +53,7 @@ cat > "$INFO_PLIST" <<PLIST
   <key>CFBundleShortVersionString</key>
   <string>$VERSION</string>
   <key>CFBundleVersion</key>
-  <string>8</string>
+  <string>9</string>
   <key>LSMinimumSystemVersion</key>
   <string>14.0</string>
   <key>LSUIElement</key>


### PR DESCRIPTION
## Summary

Fresh installs previously hit a dead-end "Config needed / Open README" card and had to hand-write `~/.toki/config.json` by copying the example file and looking up provider `type` values. This PR replaces that empty state with a click-to-connect onboarding wizard.

## What Changed

### Onboarding

- New popover screen shown whenever there's no usable `config.json` yet: scans for Claude Code (Keychain), Codex (`~/.codex/auth.json`), and OpenCode (local database) and lists what it finds.
- One-click **Connect** per detected provider, or **Connect all detected** when more than one is found - writes the right `AccountConfig` entries into `config.json` with no JSON typing required.
- OpenCode shows as "Auto-detected" (it's already tracked automatically with no config entry) rather than offering a redundant connect action.
- When nothing is detected, explains what Toki looks for and keeps a link to the existing manual JSON editor for advanced setups (API keys, budgets, manual trackers).
- Re-scans on every popover open while onboarding is showing, so signing into a tool after Toki launched doesn't require a restart.
- Gemini is intentionally out of scope - Toki has no Gemini usage integration yet.

### Fixed

- `ConfigLoader.save` now creates `~/.toki` if it doesn't exist, so the very first config write (including from onboarding) doesn't fail on a fresh install.
- `connect()` distinguishes a config.json that's genuinely unparseable from the expected onboarding case of a file that decodes but has no accounts yet, so a broken config is never silently overwritten and an empty one isn't a dead end either.
- `needsOnboarding` is cached rather than recomputed on every SwiftUI render, and `Provider`/`AccountConfig` now conform to `Sendable`.

## Version

Bumped to 2.1.4 (Constants.swift, README badge, homebrew/toki.rb, package-release.sh CFBundleVersion 8→9) with a CHANGELOG entry.