### PR TITLE
v2.2.1: memory usage and a quit button on active agent cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Active agent cards now show memory usage (RSS, the same figure Activity Monitor's "Memory" column shows) alongside the host app.
-- A quit button on each active agent card, with a confirmation dialog before it sends the process a terminate signal.
+- A quit button on each active agent card, with a confirmation dialog before it sends the process a terminate signal. Since the confirmation can sit open for a while (and PIDs get reused), it re-verifies the process still matches what was shown before actually signalling it, rather than trusting a possibly-stale PID.
 
 ## 2.2.0 - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.2.1 - 2026-07-16
+
+### Added
+
+- Active agent cards now show memory usage (RSS, the same figure Activity Monitor's "Memory" column shows) alongside the host app.
+- A quit button on each active agent card, with a confirmation dialog before it sends the process a terminate signal.
+
 ## 2.2.0 - 2026-07-16
 
 ### Added

--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -11,6 +11,9 @@ struct ActiveAgent: Identifiable, Hashable, Sendable {
     let processID: Int32
     let runtime: String
     let terminalTTY: String?
+    // Resident set size in kilobytes, straight from `ps rss=` - the same figure Activity
+    // Monitor's "Memory" column shows.
+    let memoryKB: Int
 
     // Primary label: the conversation title, else the project folder, else the provider.
     var title: String {
@@ -19,6 +22,11 @@ struct ActiveAgent: Identifiable, Hashable, Sendable {
             return folder
         }
         return "\(provider.displayName) agent"
+    }
+
+    var memoryDisplay: String {
+        let mb = Double(memoryKB) / 1024
+        return mb >= 1024 ? String(format: "%.1f GB", mb / 1024) : String(format: "%.0f MB", mb)
     }
 
     // Working directory shown relative to home (~/Code/tokenbar), when meaningful.
@@ -48,6 +56,7 @@ enum ActiveAgentScanner {
         let command: String
         let runtime: String
         let tty: String?
+        let memoryKB: Int
     }
 
     // Caches the immutable-per-process fields (cwd, host app) by PID so they're resolved
@@ -62,7 +71,7 @@ enum ActiveAgentScanner {
 
     static func scan() async -> [ActiveAgent] {
         await Task.detached(priority: .utility) {
-            guard let output = Shell.output("/bin/ps", ["-axo", "pid=,ppid=,tty=,etime=,command="]) else {
+            guard let output = Shell.output("/bin/ps", ["-axo", "pid=,ppid=,tty=,etime=,rss=,command="]) else {
                 DiagnosticLogger.shared.record(.warning, component: "agents", code: "scan_failed")
                 return []
             }
@@ -93,9 +102,10 @@ enum ActiveAgentScanner {
     // Cheap, I/O-free parse: identify the provider, tty, and lineage from the ps row.
     // Enrichment (cwd, host, title, activity) happens later, only for root agents.
     private static func parse(line: Substring) -> Candidate? {
-        let parts = line.split(maxSplits: 4, whereSeparator: { $0.isWhitespace })
-        guard parts.count == 5, let pid = Int32(parts[0]), let parentPID = Int32(parts[1]) else { return nil }
-        let command = String(parts[4])
+        let parts = line.split(maxSplits: 5, whereSeparator: { $0.isWhitespace })
+        guard parts.count == 6, let pid = Int32(parts[0]), let parentPID = Int32(parts[1]) else { return nil }
+        let memoryKB = Int(parts[4]) ?? 0
+        let command = String(parts[5])
         let commandParts = command.split(whereSeparator: { $0.isWhitespace })
         guard let executablePath = commandParts.first else { return nil }
         let executable = URL(fileURLWithPath: String(executablePath)).lastPathComponent.lowercased()
@@ -135,7 +145,7 @@ enum ActiveAgentScanner {
 
         let ttyValue = String(parts[2])
         let tty = ttyValue == "??" || ttyValue == "-" ? nil : ttyValue
-        return Candidate(pid: pid, parentPID: parentPID, provider: provider, command: command, runtime: String(parts[3]), tty: tty)
+        return Candidate(pid: pid, parentPID: parentPID, provider: provider, command: command, runtime: String(parts[3]), tty: tty, memoryKB: memoryKB)
     }
 
     // Resolves the expensive fields. cwd and host app are truly immutable for a live
@@ -159,10 +169,20 @@ enum ActiveAgentScanner {
             lastActivity: AgentSessionResolver.lastActivity(provider: c.provider, command: c.command, cwd: cwd),
             processID: c.pid,
             runtime: c.runtime,
-            terminalTTY: c.tty
+            terminalTTY: c.tty,
+            memoryKB: c.memoryKB
         )
         cache[c.pid] = CacheEntry(command: c.command, directory: cwd, hostApp: hostApp)
         return agent
+    }
+}
+
+@MainActor
+enum ActiveAgentTerminator {
+    // SIGTERM, not SIGKILL - gives the agent a chance to exit the way Ctrl-C in its own
+    // terminal would, instead of yanking it out from under any in-progress file write.
+    static func terminate(_ agent: ActiveAgent) {
+        kill(agent.processID, SIGTERM)
     }
 }
 

--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -14,6 +14,9 @@ struct ActiveAgent: Identifiable, Hashable, Sendable {
     // Resident set size in kilobytes, straight from `ps rss=` - the same figure Activity
     // Monitor's "Memory" column shows.
     let memoryKB: Int
+    // The full command line at scan time - kept only so ActiveAgentTerminator can confirm
+    // the PID still refers to this same process immediately before signalling it.
+    let command: String
 
     // Primary label: the conversation title, else the project folder, else the provider.
     var title: String {
@@ -170,7 +173,8 @@ enum ActiveAgentScanner {
             processID: c.pid,
             runtime: c.runtime,
             terminalTTY: c.tty,
-            memoryKB: c.memoryKB
+            memoryKB: c.memoryKB,
+            command: c.command
         )
         cache[c.pid] = CacheEntry(command: c.command, directory: cwd, hostApp: hostApp)
         return agent
@@ -181,7 +185,20 @@ enum ActiveAgentScanner {
 enum ActiveAgentTerminator {
     // SIGTERM, not SIGKILL - gives the agent a chance to exit the way Ctrl-C in its own
     // terminal would, instead of yanking it out from under any in-progress file write.
+    //
+    // Re-checks that the PID still belongs to the same process immediately before
+    // signalling it. The confirmation dialog can sit open for a while (and even without
+    // it, the scan that produced this agent may already be stale), and macOS reuses PIDs -
+    // without this, an agent that already exited could have its PID reassigned to some
+    // unrelated process by the time "Quit" is actually clicked, which would then be the
+    // one to receive the signal instead.
     static func terminate(_ agent: ActiveAgent) {
+        let currentCommand = Shell.output("/bin/ps", ["-p", String(agent.processID), "-o", "command="])?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard currentCommand == agent.command else {
+            DiagnosticLogger.shared.record(.warning, component: "agents", code: "terminate_stale_pid")
+            return
+        }
         kill(agent.processID, SIGTERM)
     }
 }

--- a/Sources/Toki/Config/Constants.swift
+++ b/Sources/Toki/Config/Constants.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-let appVersion = "2.2.0"
+let appVersion = "2.2.1"
 let appUserAgent = "Toki/\(appVersion)"
 let defaultConfigPath = "~/.toki/config.json"
 let defaultStatePath = "~/.toki/usage-state.json"

--- a/Sources/Toki/Store/UsageStore+Agents.swift
+++ b/Sources/Toki/Store/UsageStore+Agents.swift
@@ -11,4 +11,15 @@ extension UsageStore {
             isScanningAgents = false
         }
     }
+
+    // Drops the row immediately for a responsive feel, then reconciles with a real scan
+    // shortly after in case the signal didn't actually take effect (e.g. no permission).
+    func terminateAgent(_ agent: ActiveAgent) {
+        ActiveAgentTerminator.terminate(agent)
+        activeAgents.removeAll { $0.id == agent.id }
+        Task {
+            try? await Task.sleep(for: .seconds(1))
+            refreshActiveAgents()
+        }
+    }
 }

--- a/Sources/Toki/Views/ActiveAgentsPanel.swift
+++ b/Sources/Toki/Views/ActiveAgentsPanel.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ActiveAgentsPanel: View {
     @ObservedObject var store: UsageStore
+    @State private var pendingTermination: ActiveAgent?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -29,40 +30,55 @@ struct ActiveAgentsPanel: View {
                         )
                     } else {
                         ForEach(store.activeAgents) { agent in
-                            Button {
-                                ActiveAgentNavigator.navigate(to: agent)
-                            } label: {
-                                HStack(spacing: 8) {
-                                    ProviderLogo(provider: agent.provider, size: 18)
-                                    VStack(alignment: .leading, spacing: 2) {
-                                        Text(agent.title)
-                                            .font(.system(size: 12, weight: .semibold))
-                                            .lineLimit(1)
-                                        if let dir = agent.directoryDisplay {
-                                            Text(dir)
-                                                .font(.system(size: 10))
-                                                .foregroundStyle(.secondary)
+                            HStack(spacing: 6) {
+                                Button {
+                                    ActiveAgentNavigator.navigate(to: agent)
+                                } label: {
+                                    HStack(spacing: 8) {
+                                        ProviderLogo(provider: agent.provider, size: 18)
+                                        VStack(alignment: .leading, spacing: 2) {
+                                            Text(agent.title)
+                                                .font(.system(size: 12, weight: .semibold))
                                                 .lineLimit(1)
-                                                .truncationMode(.middle)
+                                            if let dir = agent.directoryDisplay {
+                                                Text(dir)
+                                                    .font(.system(size: 10))
+                                                    .foregroundStyle(.secondary)
+                                                    .lineLimit(1)
+                                                    .truncationMode(.middle)
+                                            }
+                                            Text(agentDetail(agent))
+                                                .font(.system(size: 9))
+                                                .foregroundStyle(.tertiary)
+                                                .lineLimit(1)
                                         }
-                                        Text(agentDetail(agent))
-                                            .font(.system(size: 9))
-                                            .foregroundStyle(.tertiary)
-                                            .lineLimit(1)
+                                        Spacer()
+                                        Image(systemName: agent.hasTerminalTarget ? "arrow.up.forward.app" : "macwindow.on.rectangle")
+                                            .foregroundStyle(Color.blue)
                                     }
-                                    Spacer()
-                                    Image(systemName: agent.hasTerminalTarget ? "arrow.up.forward.app" : "macwindow.on.rectangle")
-                                        .foregroundStyle(Color.blue)
+                                    .padding(8)
+                                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                            .stroke(Color.primary.opacity(0.07), lineWidth: 1)
+                                    )
                                 }
-                                .padding(8)
-                                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                        .stroke(Color.primary.opacity(0.07), lineWidth: 1)
-                                )
+                                .buttonStyle(.plain)
+                                .help(agent.hasTerminalTarget ? "Go to this terminal session" : "Open the likely host app")
+
+                                Button {
+                                    pendingTermination = agent
+                                } label: {
+                                    Image(systemName: "xmark.circle")
+                                        .font(.system(size: 13))
+                                        .foregroundStyle(.red)
+                                        .frame(width: 22, height: 22)
+                                }
+                                .buttonStyle(.plain)
+                                .help("Quit this agent")
+                                .accessibilityLabel("Quit this agent")
+                                .pointerOnHover()
                             }
-                            .buttonStyle(.plain)
-                            .help(agent.hasTerminalTarget ? "Go to this terminal session" : "Open the likely host app")
                         }
                     }
                 }
@@ -70,10 +86,30 @@ struct ActiveAgentsPanel: View {
             }
         }
         .frame(maxHeight: accountListHeight())
+        .confirmationDialog(
+            "Quit \(pendingTermination?.title ?? "this agent")?",
+            isPresented: Binding(
+                get: { pendingTermination != nil },
+                set: { if !$0 { pendingTermination = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Quit", role: .destructive) {
+                if let agent = pendingTermination {
+                    store.terminateAgent(agent)
+                }
+                pendingTermination = nil
+            }
+            Button("Cancel", role: .cancel) {
+                pendingTermination = nil
+            }
+        } message: {
+            Text("Sends a terminate signal to PID \(pendingTermination?.processID ?? 0). Any unsaved progress in that session may be lost.")
+        }
     }
 
     private func agentDetail(_ agent: ActiveAgent) -> String {
         let host = agent.hostApp?.displayName ?? (agent.hasTerminalTarget ? "Terminal" : "Editor or background")
-        return "\(host) • Click to open"
+        return "\(host) • \(agent.memoryDisplay) • Click to open"
     }
 }


### PR DESCRIPTION
## Summary

- **Memory usage on active agent cards.** `ActiveAgentScanner` already shells out to `ps` for pid/ppid/tty/etime/command - added an `rss=` column so each card can show memory usage (the same RSS figure Activity Monitor's "Memory" column shows), no extra process spawns needed.
- **A quit button on each active agent card.** Sends `SIGTERM` (not `SIGKILL`, so the agent gets the same chance to exit cleanly that Ctrl-C in its own terminal would) after a confirmation dialog - killing someone's live coding session is a destructive action worth confirming first. The row drops immediately for a responsive feel, then a scan a second later reconciles with reality in case the signal didn't actually land (e.g. no permission).

## Test plan

- [x] `swift build` and `swift build -c release` both succeed
- [x] Verified the `ps -axo pid=,ppid=,tty=,etime=,rss=,command=` column order matches the updated parser directly against real `ps` output
- [ ] Visual check of the memory display and quit-confirmation flow in the running app - I can't screenshot this session (no screen-recording permission), so this needs an eyeball check