### PR TITLE
v2.1.6: fix Codex percentage display, add rate-limit reset button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.1.6 - 2026-07-13
+
+### Added
+
+- "Reset now" button on the Codex account card when OpenAI has banked rate-limit reset credits available (shows the count when more than one is banked). Disabled until the current window is at least 80% used, so a reset isn't spent while there's still plenty of quota left.
+
+### Fixed
+
+- Codex usage sometimes displayed a raw token count instead of the percentage-based rate limit like Claude Code does. The `account/usage/read` and `account/rateLimits/read` app-server calls were fired together but raced a single fixed 5s sleep before the pipe closed; rate limits (which round-trip to OpenAI's backend) could lose that race while usage won, silently falling back to token display. Now polls for every expected response instead of guessing a fixed delay.
+
 ## 2.1.5 - 2026-07-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version 2.1.5" src="https://img.shields.io/badge/version-2.1.5-2f80ed">
+  <img alt="Version 2.1.6" src="https://img.shields.io/badge/version-2.1.6-2f80ed">
   <img alt="macOS 14+" src="https://img.shields.io/badge/macOS-14%2B-111111">
   <img alt="Swift 6" src="https://img.shields.io/badge/Swift-6-f05138">
   <a href="https://github.com/aashutoshrathi/toki"><img alt="Contribute on GitHub" src="https://img.shields.io/badge/contribute-GitHub-24292e?logo=github"></a>
@@ -34,6 +34,7 @@ Toki stays local. Credentials are read from your Mac, your configured commands, 
 ## Features
 
 - Live quota, rate-limit, and spend tracking for Claude Code (multi-account via `claude-swap`, with discovery, one-click switching, and Keychain credential lookup), Codex, and OpenCode.
+- One-click redemption of banked Codex rate-limit reset credits, gated to when the current window is mostly used.
 - Active-agent discovery across Codex, Claude Code, Copilot CLI, Gemini CLI, OpenCode, and ChatGPT-hosted Codex, with best-effort navigation to the matching terminal tab or host app.
 - AI-powered insight card with on-device Apple Intelligence summarization (macOS 26+), falling back to a deterministic recommendation with one-click smart switch.
 - Native low-quota and session-warning notifications with cooldowns, DND mode, and local event/usage history.
@@ -222,15 +223,17 @@ Add a Codex account when this Mac is signed in to Codex:
 
 ```json
 {
-  "id": "codex",
-  "name": "Codex",
-  "provider": "codex"
+  "label": "Codex",
+  "type": "codex",
+  "codexAuthPath": "~/.codex/auth.json"
 }
 ```
 
 Toki reads `~/.codex/auth.json` by default and asks the local Codex app-server for account usage and rate limits. Set `codexAuthPath` to use a different auth file.
 
 Codex usage is separate from OpenAI organization API usage.
+
+When OpenAI has a banked rate-limit reset credit for the account, the expanded Codex card shows a **Reset now** button (with the count when more than one is banked). It stays disabled until the current window is at least 80% used, so a reset isn't spent while there's still plenty of quota left - redeeming one resets the rate-limit window immediately via the Codex app-server.
 
 ## Development
 

--- a/Sources/Toki/API/CodexUsageClient.swift
+++ b/Sources/Toki/API/CodexUsageClient.swift
@@ -7,7 +7,7 @@ struct CodexUsageClient {
 
     func snapshot() async throws -> AccountSnapshot {
         let credentials = try CodexCredentialReader.readCredentials(account: account)
-        let payload = try CodexAppServerClient.fetch()
+        let payload = try CodexAppServerClient.fetch(account: account)
         let usage = CodexUsage(json: payload.usage ?? [:])
         let rateLimits = CodexRateLimits(json: payload.rateLimits ?? [:])
         guard usage.hasUsage || rateLimits.hasUsage else {
@@ -33,6 +33,7 @@ struct CodexUsageClient {
             subtitle: rateLimits.subtitle ?? credentials.email ?? "OpenAI Codex usage",
             remainingRatio: rateLimits.remainingRatio,
             progressRatio: rateLimits.progressRatio,
+            resetCreditsAvailable: rateLimits.resetCreditsAvailable,
             metrics: rateLimits.metrics + usage.metrics,
             accountInfo: CodexCredentialReader.accountInfo(from: credentials) + CodexAccountInfo.lines(from: payload.account)
         )
@@ -40,31 +41,108 @@ struct CodexUsageClient {
 }
 
 enum CodexAppServerClient {
-    static func fetch() throws -> CodexAppServerPayload {
+    private static let path = "$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+    static func fetch(account: AccountConfig) throws -> CodexAppServerPayload {
+        let responses = try call(account: account, requests: [
+            (id: 2, method: "account/usage/read", params: "null"),
+            (id: 3, method: "account/rateLimits/read", params: "null"),
+            (id: 4, method: "account/read", params: "{}")
+        ])
+
+        var payload = CodexAppServerPayload()
+        payload.usage = responses.results[2]
+        payload.rateLimits = responses.results[3]
+        payload.account = responses.results[4]
+
+        if payload.usage == nil && payload.rateLimits == nil {
+            throw LocalizedErrorMessage(responses.errors.first ?? "Codex app-server did not return usage")
+        }
+        // A successful account/rateLimits/read always returns a rate_limits object per the
+        // app-server schema (only primary/secondary within it are optional) - a missing
+        // response here means the call itself failed or timed out. Surface that as an error
+        // instead of silently falling back to usage's raw token count, which is exactly the
+        // degraded display this fix exists to prevent.
+        if payload.rateLimits == nil {
+            throw LocalizedErrorMessage(responses.errors.first ?? "Codex app-server did not return rate limits")
+        }
+        return payload
+    }
+
+    static func consumeRateLimitResetCredit(account: AccountConfig, creditID: String?) throws -> String {
+        var params: [String: Any] = ["idempotencyKey": UUID().uuidString]
+        if let creditID {
+            params["creditId"] = creditID
+        }
+        let paramsData = try JSONSerialization.data(withJSONObject: params)
+        let paramsString = String(data: paramsData, encoding: .utf8) ?? "{}"
+
+        let responses = try call(account: account, requests: [(id: 2, method: "account/rateLimitResetCredit/consume", params: paramsString)])
+        guard let result = responses.results[2] as? [String: Any], let outcome = result["outcome"] as? String else {
+            throw LocalizedErrorMessage(responses.errors.first ?? "Codex did not confirm the reset")
+        }
+        return outcome
+    }
+
+    // codex app-server has no per-request account parameter - it always acts on whichever
+    // session CODEX_HOME points at (default ~/.codex). Deriving CODEX_HOME from the
+    // account's configured codexAuthPath keeps multi-account setups scoped to the right
+    // session instead of silently acting on the CLI's default one - most load-bearing for
+    // consumeRateLimitResetCredit, since a reset credit is a limited resource.
+    private static func codexHomeDirectory(for account: AccountConfig) -> String {
+        let authPath = expandedPath(account.codexAuthPath ?? "~/.codex/auth.json")
+        return (authPath as NSString).deletingLastPathComponent
+    }
+
+    // Usage and rate-limit reads each round-trip to OpenAI's backend, so a fixed short
+    // sleep would race them - rateLimits can lose that race while usage (often served from a
+    // faster path) wins, silently degrading the display to raw tokens. Poll for every expected
+    // response id instead, exiting as soon as they've all arrived (bounded by ~10.4s: a 0.4s
+    // handshake plus up to 100 * 0.1s poll iterations).
+    private static func call(account: AccountConfig, requests: [(id: Int, method: String, params: String)]) throws -> (results: [Int: Any], errors: [String]) {
         let initialize = #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"Toki","version":"\#(appVersion)"},"capabilities":{"experimentalApi":true}}}"#
         let initialized = #"{"jsonrpc":"2.0","method":"initialized","params":null}"#
-        let usage = #"{"jsonrpc":"2.0","id":2,"method":"account/usage/read","params":null}"#
-        let rateLimits = #"{"jsonrpc":"2.0","id":3,"method":"account/rateLimits/read","params":null}"#
-        let account = #"{"jsonrpc":"2.0","id":4,"method":"account/read","params":{}}"#
-        let path = "$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+        let requestLines = requests.map { #"{"jsonrpc":"2.0","id":\#($0.id),"method":"\#($0.method)","params":\#($0.params)}"# }
+        let printfArgs = requestLines.map { "'\(shellEscaped($0))'" }.joined(separator: " ")
+        // Grep against the whole line, not just the id substring, so a coincidental "id"
+        // field nested inside a result payload (e.g. a future OpenAI response containing an
+        // integer id) can't be mistaken for the JSON-RPC envelope's own id and end the poll
+        // before that request's real response has actually arrived.
+        let idChecks = requests.map { #"grep '"jsonrpc":"2.0"' "$__toki_out" | grep -qE '"id"[[:space:]]*:[[:space:]]*\#($0.id)[,}]'"# }.joined(separator: " && ")
+        let codexHome = codexHomeDirectory(for: account)
 
         let command = """
+        __toki_out=$(mktemp -t toki_codex); \
         ( printf '%s\\n' '\(shellEscaped(initialize))'; \
         sleep 0.2; \
         printf '%s\\n' '\(shellEscaped(initialized))'; \
         sleep 0.2; \
-        printf '%s\\n' '\(shellEscaped(usage))' '\(shellEscaped(rateLimits))' '\(shellEscaped(account))'; \
-        sleep 5 ) | PATH="\(path)" codex app-server --stdio
+        printf '%s\\n' \(printfArgs) ) | CODEX_HOME='\(shellEscaped(codexHome))' PATH="\(path)" codex app-server --stdio > "$__toki_out" 2>&1 & \
+        __toki_pid=$!; \
+        for ((__toki_i = 1; __toki_i <= 100; __toki_i++)); do \
+        sleep 0.1; \
+        if \(idChecks); then break; fi; \
+        kill -0 $__toki_pid 2>/dev/null || break; \
+        done; \
+        kill $__toki_pid 2>/dev/null; \
+        wait $__toki_pid 2>/dev/null; \
+        cat "$__toki_out"; \
+        rm -f "$__toki_out"
         """
 
         let output = try SecretResolver.runShell(command)
-        var payload = CodexAppServerPayload()
+        var results: [Int: Any] = [:]
         var errors: [String] = []
+        var unparsedLines: [String] = []
 
-        for line in output.split(whereSeparator: \.isNewline) {
-            guard let data = String(line).data(using: .utf8),
+        for rawLine in output.split(whereSeparator: \.isNewline) {
+            let line = String(rawLine).trimmingCharacters(in: .whitespaces)
+            guard !line.isEmpty else { continue }
+
+            guard let data = line.data(using: .utf8),
                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                   let id = json["id"] as? Int else {
+                unparsedLines.append(line)
                 continue
             }
 
@@ -74,22 +152,18 @@ enum CodexAppServerClient {
                 continue
             }
 
-            guard let result = json["result"] else { continue }
-            switch id {
-            case 2:
-                payload.usage = result
-            case 3:
-                payload.rateLimits = result
-            case 4:
-                payload.account = result
-            default:
-                continue
+            if let result = json["result"], !(result is NSNull) {
+                results[id] = result
             }
         }
 
-        if payload.usage == nil && payload.rateLimits == nil {
-            throw LocalizedErrorMessage(errors.first ?? "Codex app-server did not return usage")
+        // No structured JSON-RPC error and no results usually means codex itself failed
+        // before speaking JSON-RPC (missing binary, permission error, crash) - surface that
+        // raw line instead of only the generic "did not return" fallback callers use.
+        if errors.isEmpty, results.isEmpty, let firstUnparsed = unparsedLines.first {
+            errors.append(firstUnparsed)
         }
-        return payload
+
+        return (results, errors)
     }
 }

--- a/Sources/Toki/Config/Constants.swift
+++ b/Sources/Toki/Config/Constants.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-let appVersion = "2.1.5"
+let appVersion = "2.1.6"
 let appUserAgent = "Toki/\(appVersion)"
 let defaultConfigPath = "~/.toki/config.json"
 let defaultStatePath = "~/.toki/usage-state.json"

--- a/Sources/Toki/Models/AccountSnapshot.swift
+++ b/Sources/Toki/Models/AccountSnapshot.swift
@@ -14,6 +14,7 @@ struct AccountSnapshot: Identifiable, Hashable {
     var subtitle: String
     var remainingRatio: Double?
     var progressRatio: Double? = nil
+    var resetCreditsAvailable: Int = 0
     var metrics: [MetricLine]
     var accountInfo: [MetricLine] = []
     var isError: Bool = false

--- a/Sources/Toki/Models/CodexModels.swift
+++ b/Sources/Toki/Models/CodexModels.swift
@@ -97,6 +97,7 @@ struct CodexRateLimits {
     var subtitle: String?
     var remainingRatio: Double?
     var progressRatio: Double?
+    var resetCreditsAvailable: Int = 0
 
     var hasUsage: Bool {
         !metrics.isEmpty || primary != nil
@@ -116,7 +117,10 @@ struct CodexRateLimits {
         }
         if let resetCredits = data["rateLimitResetCredits"] as? [String: Any],
            let count = optionalNumber(firstValue(resetCredits, keys: ["availableCount"])) {
-            metrics.append(MetricLine(label: "Resets", value: "\(Int(count)) available"))
+            resetCreditsAvailable = Int(count)
+            if resetCreditsAvailable > 0 {
+                metrics.append(MetricLine(label: "Resets", value: "\(resetCreditsAvailable) available"))
+            }
         }
         if let credits = limits["credits"] as? [String: Any] {
             appendCredits(credits)

--- a/Sources/Toki/Models/UsageState.swift
+++ b/Sources/Toki/Models/UsageState.swift
@@ -103,6 +103,7 @@ enum TokiEventKind: String, Codable {
     case session
     case notification
     case refresh
+    case reset
 }
 
 struct TokiEvent: Codable, Identifiable, Hashable {

--- a/Sources/Toki/Store/UsageStore+Accounts.swift
+++ b/Sources/Toki/Store/UsageStore+Accounts.swift
@@ -24,6 +24,39 @@ extension UsageStore {
         refresh()
     }
 
+    func consumeCodexResetCredit(accountID: String) {
+        guard let account = config?.accounts.first(where: { $0.id == accountID }), account.provider == .codex,
+              !resettingAccountIDs.contains(accountID) else {
+            return
+        }
+        resettingAccountIDs.insert(accountID)
+        Task {
+            defer { resettingAccountIDs.remove(accountID) }
+            let result = await Task.detached {
+                Result { try CodexAppServerClient.consumeRateLimitResetCredit(account: account, creditID: nil) }
+            }.value
+
+            switch result {
+            case .success(let outcome):
+                appendEvent(kind: .reset, title: "Codex reset", detail: resetOutcomeDescription(outcome), deliveredNotification: false)
+                refresh(keepsExistingSnapshots: true)
+            case .failure(let error):
+                DiagnosticLogger.shared.record(.error, component: "codex_reset", code: "consume_failed", detail: diagnosticErrorDetail(error))
+                appendEvent(kind: .reset, title: "Codex reset failed", detail: error.localizedDescription, deliveredNotification: false)
+            }
+        }
+    }
+
+    private func resetOutcomeDescription(_ outcome: String) -> String {
+        switch outcome {
+        case "reset": return "Rate limit windows were reset."
+        case "nothingToReset": return "No rate limit window needed a reset."
+        case "noCredit": return "No reset credits were available."
+        case "alreadyRedeemed": return "That reset was already redeemed."
+        default: return "Reset outcome: \(outcome)."
+        }
+    }
+
     func renameAccount(snapshot: AccountSnapshot, alias: String) {
         let trimmed = alias.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, var config else { return }

--- a/Sources/Toki/Store/UsageStore.swift
+++ b/Sources/Toki/Store/UsageStore.swift
@@ -27,6 +27,7 @@ final class UsageStore: ObservableObject {
     @Published var detectedProviders: [DetectedProvider] = []
     @Published var isScanningProviders = false
     @Published private(set) var needsOnboarding = false
+    @Published var resettingAccountIDs: Set<String> = []
 
     // Not private(set): these are written from UsageStore+*.swift extensions in other
     // files, and Swift's `private`/`private(set)` is scoped to the declaring file, not

--- a/Sources/Toki/Views/AccountCard.swift
+++ b/Sources/Toki/Views/AccountCard.swift
@@ -140,6 +140,28 @@ struct AccountCard: View {
                     .font(.system(size: 11, weight: .medium))
                 }
 
+                if snapshot.resetCreditsAvailable > 0 {
+                    HStack(spacing: 8) {
+                        Button {
+                            store.consumeCodexResetCredit(accountID: snapshot.id)
+                        } label: {
+                            if isResetting {
+                                ProgressView()
+                                    .controlSize(.small)
+                                    .accessibilityLabel("Resetting Codex rate limit")
+                            } else {
+                                Label(resetButtonTitle, systemImage: "arrow.counterclockwise")
+                            }
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .disabled(isResetting || !canUseResetCredit)
+                        .help(resetButtonHelp)
+                        .pointerOnHover()
+                        Spacer()
+                    }
+                }
+
                 if store.debugMode && snapshot.isError {
                     Divider()
                         .padding(.vertical, 1)
@@ -350,6 +372,33 @@ struct AccountCard: View {
 
     private var progressRatio: Double? {
         snapshot.progressRatio ?? snapshot.remainingRatio.map { 1 - $0 }
+    }
+
+    private var isResetting: Bool {
+        store.resettingAccountIDs.contains(snapshot.id)
+    }
+
+    // Resets are a limited, banked resource - redeeming one while plenty of quota remains
+    // just throws it away. Only allow it once the window is mostly spent. Uses the same
+    // progressRatio (used fraction) the progress bar renders, so it works whether the
+    // snapshot populated progressRatio or only remainingRatio.
+    private var canUseResetCredit: Bool {
+        guard let progressRatio else { return false }
+        return progressRatio >= 0.80
+    }
+
+    private var resetButtonTitle: String {
+        snapshot.resetCreditsAvailable > 1 ? "Reset now (\(snapshot.resetCreditsAvailable) available)" : "Reset now"
+    }
+
+    private var resetButtonHelp: String {
+        if canUseResetCredit {
+            return "Redeem a banked reset credit to reset this rate limit window now"
+        }
+        if progressRatio == nil {
+            return "Current usage is unavailable, so Toki can't confirm this reset would be worth spending"
+        }
+        return "Save this reset for when you're closer to the limit (usage must be at least 80% used)"
     }
 
     private var statusColor: Color {

--- a/Sources/Toki/Views/EventPanel.swift
+++ b/Sources/Toki/Views/EventPanel.swift
@@ -87,6 +87,7 @@ struct EventPanel: View {
         case .session: return "timer"
         case .notification: return event.deliveredNotification ? "bell.fill" : "bell.slash"
         case .refresh: return "arrow.clockwise"
+        case .reset: return "arrow.counterclockwise"
         }
     }
 
@@ -98,6 +99,7 @@ struct EventPanel: View {
         case .session: return .purple
         case .notification: return event.deliveredNotification ? .blue : .secondary
         case .refresh: return .secondary
+        case .reset: return .teal
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fixes Codex usage sometimes showing a raw token count instead of a percentage: `account/usage/read` and `account/rateLimits/read` raced a fixed 5s sleep before the app-server pipe closed, and rate limits (a backend round trip) could lose that race. Replaced the fixed sleep with a poll loop that waits for every expected response id (bounded at 10s).
- Adds a "Reset now" button on the Codex account card, wired to OpenAI's `account/rateLimitResetCredit/consume` app-server RPC. Shown only when a reset credit is banked (count shown if more than one), disabled until the current window is at least 80% used so a banked reset isn't spent early.
- Bumps version to 2.1.6, updates CHANGELOG and README badge.

## Test plan
- [x] `swift build` succeeds cleanly (no warnings)
- [x] Verified the exact generated app-server shell command against a simulated slow `codex` process (3s delayed rate-limits response, which would have raced the old 5s sleep) — all responses captured correctly
- [x] Verified graceful, fast exit when the `codex` binary is missing (no hang)
- [ ] Manual verification against a live Codex account with a banked reset credit (no such account available in this environment)