### PR TITLE
Credit @thepushkarp for Pi usage tracking in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Pi support using local JSONL session metadata for token and estimated-cost usage, active-agent detection with session titles, and automatic session-root discovery without authentication or Toki account configuration.
+- Pi support (#16, by @thepushkarp) using local JSONL session metadata for token and estimated-cost usage, active-agent detection with session titles, and automatic session-root discovery without authentication or Toki account configuration.
 
 ## 2.2.1 - 2026-07-16
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ macOS may ask for Keychain access the first time Toki reads Claude Code or `clau
 
 ```sh
 brew tap aashutoshrathi/tap
+brew trust --cask aashutoshrathi/tap/toki
 brew install --cask toki
 ```
 


### PR DESCRIPTION
## Summary

- CHANGELOG.md's 2.3.0 entry (rendered in-app by the "What's new" page) didn't credit the actual author of the Pi usage tracking feature. Matches the attribution already added to the GitHub release notes for v2.3.0: PR #16, by @thepushkarp.

## Test plan

- Text-only change, no build impact.