### PR TITLE
Add Pi usage tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Pi support using local JSONL session metadata for token and estimated-cost usage, active-agent detection with session titles, and automatic session-root discovery without authentication or Toki account configuration.
+
 ## 2.2.1 - 2026-07-16
 
 ### Added

--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,11 @@ let package = Package(
             resources: [
                 .process("Resources")
             ]
+        ),
+        .testTarget(
+            name: "TokiTests",
+            dependencies: ["Toki"],
+            resources: [.copy("Fixtures")]
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ## Why Toki
 
-Toki is built for people who jump between Claude Code, Codex, Copilot, Gemini, Grok, and OpenCode during the day and want a fast, local view of usage and active agents.
+Toki is built for people who jump between Claude Code, Codex, Copilot, Gemini, Grok, OpenCode, and Pi during the day and want a fast, local view of usage and active agents.
 
 It works especially well with [`claude-swap`](https://github.com/realiti4/claude-swap): Toki discovers the same Claude Code account registry, shows active and inactive accounts, and lets you switch accounts without reimplementing credential-management logic.
 
@@ -33,9 +33,9 @@ Toki stays local. Credentials are read from your Mac, your configured commands, 
 
 ## Features
 
-- Live quota, rate-limit, and spend tracking for Claude Code (multi-account via `claude-swap`, with discovery, one-click switching, and Keychain credential lookup), Codex, and OpenCode.
+- Live quota and rate-limit tracking for Claude Code (multi-account via `claude-swap`, with discovery, one-click switching, and Keychain credential lookup) and Codex, plus local token and spend tracking for OpenCode and Pi. Pi usage comes from local session history and shows tokens plus estimated costs.
 - One-click redemption of banked Codex rate-limit reset credits, gated to when the current window is mostly used.
-- Active-agent discovery across Codex, Claude Code, Copilot CLI, Gemini CLI, Grok CLI, OpenCode, and ChatGPT-hosted Codex, with best-effort navigation to the matching terminal tab or host app.
+- Active-agent discovery across Codex, Claude Code, Copilot CLI, Gemini CLI, Grok CLI, OpenCode, Pi, and ChatGPT-hosted Codex, with best-effort navigation to the matching terminal tab or host app.
 - AI-powered insight card with on-device Apple Intelligence summarization (macOS 26+), falling back to a deterministic recommendation with one-click smart switch. Custom instructions get their own Settings page and take priority over the default tone/format.
 - Native low-quota and session-warning notifications with cooldowns, DND mode, and local event/usage history.
 - Session mode for tracking quota burn during a focused coding run.
@@ -50,6 +50,7 @@ Toki stays local. Credentials are read from your Mac, your configured commands, 
 - Claude Code installed and authenticated.
 - `claude-swap` installed and configured for multi-account Claude workflows.
 - Codex installed and authenticated for Codex usage.
+- Pi installed with local session history when using Pi usage and active-agent tracking.
 - Copilot CLI, Gemini CLI, Grok CLI, or OpenCode installed when using active-agent discovery for those tools.
 
 macOS may ask for Keychain access the first time Toki reads Claude Code or `claude-swap` credentials.
@@ -95,7 +96,7 @@ The generated app bundle is written to `.build/Toki.app`.
 
 ## Configuration
 
-Toki connects providers automatically. Every time the popover opens, it scans for Claude Code (Keychain), Codex (`~/.codex/auth.json`), OpenCode (its local database), Grok CLI (`~/.grok/auth.json`), and Gemini CLI (`~/.gemini/oauth_creds.json`), and immediately writes the right entry to `~/.toki/config.json` for anything newly signed in - no Connect button, no JSON to hand-write. This isn't just a first-run thing: starting with just Claude Code and signing into Codex (or anything else) later picks it up the next time you open the menu, with no config editing needed.
+Toki connects providers automatically. Every time the popover opens, it scans for Claude Code (Keychain), Codex (`~/.codex/auth.json`), OpenCode (its local database), Pi (local JSONL session history), Grok CLI (`~/.grok/auth.json`), and Gemini CLI (`~/.gemini/oauth_creds.json`). Config-backed providers are immediately written to `~/.toki/config.json`; local-only OpenCode and Pi accounts are detected fresh without adding config. There is no Connect button or JSON to hand-write. This isn't just a first-run thing: starting with just Claude Code and signing into Codex, or creating Pi session history, picks it up the next time you open the menu.
 
 Whenever `~/.toki/config.json` is missing, or exists but has no accounts yet, Toki's popover shows a **Connect an account** screen instead of an empty list while it scans. If nothing is detected yet, sign in to Claude Code or Codex and reopen the menu.
 
@@ -164,9 +165,9 @@ The overview shows a single AIInsightCard replacing the three separate stat bloc
 
 The settings panel controls native notifications, DND mode, low-quota threshold, session warning threshold, notification cooldown, history retention, and the menu bar display mode. DND mode suppresses macOS notification delivery but still records events so you can audit what would have fired.
 
-The Agents tab inspects the local process table without persisting command lines, prompts, workspace names, or session titles. Each agent shows its conversation title when available, otherwise the project folder name relative to your home directory (`~/Code/project`). When an agent has a terminal TTY, clicking it selects the matching tab in iTerm2 or Terminal. For other hosts (iTerm, VS Code, Cursor, ChatGPT), Toki activates the resolved host app via its bundle ID.
+The Agents tab inspects the local process table without persisting command lines, prompts, workspace names, or session titles. Each agent shows its conversation title when available (including Pi's local session title), otherwise the project folder name relative to your home directory (`~/Code/project`). When an agent has a terminal TTY, clicking it selects the matching tab in iTerm2 or Terminal. For other hosts (iTerm, VS Code, Cursor, ChatGPT), Toki activates the resolved host app via its bundle ID.
 
-OpenCode usage is automatically detected from its local SQLite database and surfaced as an account. Copilot, Gemini, and Grok are agent-detection-only: Toki detects running processes locally (and, for Gemini/Grok, whether they're signed in) and shows an active-session count on their card, but does not invent quotas - none of GitHub, Google, or xAI expose a usage/quota API for these that Toki could read from.
+OpenCode usage is automatically detected from its local SQLite database and surfaced as an account. Pi is similarly auto-detected from local session history and remains one aggregated harness card even when its sessions use different underlying model providers. Copilot, Gemini, and Grok are agent-detection-only: Toki detects running processes locally (and, for Gemini/Grok, whether they're signed in) and shows an active-session count on their card, but does not invent quotas - none of GitHub, Google, or xAI expose a usage/quota API for these that Toki could read from.
 
 ### Updates and Diagnostics
 
@@ -235,6 +236,18 @@ Codex usage is separate from OpenAI organization API usage.
 
 When OpenAI has a banked rate-limit reset credit for the account, the expanded Codex card shows a **Reset now** button (with the count when more than one is banked). It stays disabled until the current window is at least 80% used, so a reset isn't spent while there's still plenty of quota left - redeeming one resets the rate-limit window immediately via the Codex app-server.
 
+## Pi Usage
+
+Pi needs no Toki account configuration. Toki reads only local Pi JSONL session metadata needed for usage and active-agent display: assistant token counts, Pi's estimated costs, session working directories, timestamps, and session titles. It does not access Pi authentication data or decode or retain prompt/message content. Usage from all underlying providers is combined into one Pi harness card.
+
+Toki discovers the session root in this order:
+
+1. `PI_CODING_AGENT_SESSION_DIR`.
+2. `sessionDir` in the global `~/.pi/agent/settings.json` (or the corresponding settings file under `PI_CODING_AGENT_DIR`).
+3. `${PI_CODING_AGENT_DIR}/sessions` (normally `~/.pi/agent/sessions`).
+
+Override paths must be absolute, exactly `~`, or begin with `~/`. Relative paths in `PI_CODING_AGENT_SESSION_DIR`, `PI_CODING_AGENT_DIR`, or the global `settings.json` cannot be auto-resolved. Project-local `.pi/settings.json` `sessionDir` values are not globally discoverable, nor are per-invocation `--session-dir` values, so sessions stored only through either mechanism are not tracked.
+
 ## Development
 
 Common commands:
@@ -269,6 +282,7 @@ Toki keeps backwards-compatible config fallbacks for the old TokenBar name, but 
 - `No credentials found`: confirm Claude Code and `claude-swap` are authenticated and that Keychain access was allowed.
 - `Claude Code usage unavailable`: Anthropic did not return usage data for that account. Try refreshing later or check the account in Claude Code.
 - `Codex usage unavailable`: confirm `codex login` has created `~/.codex/auth.json`, then refresh Toki.
+- Pi does not appear: confirm its session directory contains JSONL history and that any global environment/settings override is absolute, exactly `~`, or begins with `~/`. Per-invocation `--session-dir` sessions are not auto-discovered.
 - Switch fails: run `claude-swap --switch-to <slot>` in Terminal to inspect the underlying error.
 - Notifications do not appear: open the Events tab to check whether DND or cooldowns suppressed delivery, then confirm macOS notification permission for Toki.
 

--- a/Sources/Toki/API/PiUsageClient.swift
+++ b/Sources/Toki/API/PiUsageClient.swift
@@ -1,0 +1,371 @@
+import Foundation
+
+// Pi is BYO-provider and records token/cost metadata in local JSONL session files.
+// These narrow Decodable types intentionally omit message content, tool payloads, and
+// every other field Toki has no reason to retain.
+struct PiUsageClient {
+    struct Totals: Equatable {
+        var todayInput = 0.0
+        var todayOutput = 0.0
+        var todayCacheRead = 0.0
+        var todayCacheWrite = 0.0
+        var todayCost = 0.0
+        var allTimeCost = 0.0
+        var sessionCount = 0
+    }
+
+    struct SessionMetadata: Equatable {
+        let path: String
+        let title: String?
+        let modified: Date?
+    }
+
+    private struct Entry: Decodable {
+        let type: String
+        let id: String?
+        let timestamp: Timestamp?
+        let cwd: String?
+        let name: String?
+        let message: Message?
+    }
+
+    private struct Message: Decodable {
+        let role: String
+        let provider: String?
+        let api: String?
+        let model: String?
+        let timestamp: Double?
+        let usage: Usage?
+    }
+
+    private struct Usage: Decodable {
+        let input: Double?
+        let output: Double?
+        let cacheRead: Double?
+        let cacheWrite: Double?
+        let totalTokens: Double?
+        let cost: Cost?
+    }
+
+    private struct Cost: Decodable { let total: Double? }
+    private struct Settings: Decodable { let sessionDir: String? }
+
+    private enum Timestamp: Decodable {
+        case milliseconds(Double)
+        case iso8601(String)
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if let number = try? container.decode(Double.self) { self = .milliseconds(number) }
+            else { self = .iso8601(try container.decode(String.self)) }
+        }
+
+        var key: String {
+            switch self {
+            case .milliseconds(let value): return canonical(value)
+            case .iso8601(let value): return value
+            }
+        }
+    }
+
+    private struct IndexedFile {
+        let path: String
+        let modified: Date?
+    }
+
+    private final class SessionIndexCache: @unchecked Sendable {
+        struct Value {
+            var generation: UInt64
+            var builtAt: Date
+            var newestByCWD: [String: IndexedFile]
+            var metadataByCWD: [String: SessionMetadata]
+        }
+
+        let lock = NSLock()
+        var byRoot: [String: Value] = [:]
+        var nextGeneration: UInt64 = 0
+    }
+
+    private static let indexCache = SessionIndexCache()
+    private static let indexLifetime: TimeInterval = 5
+    private static let maximumRecordBytes = 1024 * 1024
+
+    let account: AccountConfig
+
+    func snapshot() async throws -> AccountSnapshot {
+        let totals = try Self.aggregate()
+        return AccountSnapshot(
+            id: account.id,
+            name: account.name,
+            provider: .pi,
+            primary: totals.todayCost > 0 ? "\(formatUSD(totals.todayCost)) today" : "No usage today",
+            subtitle: "Pi - local usage (estimated)",
+            remainingRatio: nil,
+            metrics: [
+                MetricLine(label: "Today", value: "\(formatCompact(totals.todayInput)) in / \(formatCompact(totals.todayOutput)) out"),
+                MetricLine(label: "Cache", value: "\(formatCompact(totals.todayCacheRead)) read / \(formatCompact(totals.todayCacheWrite)) write"),
+                MetricLine(label: "Estimated total", value: formatUSD(totals.allTimeCost)),
+                MetricLine(label: "Sessions", value: "\(totals.sessionCount)")
+            ],
+            isError: false
+        )
+    }
+
+    static let autoDetectedID = "pi-auto"
+
+    static func autoDetectedAccount(environment: [String: String] = ProcessInfo.processInfo.environment,
+                                    home: String = FileManager.default.homeDirectoryForCurrentUser.path) -> AccountConfig? {
+        guard let root = try? sessionRoot(environment: environment, home: home),
+              let files = try? sessionFiles(root: root),
+              files.contains(where: { (try? sessionHeader(path: $0)) != nil }) else { return nil }
+        return AccountConfig(id: autoDetectedID, name: "Pi", provider: .pi)
+    }
+
+    static func aggregate(root: String? = nil,
+                          environment: [String: String] = ProcessInfo.processInfo.environment,
+                          home: String = FileManager.default.homeDirectoryForCurrentUser.path,
+                          now: Date = Date(),
+                          calendar: Calendar = .current) throws -> Totals {
+        let resolvedRoot = try root ?? sessionRoot(environment: environment, home: home)
+        guard FileManager.default.fileExists(atPath: resolvedRoot) else {
+            throw LocalizedErrorMessage("Pi session history not found")
+        }
+
+        let candidates = try sessionFiles(root: resolvedRoot)
+        var totals = Totals()
+        var seen: Set<String> = []
+        let startOfDay = calendar.startOfDay(for: now)
+        guard let nextDay = calendar.date(byAdding: .day, value: 1, to: startOfDay) else { return totals }
+
+        for path in candidates {
+            guard try sessionHeader(path: path) != nil else { continue }
+            totals.sessionCount += 1
+            try forEachEntry(path: path) { entry in
+                guard entry.type == "message", let message = entry.message,
+                      message.role == "assistant", let usage = message.usage else { return true }
+
+                let input = number(usage.input)
+                let output = number(usage.output)
+                let cacheRead = number(usage.cacheRead)
+                let cacheWrite = number(usage.cacheWrite)
+                let totalTokens = number(usage.totalTokens)
+                let cost = number(usage.cost?.total)
+                let messageTimestamp = positiveNumber(message.timestamp)
+                let date = messageTimestamp.map { Date(timeIntervalSince1970: $0 / 1000) }
+                    ?? date(from: entry.timestamp)
+                let key = [
+                    entry.id ?? "", entry.timestamp?.key ?? "", messageTimestamp.map(canonical) ?? "",
+                    message.provider ?? "", message.api ?? "", message.model ?? "",
+                    canonical(input), canonical(output), canonical(cacheRead), canonical(cacheWrite),
+                    canonical(totalTokens), canonical(cost)
+                ].joined(separator: "\u{1f}")
+                guard seen.insert(key).inserted else { return true }
+
+                totals.allTimeCost += cost
+                if let date, date >= startOfDay, date < nextDay {
+                    totals.todayInput += input
+                    totals.todayOutput += output
+                    totals.todayCacheRead += cacheRead
+                    totals.todayCacheWrite += cacheWrite
+                    totals.todayCost += cost
+                }
+                return true
+            }
+        }
+        return totals
+    }
+
+    static func sessionRoot(environment: [String: String] = ProcessInfo.processInfo.environment,
+                            home: String = FileManager.default.homeDirectoryForCurrentUser.path) throws -> String {
+        if let override = environment["PI_CODING_AGENT_SESSION_DIR"].flatMap(nonEmpty) {
+            return try absolutePath(override, home: home)
+        }
+        let rawAgentDir = environment["PI_CODING_AGENT_DIR"].flatMap(nonEmpty) ?? "~/.pi/agent"
+        let agentDir = try absolutePath(rawAgentDir, home: home)
+        let settingsPath = (agentDir as NSString).appendingPathComponent("settings.json")
+        if let data = try? Data(contentsOf: URL(fileURLWithPath: settingsPath)),
+           let configured = (try? JSONDecoder().decode(Settings.self, from: data).sessionDir).flatMap(nonEmpty) {
+            return try absolutePath(configured, home: home)
+        }
+        return (agentDir as NSString).appendingPathComponent("sessions")
+    }
+
+    static func latestSession(cwd: String?,
+                              root: String? = nil,
+                              environment: [String: String] = ProcessInfo.processInfo.environment,
+                              home: String = FileManager.default.homeDirectoryForCurrentUser.path,
+                              now: Date = Date()) -> SessionMetadata? {
+        guard let cwd, let resolvedRoot = root ?? (try? sessionRoot(environment: environment, home: home)) else { return nil }
+        if let cached = cachedMetadata(root: resolvedRoot, cwd: cwd, now: now) { return cached }
+        guard let index = sessionIndex(root: resolvedRoot, now: now), let file = index[cwd] else { return nil }
+
+        var latestName: String?
+        var sawSessionInfo = false
+        try? forEachEntry(path: file.path) { entry in
+            if entry.type == "session_info" {
+                sawSessionInfo = true
+                latestName = entry.name?.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            return true
+        }
+        let title = sawSessionInfo && !(latestName?.isEmpty ?? true) ? latestName : nil
+        let metadata = SessionMetadata(path: file.path, title: title, modified: file.modified)
+        storeMetadata(metadata, root: resolvedRoot, cwd: cwd)
+        return metadata
+    }
+
+    private static func cachedMetadata(root: String, cwd: String, now: Date) -> SessionMetadata? {
+        indexCache.lock.lock()
+        defer { indexCache.lock.unlock() }
+        guard let value = indexCache.byRoot[root],
+              case let age = now.timeIntervalSince(value.builtAt), age >= 0, age < indexLifetime else { return nil }
+        return value.metadataByCWD[cwd]
+    }
+
+    private static func sessionIndex(root: String, now: Date) -> [String: IndexedFile]? {
+        indexCache.lock.lock()
+        if let value = indexCache.byRoot[root],
+           case let age = now.timeIntervalSince(value.builtAt), age >= 0, age < indexLifetime {
+            indexCache.lock.unlock()
+            return value.newestByCWD
+        }
+        indexCache.nextGeneration &+= 1
+        let generation = indexCache.nextGeneration
+        indexCache.lock.unlock()
+
+        let rebuildStartedAt = ProcessInfo.processInfo.systemUptime
+        guard let files = try? sessionFiles(root: root) else { return nil }
+        var newestByCWD: [String: IndexedFile] = [:]
+        for path in files {
+            guard let header = try? sessionHeader(path: path) else { continue }
+            let modified = (try? FileManager.default.attributesOfItem(atPath: path)[.modificationDate]) as? Date
+            let candidate = IndexedFile(path: path, modified: modified)
+            if let current = newestByCWD[header.cwd],
+               (current.modified ?? .distantPast) >= (candidate.modified ?? .distantPast) { continue }
+            newestByCWD[header.cwd] = candidate
+        }
+        let completedAt = now.addingTimeInterval(max(ProcessInfo.processInfo.systemUptime - rebuildStartedAt, 0))
+
+        indexCache.lock.lock()
+        if let published = indexCache.byRoot[root], published.generation > generation {
+            indexCache.lock.unlock()
+            return published.newestByCWD
+        }
+        indexCache.byRoot[root] = .init(
+            generation: generation,
+            builtAt: completedAt,
+            newestByCWD: newestByCWD,
+            metadataByCWD: [:]
+        )
+        indexCache.lock.unlock()
+        return newestByCWD
+    }
+
+    private static func storeMetadata(_ metadata: SessionMetadata, root: String, cwd: String) {
+        indexCache.lock.lock()
+        defer { indexCache.lock.unlock() }
+        guard indexCache.byRoot[root]?.newestByCWD[cwd]?.path == metadata.path else { return }
+        indexCache.byRoot[root]?.metadataByCWD[cwd] = metadata
+    }
+
+    private static func sessionHeader(path: String) throws -> (id: String, cwd: String)? {
+        var header: (id: String, cwd: String)?
+        try forEachEntry(path: path) { entry in
+            guard entry.type == "session", let id = entry.id.flatMap(nonEmpty), let cwd = entry.cwd.flatMap(nonEmpty) else {
+                return false
+            }
+            header = (id, cwd)
+            return false
+        }
+        return header
+    }
+
+    private static func sessionFiles(root: String) throws -> [String] {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: root, isDirectory: &isDirectory), isDirectory.boolValue else {
+            throw LocalizedErrorMessage("Unable to read Pi session history")
+        }
+        var enumerationFailed = false
+        guard let enumerator = FileManager.default.enumerator(
+            at: URL(fileURLWithPath: root), includingPropertiesForKeys: [.isRegularFileKey],
+            errorHandler: { _, _ in enumerationFailed = true; return false }
+        ) else { throw LocalizedErrorMessage("Unable to read Pi session history") }
+        let files: [String]
+        do {
+            files = try enumerator.compactMap { item -> String? in
+                guard let url = item as? URL, url.pathExtension.lowercased() == "jsonl",
+                      try url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile == true else { return nil }
+                return url.path
+            }.sorted()
+        } catch { throw LocalizedErrorMessage("Unable to read Pi session history") }
+        guard !enumerationFailed else { throw LocalizedErrorMessage("Unable to read Pi session history") }
+        return files
+    }
+
+    // Reads bounded records without repeatedly removing prefixes from a growing buffer.
+    // Oversized records are discarded through their newline and never decoded or logged.
+    private static func forEachEntry(path: String, _ body: (Entry) -> Bool) throws {
+        do {
+            let handle = try FileHandle(forReadingFrom: URL(fileURLWithPath: path))
+            defer { try? handle.close() }
+            let decoder = JSONDecoder()
+            var record = Data()
+            var discarding = false
+            var shouldContinue = true
+            while shouldContinue, let chunk = try handle.read(upToCount: 64 * 1024), !chunk.isEmpty {
+                for byte in chunk {
+                    if byte == 0x0A {
+                        if !discarding, let entry = try? decoder.decode(Entry.self, from: record) {
+                            shouldContinue = body(entry)
+                        }
+                        record.removeAll(keepingCapacity: true)
+                        discarding = false
+                        if !shouldContinue { break }
+                    } else if !discarding {
+                        if record.count < maximumRecordBytes { record.append(byte) }
+                        else { record.removeAll(keepingCapacity: true); discarding = true }
+                    }
+                }
+            }
+            if shouldContinue, !discarding, !record.isEmpty,
+               let entry = try? decoder.decode(Entry.self, from: record) { _ = body(entry) }
+        } catch { throw LocalizedErrorMessage("Unable to read a Pi session file") }
+    }
+
+    private static func number(_ value: Double?) -> Double {
+        guard let value, value.isFinite, value >= 0 else { return 0 }
+        return value
+    }
+
+    private static func positiveNumber(_ value: Double?) -> Double? {
+        guard let value, value.isFinite, value > 0 else { return nil }
+        return value
+    }
+
+    private static func date(from timestamp: Timestamp?) -> Date? {
+        guard let timestamp else { return nil }
+        switch timestamp {
+        case .milliseconds(let value):
+            guard value.isFinite, value > 0 else { return nil }
+            return Date(timeIntervalSince1970: value / 1000)
+        case .iso8601(let raw):
+            let fractional = ISO8601DateFormatter()
+            fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            return fractional.date(from: raw) ?? ISO8601DateFormatter().date(from: raw)
+        }
+    }
+
+    private static func canonical(_ value: Double) -> String { String(format: "%.17g", value) }
+    private static func nonEmpty(_ value: String) -> String? { value.isEmpty ? nil : value }
+
+    private static func absolutePath(_ raw: String, home: String) throws -> String {
+        let expanded: String
+        if raw == "~" { expanded = home }
+        else if raw.hasPrefix("~/") { expanded = home + raw.dropFirst() }
+        else { expanded = raw }
+        guard expanded.hasPrefix("/") else {
+            throw LocalizedErrorMessage("Pi session directory must be absolute, exactly ~, or begin with ~/")
+        }
+        return (expanded as NSString).standardizingPath
+    }
+}

--- a/Sources/Toki/API/UsageFetcher.swift
+++ b/Sources/Toki/API/UsageFetcher.swift
@@ -56,14 +56,19 @@ enum UsageFetcher {
         }
     }
 
-    // Appends a synthetic OpenCode account when its local database exists and the user
-    // hasn't configured one explicitly. Never persisted - detected fresh each fetch.
+    // Appends synthetic local-only accounts when readable history exists. These are never
+    // persisted and are suppressed by an explicitly configured account of the same type.
     private static func accountsIncludingAutoDetected(_ configured: [AccountConfig]) -> [AccountConfig] {
-        guard !configured.contains(where: { $0.provider == .openCode }),
-              let detected = OpenCodeUsageClient.autoDetectedAccount() else {
-            return configured
+        var accounts = configured
+        if !configured.contains(where: { $0.provider == .openCode }),
+           let detected = OpenCodeUsageClient.autoDetectedAccount() {
+            accounts.append(detected)
         }
-        return configured + [detected]
+        if !configured.contains(where: { $0.provider == .pi }),
+           let detected = PiUsageClient.autoDetectedAccount() {
+            accounts.append(detected)
+        }
+        return accounts
     }
 
     private static func snapshots(
@@ -100,6 +105,8 @@ enum UsageFetcher {
                 snapshots = [agentOnlySnapshot(for: account)]
             case .openCode:
                 snapshots = [try await OpenCodeUsageClient(account: account).snapshot()]
+            case .pi:
+                snapshots = [try await PiUsageClient(account: account).snapshot()]
             case .openai:
                 snapshots = [try await OpenAIUsageClient(account: account).snapshot()]
             case .codex:
@@ -135,7 +142,7 @@ enum UsageFetcher {
 
     private static func apiCacheKey(for account: AccountConfig) -> String? {
         switch account.provider {
-        case .chatgpt, .claude, .copilot, .openCode, .grok, .gemini, .manual:
+        case .chatgpt, .claude, .copilot, .openCode, .grok, .gemini, .pi, .manual:
             return nil
         case .claudeCode, .codex, .openai, .anthropic:
             return "\(account.provider.rawValue):\(account.id)"
@@ -159,7 +166,7 @@ enum UsageFetcher {
             return claudeRefreshInterval
         case .codex, .openai, .anthropic:
             return defaultAPIRefreshInterval
-        case .chatgpt, .claude, .copilot, .openCode, .grok, .gemini, .manual:
+        case .chatgpt, .claude, .copilot, .openCode, .grok, .gemini, .pi, .manual:
             return 0
         }
     }

--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -117,24 +117,7 @@ enum ActiveAgentScanner {
         // Classify by executable first. A recognized agent binary is a real agent no matter
         // where it lives (e.g. Codex inside ChatGPT.app); the bundle-helper noise filter
         // only decides whether an UNRECOGNIZED process is worth ignoring.
-        let provider: Provider
-        if executable == "opencode" {
-            provider = .openCode
-        } else if executable == "copilot"
-                    || (executable == "node" && entrypoint?.contains("/@github/copilot/") == true) {
-            provider = .copilot
-        } else if executable == "codex"
-                    || executable.hasPrefix("codex-")
-                    || (executable == "node" && entrypoint?.contains("/@openai/codex/") == true) {
-            provider = .codex
-        } else if executable == "claude" {
-            provider = .claudeCode
-        } else if executable == "grok" {
-            provider = .grok
-        } else if executable == "gemini"
-                    || (executable == "node" && entrypoint.map { URL(fileURLWithPath: $0).lastPathComponent } == "gemini") {
-            provider = .gemini
-        } else {
+        guard let provider = providerForProcess(executable: executable, entrypoint: entrypoint) else {
             return nil
         }
 
@@ -149,6 +132,29 @@ enum ActiveAgentScanner {
         let ttyValue = String(parts[2])
         let tty = ttyValue == "??" || ttyValue == "-" ? nil : ttyValue
         return Candidate(pid: pid, parentPID: parentPID, provider: provider, command: command, runtime: String(parts[3]), tty: tty, memoryKB: memoryKB)
+    }
+
+    static func providerForCommand(_ command: String) -> Provider? {
+        let parts = command.split(whereSeparator: { $0.isWhitespace })
+        guard let first = parts.first else { return nil }
+        let executable = URL(fileURLWithPath: String(first)).lastPathComponent.lowercased()
+        return providerForProcess(executable: executable, entrypoint: parts.dropFirst().first.map { String($0).lowercased() })
+    }
+
+    private static func providerForProcess(executable: String, entrypoint: String?) -> Provider? {
+        if executable == "pi" { return .pi }
+        if (executable == "node" || executable == "bun"), let entrypoint,
+           entrypoint.contains("/@earendil-works/pi-coding-agent/")
+            || entrypoint.contains("/@mariozechner/pi-coding-agent/") {
+            return .pi
+        }
+        if executable == "opencode" { return .openCode }
+        if executable == "copilot" || (executable == "node" && entrypoint?.contains("/@github/copilot/") == true) { return .copilot }
+        if executable == "codex" || executable.hasPrefix("codex-") || (executable == "node" && entrypoint?.contains("/@openai/codex/") == true) { return .codex }
+        if executable == "claude" { return .claudeCode }
+        if executable == "grok" { return .grok }
+        if executable == "gemini" || (executable == "node" && entrypoint.map { URL(fileURLWithPath: $0).lastPathComponent } == "gemini") { return .gemini }
+        return nil
     }
 
     // Resolves the expensive fields. cwd and host app are truly immutable for a live

--- a/Sources/Toki/Agents/AgentSessionResolver.swift
+++ b/Sources/Toki/Agents/AgentSessionResolver.swift
@@ -14,6 +14,8 @@ enum AgentSessionResolver {
             return openCodeChatTitle(cwd: cwd)
         case .grok:
             return newestGrokSession(cwd: cwd)?.title
+        case .pi:
+            return PiUsageClient.latestSession(cwd: cwd)?.title
         default:
             return nil
         }
@@ -28,6 +30,8 @@ enum AgentSessionResolver {
             return openCodeLastActivity(cwd: cwd)
         case .grok:
             return newestGrokSession(cwd: cwd)?.lastActiveAt
+        case .pi:
+            return PiUsageClient.latestSession(cwd: cwd)?.modified
         default:
             return nil
         }

--- a/Sources/Toki/Discovery/ProviderDetection.swift
+++ b/Sources/Toki/Discovery/ProviderDetection.swift
@@ -26,6 +26,7 @@ enum ProviderDetection {
             if let claude = detectClaudeCode() { detected.append(claude) }
             if let codex = detectCodex() { detected.append(codex) }
             if let openCode = detectOpenCode() { detected.append(openCode) }
+            if let pi = detectPi() { detected.append(pi) }
             if let grok = detectGrok() { detected.append(grok) }
             if let gemini = detectGemini() { detected.append(gemini) }
             return detected
@@ -71,6 +72,16 @@ enum ProviderDetection {
             provider: .openCode,
             title: "OpenCode",
             detail: "Auto-detected from its local database - no setup needed",
+            makeAccount: nil
+        )
+    }
+
+    private static func detectPi() -> DetectedProvider? {
+        guard PiUsageClient.autoDetectedAccount() != nil else { return nil }
+        return DetectedProvider(
+            provider: .pi,
+            title: "Pi",
+            detail: "Auto-detected from local session history - no setup needed",
             makeAccount: nil
         )
     }

--- a/Sources/Toki/Models/Provider.swift
+++ b/Sources/Toki/Models/Provider.swift
@@ -11,6 +11,7 @@ enum Provider: String, Codable, Sendable {
     case openCode
     case grok
     case gemini
+    case pi
     case manual
 
     var displayName: String {
@@ -25,6 +26,7 @@ enum Provider: String, Codable, Sendable {
         case .openCode: return "OpenCode"
         case .grok: return "Grok"
         case .gemini: return "Gemini"
+        case .pi: return "Pi"
         case .manual: return "Manual"
         }
     }
@@ -32,7 +34,7 @@ enum Provider: String, Codable, Sendable {
     var isConsumerTracked: Bool {
         switch self {
         case .chatgpt, .claude, .manual: return true
-        case .openai, .codex, .anthropic, .claudeCode, .copilot, .openCode, .grok, .gemini: return false
+        case .openai, .codex, .anthropic, .claudeCode, .copilot, .openCode, .grok, .gemini, .pi: return false
         }
     }
 

--- a/Sources/Toki/Resources/pi-logo.svg
+++ b/Sources/Toki/Resources/pi-logo.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800">
+  <rect width="800" height="800" rx="120" fill="#09090b"/>
+  <path fill="#fff" fill-rule="evenodd" d="
+    M165.29 165.29
+    H517.36
+    V400
+    H400
+    V517.36
+    H282.65
+    V634.72
+    H165.29
+    Z
+    M282.65 282.65
+    V400
+    H400
+    V282.65
+    Z
+  "/>
+  <path fill="#fff" d="M517.36 400 H634.72 V634.72 H517.36 Z"/>
+</svg>

--- a/Sources/Toki/Store/UsageStore+Onboarding.swift
+++ b/Sources/Toki/Store/UsageStore+Onboarding.swift
@@ -1,9 +1,29 @@
 import Foundation
 
+enum ProviderScanDisposition: Equatable {
+    case persistConnectable
+    case activateLocalUsage
+    case noAction
+}
+
+func providerScanDisposition(
+    detected: [DetectedProvider],
+    snapshotProviders: Set<Provider>,
+    configIsNil: Bool,
+    needsOnboarding: Bool
+) -> ProviderScanDisposition {
+    let newProviders = detected.filter { !snapshotProviders.contains($0.provider) }
+    if newProviders.contains(where: \.isConnectable) { return .persistConnectable }
+    if configIsNil, needsOnboarding, newProviders.contains(where: { !$0.isConnectable }) {
+        return .activateLocalUsage
+    }
+    return .noAction
+}
+
 extension UsageStore {
     // True when there's nothing to lose by showing the connect wizard: no config.json yet,
     // or one that decodes fine but simply has no accounts. A config.json that exists and
-    // decodes but is invalid for any other reason (e.g. a copilot entry) - or doesn't decode
+    // decodes but is invalid for any other reason (e.g. duplicate account ids) - or doesn't decode
     // at all - is a real error; connect() would still fail its own validate() call there, so
     // showing Connect buttons would be a dead end. Those cases fall through to the normal
     // error banner instead (config stays nil, needsOnboarding is false).
@@ -66,23 +86,43 @@ extension UsageStore {
     // detectedProviders minus anything already present in snapshots (whether connected
     // through config.json or auto-detected like OpenCode) - only ever non-empty for a
     // moment between a scan finding something and connectDetected writing it, or for
-    // providers with no makeAccount (OpenCode) that never get written at all.
+    // local-only providers with no makeAccount that never get written at all.
     var addableProviders: [DetectedProvider] {
         detectedProviders.filter { detected in !snapshots.contains(where: { $0.provider == detected.provider }) }
     }
 
-    // Auto-adds every newly detected, connectable provider - no manual "Connect" click
-    // needed. Providers with no makeAccount (OpenCode) are untouched; they're already
-    // auto-tracked without a config entry.
+    // Auto-adds newly detected connectable providers. On a fresh install with only
+    // local-history providers, installs an empty config in memory so UsageFetcher can
+    // surface its synthetic accounts without creating config.json on disk.
     private func connectDetected(_ detected: [DetectedProvider]) {
-        let newAccounts = detected.compactMap { candidate -> AccountConfig? in
-            guard candidate.isConnectable, !snapshots.contains(where: { $0.provider == candidate.provider }) else {
-                return nil
+        let snapshotProviders = Set(snapshots.map(\.provider))
+        switch providerScanDisposition(
+            detected: detected,
+            snapshotProviders: snapshotProviders,
+            configIsNil: config == nil,
+            needsOnboarding: needsOnboarding
+        ) {
+        case .persistConnectable:
+            let newAccounts = detected.compactMap { candidate -> AccountConfig? in
+                guard candidate.isConnectable, !snapshotProviders.contains(candidate.provider) else { return nil }
+                return candidate.makeAccount?()
             }
-            return candidate.makeAccount?()
+            guard !newAccounts.isEmpty else { return }
+            connect(newAccounts)
+        case .activateLocalUsage:
+            config = AppConfig(refreshMinutes: nil, accountLabels: nil, accounts: [], aiInstructions: nil)
+            setNeedsOnboarding(false)
+            configError = nil
+            // Match the successful config-load path before refresh can persist state;
+            // otherwise a configless local-only launch would overwrite saved user state
+            // with the UsageStore initializer's defaults.
+            usageState = StateLoader.load()
+            syncPublishedState()
+            scheduleRefresh()
+            refresh(keepsExistingSnapshots: true, minimumRefreshInterval: 60)
+        case .noAction:
+            return
         }
-        guard !newAccounts.isEmpty else { return }
-        connect(newAccounts)
     }
 
     // Appends detected accounts to config.json (creating it if this is a fresh install)

--- a/Sources/Toki/Views/ActiveAgentsPanel.swift
+++ b/Sources/Toki/Views/ActiveAgentsPanel.swift
@@ -26,7 +26,7 @@ struct ActiveAgentsPanel: View {
                         EmptyPanel(
                             systemImage: "terminal",
                             title: "No active agents",
-                            detail: "Codex (terminal or inside ChatGPT), Claude Code, Copilot CLI, OpenCode, Grok, and Gemini sessions appear here."
+                            detail: "Supported coding-agent sessions appear here while they are running."
                         )
                     } else {
                         ForEach(store.activeAgents) { agent in

--- a/Sources/Toki/Views/OnboardingView.swift
+++ b/Sources/Toki/Views/OnboardingView.swift
@@ -86,7 +86,7 @@ struct OnboardingView: View {
         HStack(spacing: 6) {
             ProgressView()
                 .controlSize(.small)
-            Text("Looking for Claude Code, Codex, OpenCode…")
+            Text("Looking for supported coding agents and local usage…")
                 .font(.system(size: 10))
                 .foregroundStyle(.secondary)
         }
@@ -96,7 +96,7 @@ struct OnboardingView: View {
         VStack(alignment: .leading, spacing: 4) {
             Text("Nothing detected yet")
                 .font(.system(size: 11, weight: .medium))
-            Text("Sign in to Claude Code or Codex, then reopen this menu - Toki will pick them up automatically.")
+            Text("Sign in to or use a supported coding agent, then reopen this menu - Toki will pick it up automatically.")
                 .font(.system(size: 10))
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/Sources/Toki/Views/ProviderLogo.swift
+++ b/Sources/Toki/Views/ProviderLogo.swift
@@ -53,6 +53,13 @@ struct ProviderLogo: View {
                             )
                         )
                 }
+            case .pi:
+                // Official Pi press-kit badge: https://pi.dev/press-kit
+                SVGLogoMark(asset: "pi-logo", size: size) {
+                    Image(systemName: "terminal.fill")
+                        .font(.system(size: size * 0.72, weight: .semibold))
+                        .foregroundStyle(Color.primary)
+                }
             case .manual:
                 Circle()
                     .foregroundStyle(Color.secondary)

--- a/Tests/TokiTests/Fixtures/pi/project/session-a.jsonl
+++ b/Tests/TokiTests/Fixtures/pi/project/session-a.jsonl
@@ -1,0 +1,7 @@
+{"type":"session","id":"session-a","timestamp":"2026-07-18T10:00:00Z","cwd":"/tmp/pi-project"}
+{"type":"session_info","id":"info-a","timestamp":"2026-07-18T10:01:00Z","name":"Older title"}
+{"type":"message","id":"assistant-1","timestamp":"2026-07-18T12:00:01Z","message":{"role":"assistant","provider":"openai","api":"responses","model":"gpt-test","timestamp":1784376000000,"usage":{"input":100,"output":20,"cacheRead":5,"cacheWrite":2,"totalTokens":127,"cost":{"total":0.12}},"stopReason":"stop"}}
+{"type":"message","id":"assistant-old","timestamp":"2026-07-17T12:00:00Z","message":{"role":"assistant","provider":"openai","api":"responses","model":"gpt-test","timestamp":1784289600000,"usage":{"input":10,"output":4,"cacheRead":1,"cacheWrite":0,"totalTokens":15,"cost":{"total":0.01}},"stopReason":"error"}}
+{"type":"message","id":"assistant-outer","timestamp":"2026-07-18T13:00:00Z","message":{"role":"assistant","provider":"anthropic","api":"messages","model":"claude-test","usage":{"input":7,"output":3,"cacheRead":0,"cacheWrite":0,"totalTokens":10,"cost":{"total":0.07}},"stopReason":"aborted"}}
+{"type":"message","id":"ignored-user","message":{"role":"user","usage":{"input":999,"output":999,"cost":{"total":99}}}}
+{"type":"message","id":"truncated"

--- a/Tests/TokiTests/Fixtures/pi/project/session-b.jsonl
+++ b/Tests/TokiTests/Fixtures/pi/project/session-b.jsonl
@@ -1,0 +1,4 @@
+{"type":"session","id":"session-b","timestamp":"2026-07-18T11:00:00Z","cwd":"/tmp/pi-project"}
+{"type":"session_info","id":"info-b","timestamp":"2026-07-18T11:01:00Z","name":"Explicit Pi title"}
+{"type":"message","id":"assistant-1","timestamp":"2026-07-18T12:00:01Z","message":{"role":"assistant","provider":"openai","api":"responses","model":"gpt-test","timestamp":1784376000000,"usage":{"input":100,"output":20,"cacheRead":5,"cacheWrite":2,"totalTokens":127,"cost":{"total":0.12}},"stopReason":"stop"}}
+{"type":"message","id":"assistant-1","timestamp":"2026-07-18T12:00:01Z","message":{"role":"assistant","provider":"openai","api":"responses","model":"gpt-test","timestamp":1784376000000,"usage":{"input":1,"output":2,"cacheRead":0,"cacheWrite":0,"totalTokens":3,"cost":{"total":0.02}},"stopReason":"error"}}

--- a/Tests/TokiTests/PiUsageClientTests.swift
+++ b/Tests/TokiTests/PiUsageClientTests.swift
@@ -1,0 +1,333 @@
+import Foundation
+import XCTest
+@testable import Toki
+
+final class PiUsageClientTests: XCTestCase {
+    func testFixtureAggregationDeduplicatesCopiesAndToleratesMalformedLines() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let now = ISO8601DateFormatter().date(from: "2026-07-18T18:00:00Z")!
+
+        let totals = try PiUsageClient.aggregate(root: fixtureRoot, now: now, calendar: calendar)
+
+        XCTAssertEqual(totals.todayInput, 108)
+        XCTAssertEqual(totals.todayOutput, 25)
+        XCTAssertEqual(totals.todayCacheRead, 5)
+        XCTAssertEqual(totals.todayCacheWrite, 2)
+        XCTAssertEqual(totals.todayCost, 0.21, accuracy: 0.000_001)
+        XCTAssertEqual(totals.allTimeCost, 0.22, accuracy: 0.000_001)
+        XCTAssertEqual(totals.sessionCount, 2)
+    }
+
+    func testAssistantTimestampTakesPrecedenceOverOuterTimestamp() throws {
+        let root = try temporaryDirectory()
+        let file = (root as NSString).appendingPathComponent("timestamp.jsonl")
+        let jsonl = """
+        {"type":"session","id":"timestamp-session","cwd":"/tmp/timestamp","timestamp":"2026-07-17T00:00:00Z"}
+        {"type":"message","id":"ts","timestamp":"2026-07-18T12:00:00Z","message":{"role":"assistant","timestamp":1784289600000,"provider":"p","api":"a","model":"m","usage":{"input":5,"output":2,"cost":{"total":0.5}}}}
+        """
+        try jsonl.write(toFile: file, atomically: true, encoding: .utf8)
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let now = ISO8601DateFormatter().date(from: "2026-07-18T18:00:00Z")!
+
+        let totals = try PiUsageClient.aggregate(root: root, now: now, calendar: calendar)
+
+        XCTAssertEqual(totals.todayInput, 0)
+        XCTAssertEqual(totals.allTimeCost, 0.5)
+    }
+
+    func testFractionalOuterTimestampIsAcceptedWhenMessageTimestampIsAbsent() throws {
+        let root = try temporaryDirectory()
+        let file = (root as NSString).appendingPathComponent("fractional.jsonl")
+        let jsonl = """
+        {"type":"session","id":"fractional-session","cwd":"/tmp/fractional","timestamp":"2026-07-18T00:00:00Z"}
+        {"type":"message","id":"fractional","timestamp":"2026-07-18T13:00:00.123Z","message":{"role":"assistant","provider":"p","api":"a","model":"m","usage":{"input":5,"output":2,"cost":{"total":0.5}}}}
+        """
+        try jsonl.write(toFile: file, atomically: true, encoding: .utf8)
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let now = ISO8601DateFormatter().date(from: "2026-07-18T18:00:00Z")!
+
+        let totals = try PiUsageClient.aggregate(root: root, now: now, calendar: calendar)
+
+        XCTAssertEqual(totals.todayInput, 5)
+        XCTAssertEqual(totals.todayCost, 0.5)
+    }
+
+    func testZeroMessageTimestampFallsBackToOuterTimestamp() throws {
+        let root = try temporaryDirectory()
+        let file = (root as NSString).appendingPathComponent("zero-timestamp.jsonl")
+        let jsonl = """
+        {"type":"session","id":"zero-session","cwd":"/tmp/zero","timestamp":"2026-07-18T00:00:00Z"}
+        {"type":"message","id":"zero","timestamp":"2026-07-18T13:00:00Z","message":{"role":"assistant","timestamp":0,"provider":"p","api":"a","model":"m","usage":{"input":5,"output":2,"cost":{"total":0.5}}}}
+        """
+        try jsonl.write(toFile: file, atomically: true, encoding: .utf8)
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let now = ISO8601DateFormatter().date(from: "2026-07-18T18:00:00Z")!
+
+        let totals = try PiUsageClient.aggregate(root: root, now: now, calendar: calendar)
+
+        XCTAssertEqual(totals.todayInput, 5)
+        XCTAssertEqual(totals.todayCost, 0.5)
+    }
+
+    func testNegativeUsageAndCostAreIgnored() throws {
+        let root = try temporaryDirectory()
+        let file = (root as NSString).appendingPathComponent("negative.jsonl")
+        let jsonl = """
+        {"type":"session","id":"negative-session","cwd":"/tmp/negative","timestamp":"2026-07-18T00:00:00Z"}
+        {"type":"message","id":"negative","timestamp":"2026-07-18T13:00:00Z","message":{"role":"assistant","provider":"p","api":"a","model":"m","usage":{"input":-5,"output":-2,"cacheRead":-1,"cacheWrite":-3,"cost":{"total":-0.5}}}}
+        """
+        try jsonl.write(toFile: file, atomically: true, encoding: .utf8)
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let now = ISO8601DateFormatter().date(from: "2026-07-18T18:00:00Z")!
+
+        let totals = try PiUsageClient.aggregate(root: root, now: now, calendar: calendar)
+
+        XCTAssertEqual(totals.todayInput, 0)
+        XCTAssertEqual(totals.todayOutput, 0)
+        XCTAssertEqual(totals.todayCacheRead, 0)
+        XCTAssertEqual(totals.todayCacheWrite, 0)
+        XCTAssertEqual(totals.todayCost, 0)
+        XCTAssertEqual(totals.allTimeCost, 0)
+    }
+
+    func testMissingAndUnreadableRootErrorsDoNotExposePaths() throws {
+        let root = try temporaryDirectory()
+        let missing = (root as NSString).appendingPathComponent("private/missing/sessions")
+        XCTAssertThrowsError(try PiUsageClient.aggregate(root: missing)) { error in
+            XCTAssertEqual(error.localizedDescription, "Pi session history not found")
+            XCTAssertFalse(error.localizedDescription.contains(root))
+        }
+
+        let notDirectory = (root as NSString).appendingPathComponent("private-history")
+        try "not a directory".write(toFile: notDirectory, atomically: true, encoding: .utf8)
+        XCTAssertThrowsError(try PiUsageClient.aggregate(root: notDirectory)) { error in
+            XCTAssertEqual(error.localizedDescription, "Unable to read Pi session history")
+            XCTAssertFalse(error.localizedDescription.contains(root))
+        }
+    }
+
+    func testUnreadableSessionFileErrorDoesNotExposePath() throws {
+        let root = try temporaryDirectory()
+        let invalidSession = (root as NSString).appendingPathComponent("private-session.jsonl")
+        try "{}".write(toFile: invalidSession, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: invalidSession)
+
+        XCTAssertThrowsError(try PiUsageClient.aggregate(root: root)) { error in
+            XCTAssertEqual(error.localizedDescription, "Unable to read a Pi session file")
+            XCTAssertFalse(error.localizedDescription.contains(root))
+        }
+    }
+
+    func testSessionRootPrecedenceAndAbsoluteSettingsResolution() throws {
+        let home = try temporaryDirectory()
+        let agent = (home as NSString).appendingPathComponent("agent")
+        let configured = (home as NSString).appendingPathComponent("configured-history")
+        try FileManager.default.createDirectory(atPath: agent, withIntermediateDirectories: true)
+        try "{\"sessionDir\":\"\(configured)\"}".write(
+            toFile: (agent as NSString).appendingPathComponent("settings.json"), atomically: true, encoding: .utf8
+        )
+
+        XCTAssertEqual(
+            try PiUsageClient.sessionRoot(environment: ["PI_CODING_AGENT_DIR": agent], home: home),
+            configured
+        )
+        XCTAssertEqual(
+            try PiUsageClient.sessionRoot(environment: ["PI_CODING_AGENT_DIR": agent, "PI_CODING_AGENT_SESSION_DIR": "~/override"], home: home),
+            (home as NSString).appendingPathComponent("override")
+        )
+        XCTAssertEqual(
+            try PiUsageClient.sessionRoot(
+                environment: ["PI_CODING_AGENT_DIR": "relative-agent", "PI_CODING_AGENT_SESSION_DIR": configured],
+                home: home
+            ),
+            configured
+        )
+        XCTAssertEqual(
+            try PiUsageClient.sessionRoot(
+                environment: ["PI_CODING_AGENT_DIR": "relative-agent", "PI_CODING_AGENT_SESSION_DIR": "~/override"],
+                home: home
+            ),
+            (home as NSString).appendingPathComponent("override")
+        )
+    }
+
+    func testRelativePiDirectoriesAreRejected() throws {
+        let home = try temporaryDirectory()
+        XCTAssertThrowsError(try PiUsageClient.sessionRoot(environment: ["PI_CODING_AGENT_DIR": "relative-agent"], home: home))
+        XCTAssertThrowsError(try PiUsageClient.sessionRoot(environment: ["PI_CODING_AGENT_SESSION_DIR": "relative-sessions"], home: home))
+
+        let agent = (home as NSString).appendingPathComponent("agent")
+        try FileManager.default.createDirectory(atPath: agent, withIntermediateDirectories: true)
+        try #"{"sessionDir":"relative/history"}"#.write(
+            toFile: (agent as NSString).appendingPathComponent("settings.json"), atomically: true, encoding: .utf8
+        )
+        XCTAssertThrowsError(try PiUsageClient.sessionRoot(environment: ["PI_CODING_AGENT_DIR": agent], home: home)) { error in
+            XCTAssertEqual(error.localizedDescription, "Pi session directory must be absolute, exactly ~, or begin with ~/")
+            XCTAssertFalse(error.localizedDescription.contains(home))
+        }
+    }
+
+    func testUnrelatedJSONLDoesNotCreateAccountOrInflateUsage() throws {
+        let root = try temporaryDirectory()
+        try #"{"event":"other","message":{"role":"assistant","usage":{"input":999,"cost":{"total":99}}}}"#.write(
+            toFile: (root as NSString).appendingPathComponent("other.jsonl"), atomically: true, encoding: .utf8
+        )
+        XCTAssertNil(PiUsageClient.autoDetectedAccount(environment: ["PI_CODING_AGENT_SESSION_DIR": root], home: root))
+
+        let valid = """
+        {"type":"session","id":"valid-session","cwd":"/tmp/valid","timestamp":"2026-07-18T00:00:00Z"}
+        {"type":"message","id":"valid","timestamp":"2026-07-18T13:00:00Z","message":{"role":"assistant","provider":"p","api":"a","model":"m","usage":{"input":5,"output":2,"cost":{"total":0.5}}}}
+        """
+        try valid.write(toFile: (root as NSString).appendingPathComponent("valid.jsonl"), atomically: true, encoding: .utf8)
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let now = ISO8601DateFormatter().date(from: "2026-07-18T18:00:00Z")!
+
+        let totals = try PiUsageClient.aggregate(root: root, now: now, calendar: calendar)
+
+        XCTAssertEqual(totals.sessionCount, 1)
+        XCTAssertEqual(totals.todayInput, 5)
+        XCTAssertEqual(totals.allTimeCost, 0.5)
+        XCTAssertNotNil(PiUsageClient.autoDetectedAccount(environment: ["PI_CODING_AGENT_SESSION_DIR": root], home: root))
+    }
+
+    func testOversizedRecordIsSkippedAndFollowingUsageCounts() throws {
+        let root = try temporaryDirectory()
+        let file = (root as NSString).appendingPathComponent("oversized.jsonl")
+        let oversized = "{\"type\":\"custom\",\"payload\":\"" + String(repeating: "x", count: 1_100_000) + "\"}"
+        let jsonl = """
+        {"type":"session","id":"oversized-session","cwd":"/tmp/oversized","timestamp":"2026-07-18T00:00:00Z"}
+        \(oversized)
+        {"type":"message","id":"after-large","timestamp":"2026-07-18T13:00:00Z","message":{"role":"assistant","provider":"p","api":"a","model":"m","usage":{"input":5,"output":2,"cost":{"total":0.5}}}}
+        """
+        try jsonl.write(toFile: file, atomically: true, encoding: .utf8)
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let now = ISO8601DateFormatter().date(from: "2026-07-18T18:00:00Z")!
+
+        let totals = try PiUsageClient.aggregate(root: root, now: now, calendar: calendar)
+
+        XCTAssertEqual(totals.sessionCount, 1)
+        XCTAssertEqual(totals.todayInput, 5)
+    }
+
+    func testDefaultRootAndTildeSettings() throws {
+        let home = try temporaryDirectory()
+        XCTAssertEqual(
+            try PiUsageClient.sessionRoot(environment: [:], home: home),
+            (home as NSString).appendingPathComponent(".pi/agent/sessions")
+        )
+
+        let agent = (home as NSString).appendingPathComponent(".pi/agent")
+        try FileManager.default.createDirectory(atPath: agent, withIntermediateDirectories: true)
+        try #"{"sessionDir":"~/pi-history"}"#.write(
+            toFile: (agent as NSString).appendingPathComponent("settings.json"), atomically: true, encoding: .utf8
+        )
+        XCTAssertEqual(
+            try PiUsageClient.sessionRoot(environment: [:], home: home),
+            (home as NSString).appendingPathComponent("pi-history")
+        )
+    }
+
+    func testProcessClassificationIsNarrow() {
+        let matches: [(String, Provider)] = [
+            ("/opt/homebrew/bin/opencode", .openCode),
+            ("/usr/local/bin/copilot", .copilot),
+            ("node /x/@github/copilot/dist/index.js", .copilot),
+            ("/opt/homebrew/bin/codex", .codex),
+            ("node /x/@openai/codex/dist/cli.js", .codex),
+            ("/usr/local/bin/claude", .claudeCode),
+            ("/usr/local/bin/grok", .grok),
+            ("/usr/local/bin/gemini", .gemini),
+            ("node /x/bin/gemini", .gemini),
+            ("/opt/homebrew/bin/pi", .pi),
+            ("node /x/@earendil-works/pi-coding-agent/dist/cli.js", .pi),
+            ("bun /x/@mariozechner/pi-coding-agent/dist/cli.js", .pi)
+        ]
+        for (command, expected) in matches {
+            XCTAssertEqual(ActiveAgentScanner.providerForCommand(command), expected, command)
+        }
+
+        let nonMatches = [
+            "node /tmp/pi-helper.js",
+            "python pi",
+            "node /x/pi-coding-agent/dist/cli.js",
+            "bun /x/@earendil-works/not-pi/dist/cli.js",
+            "node /tmp/copilot-helper.js",
+            "node /tmp/codex-helper.js",
+            "node /tmp/gemini-helper.js"
+        ]
+        for command in nonMatches {
+            XCTAssertNil(ActiveAgentScanner.providerForCommand(command), command)
+        }
+    }
+
+    func testLatestSessionUsesExplicitSessionInfoAndMatchingCWD() throws {
+        let root = try temporaryDirectory()
+        let destination = (root as NSString).appendingPathComponent("project")
+        try FileManager.default.copyItem(atPath: fixtureRoot, toPath: destination)
+        let sessionDirectory = (destination as NSString).appendingPathComponent("project")
+        let older = (sessionDirectory as NSString).appendingPathComponent("session-a.jsonl")
+        let newer = (sessionDirectory as NSString).appendingPathComponent("session-b.jsonl")
+        try FileManager.default.setAttributes([.modificationDate: Date(timeIntervalSince1970: 10)], ofItemAtPath: older)
+        try FileManager.default.setAttributes([.modificationDate: Date(timeIntervalSince1970: 20)], ofItemAtPath: newer)
+
+        let metadata = PiUsageClient.latestSession(cwd: "/tmp/pi-project", root: root)
+
+        XCTAssertEqual(metadata?.title, "Explicit Pi title")
+        XCTAssertEqual((metadata?.path as NSString?)?.lastPathComponent, (newer as NSString).lastPathComponent)
+        XCTAssertNil(PiUsageClient.latestSession(cwd: "/tmp/other", root: root))
+    }
+
+    func testLatestSessionIndexIsReusedWithinWindowAndRefreshedAfterExpiry() throws {
+        let root = try temporaryDirectory()
+        let first = (root as NSString).appendingPathComponent("first.jsonl")
+        try """
+        {"type":"session","id":"first","cwd":"/tmp/cache","timestamp":"2026-07-18T00:00:00Z"}
+        {"type":"session_info","id":"first-info","name":"First"}
+        """.write(toFile: first, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.modificationDate: Date(timeIntervalSince1970: 10)], ofItemAtPath: first)
+
+        let initial = PiUsageClient.latestSession(cwd: "/tmp/cache", root: root, now: Date(timeIntervalSince1970: 100))
+        XCTAssertEqual(initial?.title, "First")
+
+        let second = (root as NSString).appendingPathComponent("second.jsonl")
+        try """
+        {"type":"session","id":"second","cwd":"/tmp/cache","timestamp":"2026-07-18T00:01:00Z"}
+        {"type":"session_info","id":"second-info","name":"Second"}
+        """.write(toFile: second, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.modificationDate: Date(timeIntervalSince1970: 20)], ofItemAtPath: second)
+
+        XCTAssertEqual(
+            PiUsageClient.latestSession(cwd: "/tmp/cache", root: root, now: Date(timeIntervalSince1970: 102))?.title,
+            "First"
+        )
+        XCTAssertEqual(
+            PiUsageClient.latestSession(cwd: "/tmp/cache", root: root, now: Date(timeIntervalSince1970: 106))?.title,
+            "Second"
+        )
+    }
+
+    func testProviderCoding() throws {
+        XCTAssertEqual(try JSONDecoder().decode(Provider.self, from: Data(#""pi""#.utf8)), .pi)
+        XCTAssertEqual(String(decoding: try JSONEncoder().encode(Provider.pi), as: UTF8.self), #""pi""#)
+        XCTAssertFalse(Provider.pi.isConsumerTracked)
+        XCTAssertEqual(Provider.pi.displayName, "Pi")
+    }
+
+    private var fixtureRoot: String {
+        Bundle.module.url(forResource: "pi", withExtension: nil, subdirectory: "Fixtures")!.path
+    }
+
+    private func temporaryDirectory() throws -> String {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url.path
+    }
+}

--- a/Tests/TokiTests/ProviderScanDispositionTests.swift
+++ b/Tests/TokiTests/ProviderScanDispositionTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import Toki
+
+final class ProviderScanDispositionTests: XCTestCase {
+    func testFreshLocalOnlyDetectionActivatesTransientUsage() {
+        XCTAssertEqual(
+            providerScanDisposition(
+                detected: [local(.pi)],
+                snapshotProviders: [],
+                configIsNil: true,
+                needsOnboarding: true
+            ),
+            .activateLocalUsage
+        )
+    }
+
+    func testConnectableDetectionStillTakesPersistencePath() {
+        XCTAssertEqual(
+            providerScanDisposition(
+                detected: [local(.pi), connectable(.codex)],
+                snapshotProviders: [],
+                configIsNil: true,
+                needsOnboarding: true
+            ),
+            .persistConnectable
+        )
+    }
+
+    func testCorruptConfigCannotActivateTransientUsage() {
+        XCTAssertEqual(
+            providerScanDisposition(
+                detected: [local(.openCode)],
+                snapshotProviders: [],
+                configIsNil: true,
+                needsOnboarding: false
+            ),
+            .noAction
+        )
+    }
+
+    func testAlreadySurfacedOrConfiguredLocalProviderDoesNothing() {
+        XCTAssertEqual(
+            providerScanDisposition(
+                detected: [local(.pi)],
+                snapshotProviders: [.pi],
+                configIsNil: true,
+                needsOnboarding: true
+            ),
+            .noAction
+        )
+        XCTAssertEqual(
+            providerScanDisposition(
+                detected: [local(.pi)],
+                snapshotProviders: [],
+                configIsNil: false,
+                needsOnboarding: true
+            ),
+            .noAction
+        )
+    }
+
+    private func local(_ provider: Provider) -> DetectedProvider {
+        DetectedProvider(provider: provider, title: provider.displayName, detail: "local", makeAccount: nil)
+    }
+
+    private func connectable(_ provider: Provider) -> DetectedProvider {
+        DetectedProvider(provider: provider, title: provider.displayName, detail: "account") {
+            AccountConfig(id: provider.rawValue, name: provider.displayName, provider: provider)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add automatic Pi usage tracking from local JSONL session history
- surface token counts, cache usage, estimated costs, sessions, and active Pi agents
- support explicit Pi session names, safe process detection, and the official Pi badge
- let configless local-only providers such as Pi and OpenCode leave onboarding without writing `config.json`
- document Pi discovery, privacy, path precedence, and supported limitations

## Implementation notes

Pi usage is read locally without accessing authentication data or retaining prompt/message content. The parser validates Pi session headers, deduplicates history copied by forks/clones, bounds record memory, ignores malformed or oversized records, and sanitizes filesystem errors. Underlying model providers are aggregated into one Pi harness card.

## Validation

- `swift test` — 20 tests passed
- `scripts/build-app.sh`
- `plutil -lint .build/Toki.app/Contents/Info.plist`
- bundled `pi-logo.svg` matches the official Pi press-kit asset
- tested locally with Pi 0.73.1 and confirmed active-agent detection and usage display
- `git diff --check`