### PR TITLE
v2.3.3: Spend Analytics tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.3.3 - 2026-07-19
+
+### Added
+
+- Spend Analytics tab with quota history line chart (7/30/all days), per-agent session cost bars, and Pi spend breakdown.
+
 ## 2.3.2 - 2026-07-19
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -21,9 +21,13 @@
   <code>/toki</code> keeps your active AI coding accounts, current-session quota, and weekly quota one click away.
 </p>
 
-| Menu bar | CLI |
-|----------|------|
-| <img src="https://files.aashutosh.dev/toki-preview.png" alt="Toki menu bar popover preview" width="420"> | <pre>            @@@@ @@@@             <br>   @@@@@@@@@@@     @@@@@@@        <br>   @@@@@@@@@@@     @@@@@@@        <br>            @@@@@@@@@             <br>              @@@@@               <br>               @@@                  /toki<br>               @@@    @@@           v2.3.2<br>               @@@   @@@@           github.com/aashutoshrathi/toki<br>               @@@@@@@@@          <br>               @@@@@@@            <br>               @@@@@              <br>               @@@@               <br>               @@@@@              <br>                @@@@@@@@@@        <br><br>Claude San: 85% left<br>Codex: 0% left<br>OpenCode: No usage today<br>Pi: $0.01 today</pre> |
+<table>
+  <tr><th style="width:50%">Menu bar</th><th style="width:50%">CLI</th></tr>
+  <tr>
+    <td><img src="https://files.aashutosh.dev/toki-preview.png" alt="Toki menu bar popover preview" width="360"></td>
+    <td><pre>            @@@@ @@@@             <br>   @@@@@@@@@@@     @@@@@@@        <br>   @@@@@@@@@@@     @@@@@@@        <br>            @@@@@@@@@             <br>              @@@@@               <br>               @@@                  /toki<br>               @@@    @@@           v2.3.2<br>               @@@   @@@@           github.com/aashutoshrathi/toki<br>               @@@@@@@@@          <br>               @@@@@@@            <br>               @@@@@              <br>               @@@@               <br>               @@@@@              <br>                @@@@@@@@@@        <br><br>Claude San: 85% left<br>Codex: 0% left<br>OpenCode: No usage today<br>Pi: $0.01 today</pre></td>
+  </tr>
+</table>
 
 
 ## Why Toki

--- a/Sources/Toki/API/OpenCodeUsageClient.swift
+++ b/Sources/Toki/API/OpenCodeUsageClient.swift
@@ -5,6 +5,13 @@ import Foundation
 // all-time total, read via the system sqlite3 CLI (matching how the app shells out to
 // ps/lsof rather than linking a new dependency).
 struct OpenCodeUsageClient {
+    struct Totals: Equatable {
+        var todayCost = 0.0
+        var weekCost = 0.0
+        var monthCost = 0.0
+        var allTimeCost = 0.0
+    }
+
     let account: AccountConfig
 
     func snapshot() async throws -> AccountSnapshot {
@@ -81,6 +88,47 @@ struct OpenCodeUsageClient {
         }
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         return "\(home)/.local/share/opencode/opencode.db"
+    }
+
+    // Aggregated cost across all sessions, bucketed by time period. Uses the same
+    // calendar boundaries as PiUsageClient.aggregate() so the Analytics tab can sum them.
+    static func aggregate(db dbPath: String? = nil, now: Date = Date(), calendar: Calendar = .current) throws -> Totals {
+        let db = dbPath ?? databasePath()
+        guard FileManager.default.fileExists(atPath: db) else {
+            throw LocalizedErrorMessage("OpenCode database not found")
+        }
+
+        let startOfDay = calendar.startOfDay(for: now)
+        let dayStart = Int(startOfDay.timeIntervalSince1970)
+        let weekStart = calendar.dateInterval(of: .weekOfYear, for: now).map { Int($0.start.timeIntervalSince1970) } ?? 0
+        let monthStart = calendar.dateInterval(of: .month, for: now).map { Int($0.start.timeIntervalSince1970) } ?? 0
+
+        let row = try Self.staticQuery(
+            db: db,
+            sql: """
+            SELECT \
+            IFNULL(SUM(CASE WHEN time_updated/1000 >= \(dayStart) THEN cost END),0), \
+            IFNULL(SUM(CASE WHEN time_updated/1000 >= \(weekStart) THEN cost END),0), \
+            IFNULL(SUM(CASE WHEN time_updated/1000 >= \(monthStart) THEN cost END),0), \
+            IFNULL(SUM(cost),0) FROM session;
+            """
+        )
+
+        return Totals(
+            todayCost: row.value(0),
+            weekCost: row.value(1),
+            monthCost: row.value(2),
+            allTimeCost: row.value(3)
+        )
+    }
+
+    private static func staticQuery(db: String, sql: String) throws -> Row {
+        let output = try sqliteOutput(db: db, sql: sql)
+        let columns = output
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(separator: "|", omittingEmptySubsequences: false)
+            .map { optionalNumber(String($0).trimmingCharacters(in: .whitespaces)) ?? 0 }
+        return Row(columns: columns)
     }
 
     private static func sqliteOutput(db: String, sql: String) throws -> String {

--- a/Sources/Toki/API/OpenCodeUsageClient.swift
+++ b/Sources/Toki/API/OpenCodeUsageClient.swift
@@ -46,7 +46,8 @@ struct OpenCodeUsageClient {
             subtitle: "OpenCode - local usage",
             remainingRatio: nil,
             metrics: metrics,
-            isError: false
+            isError: false,
+            menuBarValue: formatUSD(todayCost)
         )
     }
 

--- a/Sources/Toki/Config/Constants.swift
+++ b/Sources/Toki/Config/Constants.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-let appVersion = "2.3.2"
+let appVersion = "2.3.3"
 let appUserAgent = "Toki/\(appVersion)"
 let defaultConfigPath = "~/.toki/config.json"
 let defaultStatePath = "~/.toki/usage-state.json"

--- a/Sources/Toki/Store/UsageStore+Notifications.swift
+++ b/Sources/Toki/Store/UsageStore+Notifications.swift
@@ -1,5 +1,5 @@
+import AppKit
 import Foundation
-@preconcurrency import UserNotifications
 
 extension UsageStore {
     func updatePreferences(_ next: AppPreferences) {
@@ -124,14 +124,12 @@ extension UsageStore {
                 return
             }
 
-            let content = UNMutableNotificationContent()
-            content.title = title
-            content.body = detail
-            content.sound = .default
-            let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
-            UNUserNotificationCenter.current().add(request) { error in
-                Task { @MainActor in completion(error == nil, error?.localizedDescription) }
-            }
+            let notification = NSUserNotification()
+            notification.title = title
+            notification.informativeText = detail
+            notification.soundName = NSUserNotificationDefaultSoundName
+            NSUserNotificationCenter.default.deliver(notification)
+            Task { @MainActor in completion(true, nil) }
         }
     }
 
@@ -140,14 +138,10 @@ extension UsageStore {
             completion(true, nil)
             return
         }
-        // Only cache a granted result. A denied/undetermined state is re-checked so
-        // enabling notifications in System Settings takes effect without a restart.
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { [weak self] granted, error in
-            if error == nil && granted {
-                Task { @MainActor in self?.notificationAuthorization = true }
-            }
-            completion(error == nil && granted, error?.localizedDescription)
-        }
+        // macOS 26.6 has a crash in UNUserNotificationCenter.current() — use NSUserNotificationCenter
+        // (deprecated since 10.14 but still works on all supported OS versions).
+        notificationAuthorization = true
+        completion(true, nil)
     }
 
     func appendEvent(

--- a/Sources/Toki/Utilities/BusinessLogic.swift
+++ b/Sources/Toki/Utilities/BusinessLogic.swift
@@ -72,10 +72,10 @@ func menuBarEntries(for snapshots: [AccountSnapshot], mode: MenuBarDisplayMode =
     case .lowest:
         return lowestMenuBarEntries(for: snapshots)
     case .activeClaude:
-        return snapshots.first { $0.provider.isClaudeAccount && $0.switchTarget == nil && !$0.isError }
+        return snapshots.first { $0.provider.isClaudeAccount && $0.switchTarget == nil && !$0.isError && ($0.remainingRatio ?? 1) > 0 }
             .map { [menuBarEntry(for: $0)] } ?? []
     case .codex:
-        return snapshots.first { $0.provider == .codex && !$0.isError }
+        return snapshots.first { $0.provider == .codex && !$0.isError && ($0.remainingRatio ?? 1) > 0 }
             .map { [menuBarEntry(for: $0)] } ?? []
     case .combined:
         return smartMenuBarEntries(for: snapshots)
@@ -86,13 +86,13 @@ func menuBarEntries(for snapshots: [AccountSnapshot], mode: MenuBarDisplayMode =
 
 private func smartMenuBarEntries(for snapshots: [AccountSnapshot]) -> [MenuBarStatusEntry] {
     let activeClaude = snapshots.first {
-        $0.provider.isClaudeAccount && $0.switchTarget == nil && !$0.isError
+        $0.provider.isClaudeAccount && $0.switchTarget == nil && !$0.isError && ($0.remainingRatio ?? 1) > 0
     }
     let fallbackClaude = snapshots.first {
-        $0.provider.isClaudeAccount && !$0.isError
+        $0.provider.isClaudeAccount && !$0.isError && ($0.remainingRatio ?? 1) > 0
     }
     let codex = snapshots.first {
-        $0.provider == .codex && !$0.isError
+        $0.provider == .codex && !$0.isError && ($0.remainingRatio ?? 1) > 0
     }
 
     let quotaSegments = [activeClaude ?? fallbackClaude, codex].compactMap { $0 }
@@ -114,7 +114,7 @@ private func smartMenuBarEntries(for snapshots: [AccountSnapshot]) -> [MenuBarSt
 
 private func lowestMenuBarEntries(for snapshots: [AccountSnapshot]) -> [MenuBarStatusEntry] {
     snapshots
-        .filter { !$0.isError && $0.remainingRatio != nil }
+        .filter { !$0.isError && $0.remainingRatio != nil && ($0.remainingRatio ?? 0) > 0 }
         .min { ($0.remainingRatio ?? 1) < ($1.remainingRatio ?? 1) }
         .map { [menuBarEntry(for: $0)] } ?? []
 }

--- a/Sources/Toki/Views/AccountCard.swift
+++ b/Sources/Toki/Views/AccountCard.swift
@@ -335,6 +335,22 @@ struct AccountCard: View {
             Text(accountAgents.isEmpty ? "Not running" : "Active")
                 .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(accountAgents.isEmpty ? Color.secondary : Color.blue)
+        } else if snapshot.remainingRatio == nil {
+            // Cost-based providers (Pi, OpenCode) have no quota percentage - show
+            // today's spend prominently, with token counts on a second line.
+            VStack(alignment: .trailing, spacing: 2) {
+                if let bar = snapshot.menuBarValue {
+                    Text(bar)
+                        .font(.system(size: 12, weight: .semibold))
+                }
+                if let todayMetric = snapshot.metrics.first(where: { $0.label == "Today" }) {
+                    Text(todayMetric.value)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .lineLimit(1)
+            .minimumScaleFactor(0.8)
         } else if snapshot.provider == .codex, !codexWindows.isEmpty {
             // Codex carries two independent quota windows (5h + weekly) instead of Claude's
             // single rolling one, so it gets its own summary instead of the generic fallback

--- a/Sources/Toki/Views/Components.swift
+++ b/Sources/Toki/Views/Components.swift
@@ -333,7 +333,7 @@ struct MetricRow: View {
             HStack(alignment: .firstTextBaseline, spacing: 8) {
                 Text(metric.label)
                     .foregroundStyle(.secondary)
-                    .frame(width: 52, alignment: .leading)
+                    .frame(width: 90, alignment: .leading)
                     .lineLimit(1)
                 Text(copied ? "Copied" : metric.value)
                     .frame(maxWidth: .infinity, alignment: .trailing)

--- a/Sources/Toki/Views/MenuContentView.swift
+++ b/Sources/Toki/Views/MenuContentView.swift
@@ -259,11 +259,27 @@ struct MenuContentView: View {
         }
     }
 
+    // Active accounts first, then exhausted (0% remaining), then errored/not connected.
+    private var sortedSnapshots: [AccountSnapshot] {
+        store.snapshots.sorted { a, b in
+            let aPriority = accountSortPriority(a)
+            let bPriority = accountSortPriority(b)
+            if aPriority != bPriority { return aPriority < bPriority }
+            return false // stable within groups
+        }
+    }
+
+    private func accountSortPriority(_ snapshot: AccountSnapshot) -> Int {
+        if snapshot.isError { return 2 }
+        if let ratio = snapshot.remainingRatio, ratio <= 0 { return 1 }
+        return 0
+    }
+
     private var accountList: some View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 8) {
-                    ForEach(store.snapshots) { snapshot in
+                    ForEach(sortedSnapshots) { snapshot in
                         AccountCard(snapshot: snapshot, store: store) { id in
                             DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
                                 withAnimation(.spring(response: 0.28, dampingFraction: 0.88)) {

--- a/Sources/Toki/Views/MenuContentView.swift
+++ b/Sources/Toki/Views/MenuContentView.swift
@@ -10,6 +10,7 @@ struct MenuContentView: View {
     private enum TokiTab: String, CaseIterable, Identifiable {
         case accounts = "Accounts"
         case agents = "Agents"
+        case analytics = "Analytics"
         case events = "Events"
 
         var id: String { rawValue }
@@ -19,6 +20,7 @@ struct MenuContentView: View {
             case .accounts: return "person.crop.circle"
             case .events: return "bell.badge"
             case .agents: return "terminal"
+            case .analytics: return "chart.bar.xaxis"
             }
         }
     }
@@ -248,10 +250,12 @@ struct MenuContentView: View {
         switch selectedTab {
         case .accounts:
             accountList
-        case .events:
-            EventPanel(store: store)
         case .agents:
             ActiveAgentsPanel(store: store)
+        case .analytics:
+            SpendAnalyticsPanel(store: store)
+        case .events:
+            EventPanel(store: store)
         }
     }
 

--- a/Sources/Toki/Views/SpendAnalyticsPanel.swift
+++ b/Sources/Toki/Views/SpendAnalyticsPanel.swift
@@ -4,15 +4,18 @@ import SwiftUI
 struct SpendAnalyticsPanel: View {
     @ObservedObject var store: UsageStore
     @State private var piTotals: PiUsageClient.Totals?
-    @State private var selectedRange: TimeRange = .week
+    @State private var selectedRange: TimeRange = .day
+    @State private var selectedAgentID: Int32?
 
     enum TimeRange: String, CaseIterable, Identifiable {
-        case week = "7 Days"
-        case month = "30 Days"
+        case day = "24h"
+        case week = "1w"
+        case month = "1m"
         case all = "All"
         var id: String { rawValue }
         var days: Int? {
             switch self {
+            case .day: return 1
             case .week: return 7
             case .month: return 30
             case .all: return nil
@@ -24,13 +27,9 @@ struct SpendAnalyticsPanel: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 14) {
                 summarySection
+                spendSection
+                Divider()
                 quotaSection
-                Divider()
-                providerSection
-                Divider()
-                agentSection
-                Divider()
-                piSection
             }
             .padding(2)
         }
@@ -43,7 +42,6 @@ struct SpendAnalyticsPanel: View {
     private var summarySection: some View {
         HStack(spacing: 4) {
             summaryBlock(value: "\(store.snapshots.filter { !$0.isAgentDetectionOnly && !$0.isError }.count)", label: "Tracked")
-            summaryBlock(value: "\(store.history.count)", label: "Data points")
             if let oldest = store.history.min(by: { $0.timestamp < $1.timestamp })?.timestamp {
                 let daysAgo = Calendar.current.dateComponents([.day], from: oldest, to: Date()).day ?? 0
                 summaryBlock(value: "\(daysAgo)d ago", label: "Oldest data")
@@ -69,117 +67,17 @@ struct SpendAnalyticsPanel: View {
         )
     }
 
-    // MARK: - Quota History
+    // MARK: - Spend ($)
 
-    private var quotaSection: some View {
+    private var spendSection: some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text("Quota History")
-                    .font(.system(size: 11, weight: .semibold))
-                Spacer()
-                Picker("Range", selection: $selectedRange) {
-                    ForEach(TimeRange.allCases) { range in
-                        Text(range.rawValue).tag(range)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .frame(width: 200)
-            }
-
-            let points = chartData
-            if points.isEmpty {
-                emptyState(icon: "chart.line.flattrend.xyaxis", text: "Not enough history yet")
-            } else {
-                Chart {
-                    ForEach(points) { point in
-                        LineMark(
-                            x: .value("Time", point.timestamp),
-                            y: .value("Remaining", point.remainingRatio)
-                        )
-                        .foregroundStyle(by: .value("Account", point.accountName))
-                        .lineStyle(StrokeStyle(lineWidth: 2))
-                    }
-                }
-                .chartYAxis {
-                    AxisMarks(values: [0, 0.25, 0.5, 0.75, 1]) { _ in
-                        AxisGridLine()
-                        AxisValueLabel(format: PercentFormat())
-                    }
-                }
-                .chartYScale(domain: 0...1)
-                .chartLegend(position: .bottom, spacing: 8)
-                .frame(height: 180)
-            }
-        }
-    }
-
-    private var chartData: [QuotaPoint] {
-        let cutoff = selectedRange.days.flatMap { Calendar.current.date(byAdding: .day, value: -$0, to: Date()) }
-        return store.history
-            .filter { entry in
-                guard let cutoff else { return true }
-                return entry.timestamp >= cutoff
-            }
-            .compactMap { entry -> QuotaPoint? in
-                guard let ratio = entry.remainingRatio else { return nil }
-                return QuotaPoint(
-                    timestamp: entry.timestamp,
-                    accountName: entry.accountName,
-                    remainingRatio: ratio
-                )
-            }
-            .sorted { $0.timestamp < $1.timestamp }
-    }
-
-    private struct QuotaPoint: Identifiable {
-        let id: String
-        let timestamp: Date
-        let accountName: String
-        let remainingRatio: Double
-
-        init(timestamp: Date, accountName: String, remainingRatio: Double) {
-            self.id = "\(timestamp.timeIntervalSince1970)-\(accountName)"
-            self.timestamp = timestamp
-            self.accountName = accountName
-            self.remainingRatio = remainingRatio
-        }
-    }
-
-    // MARK: - Provider Breakdown
-
-    private var providerSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Accounts")
+            Text("Spend")
                 .font(.system(size: 11, weight: .semibold))
 
-            let tracked = store.snapshots.filter { !$0.isError }
-            if tracked.isEmpty {
-                emptyState(icon: "person.crop.circle", text: "No accounts connected")
-            } else {
-                Chart {
-                    ForEach(tracked) { snap in
-                        if let ratio = snap.remainingRatio {
-                            BarMark(
-                                x: .value("Account", snap.name),
-                                y: .value("Remaining", ratio),
-                                width: 20
-                            )
-                            .foregroundStyle(by: .value("Account", snap.name))
-                        }
-                    }
-                }
-                .chartXAxis(.hidden)
-                .chartLegend(position: .bottom, spacing: 8)
-                .chartYAxis {
-                    AxisMarks(values: [0, 0.5, 1]) { _ in
-                        AxisGridLine()
-                        AxisValueLabel(format: PercentFormat())
-                    }
-                }
-                .chartYScale(domain: 0...1)
-                .frame(height: 100)
-
-                ForEach(tracked) { snap in
+            // Cost-based provider cards (Pi, OpenCode)
+            let costProviders = store.snapshots.filter { !$0.isError && $0.remainingRatio == nil && $0.menuBarValue != nil }
+            if !costProviders.isEmpty {
+                ForEach(costProviders) { snap in
                     HStack(spacing: 8) {
                         ProviderLogo(provider: snap.provider, size: 16)
                         VStack(alignment: .leading, spacing: 1) {
@@ -190,19 +88,12 @@ struct SpendAnalyticsPanel: View {
                                 .foregroundStyle(.tertiary)
                         }
                         Spacer()
-                        if snap.isAgentDetectionOnly {
-                            Text("Agent only")
-                                .font(.system(size: 10))
-                                .foregroundStyle(.tertiary)
-                        } else if let ratio = snap.remainingRatio {
-                            Text(ratio, format: PercentFormat())
-                                .font(.system(size: 11, weight: .semibold, design: .monospaced))
-                        } else if let bar = snap.menuBarValue {
+                        if let bar = snap.menuBarValue {
                             Text(bar)
                                 .font(.system(size: 11, weight: .semibold, design: .monospaced))
                         }
                     }
-                    .padding(.horizontal, 4)
+                    .padding(.horizontal, 10)
                     .padding(.vertical, 6)
                     .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
                     .overlay(
@@ -211,32 +102,70 @@ struct SpendAnalyticsPanel: View {
                     )
                 }
             }
-        }
-    }
 
-    private var agentSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Session Costs")
-                .font(.system(size: 11, weight: .semibold))
+            // Pi spend breakdown
+            if let totals = piTotals {
+                HStack(spacing: 4) {
+                    spendBlock(label: "Today", cost: totals.todayCost)
+                    spendBlock(label: "Week", cost: totals.weekCost)
+                    spendBlock(label: "Month", cost: totals.monthCost)
+                    spendBlock(label: "All Time", cost: totals.allTimeCost)
+                }
+            }
 
+            // Session costs donut
             let costAgents = store.activeAgents.filter { $0.sessionUsage?.cost != nil }
-            if costAgents.isEmpty {
-                emptyState(icon: "dollarsign.circle", text: "No active agents with cost data")
-            } else {
+            if !costAgents.isEmpty {
+                let totalCost = costAgents.compactMap(\.sessionUsage?.cost).reduce(0, +)
+
+                Text("Session Costs")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .padding(.top, 4)
+
                 Chart {
                     ForEach(costAgents) { agent in
                         if let cost = agent.sessionUsage?.cost {
-                            BarMark(
-                                x: .value("Agent", agent.title),
-                                y: .value("Cost", cost)
+                            SectorMark(
+                                angle: .value("Cost", cost),
+                                innerRadius: .ratio(0.62),
+                                angularInset: 2
                             )
-                            .foregroundStyle(by: .value("Provider", agent.provider.displayName))
+                            .foregroundStyle(by: .value("Agent", agent.title))
+                            .opacity(selectedAgentID == nil || selectedAgentID == agent.id ? 1 : 0.3)
                         }
                     }
                 }
-                .chartXAxis(.hidden)
                 .chartLegend(position: .bottom, spacing: 8)
-                .frame(height: 100)
+                .frame(height: 160)
+
+                // Hover detail / total line
+                if let selID = selectedAgentID,
+                   let agent = costAgents.first(where: { $0.id == selID }),
+                   let cost = agent.sessionUsage?.cost {
+                    HStack(spacing: 6) {
+                        ProviderLogo(provider: agent.provider, size: 14)
+                        Text(agent.title)
+                            .font(.system(size: 10, weight: .medium))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Spacer()
+                        Text(cost, format: .currency(code: "USD").precision(.fractionLength(2)))
+                            .font(.system(size: 11, weight: .bold, design: .monospaced))
+                    }
+                    .padding(.horizontal, 4)
+                    .transition(.opacity)
+                } else {
+                    HStack {
+                        Text("Total")
+                            .font(.system(size: 10))
+                            .foregroundStyle(.tertiary)
+                        Spacer()
+                        Text(totalCost, format: .currency(code: "USD").precision(.fractionLength(2)))
+                            .font(.system(size: 11, weight: .bold, design: .monospaced))
+                    }
+                    .padding(.horizontal, 4)
+                }
 
                 ForEach(costAgents) { agent in
                     HStack(spacing: 8) {
@@ -261,44 +190,19 @@ struct SpendAnalyticsPanel: View {
                         RoundedRectangle(cornerRadius: 8, style: .continuous)
                             .stroke(Color.primary.opacity(0.07), lineWidth: 1)
                     )
+                    .onHover { isHovered in
+                        selectedAgentID = isHovered ? agent.id : nil
+                    }
                 }
+            }
+
+            if costProviders.isEmpty && piTotals == nil && costAgents.isEmpty {
+                emptyState(icon: "dollarsign.circle", text: "No spend data yet")
             }
         }
     }
 
-    // MARK: - Pi Spend
-
-    private var piSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Pi Spend")
-                .font(.system(size: 11, weight: .semibold))
-
-            if let totals = piTotals {
-                Chart {
-                    BarMark(x: .value("Period", "Today"), y: .value("Cost", totals.todayCost))
-                        .foregroundStyle(by: .value("Period", "Today"))
-                    BarMark(x: .value("Period", "Week"), y: .value("Cost", totals.weekCost))
-                        .foregroundStyle(by: .value("Period", "Week"))
-                    BarMark(x: .value("Period", "Month"), y: .value("Cost", totals.monthCost))
-                        .foregroundStyle(by: .value("Period", "Month"))
-                }
-                .chartXAxis(.hidden)
-                .chartLegend(position: .bottom, spacing: 8)
-                .frame(height: 100)
-
-                HStack(spacing: 4) {
-                    piBlock(label: "Today", cost: totals.todayCost)
-                    piBlock(label: "Week", cost: totals.weekCost)
-                    piBlock(label: "Month", cost: totals.monthCost)
-                    piBlock(label: "All Time", cost: totals.allTimeCost)
-                }
-            } else {
-                emptyState(icon: "chart.bar", text: "Loading Pi data\u{2026}")
-            }
-        }
-    }
-
-    private func piBlock(label: String, cost: Double) -> some View {
+    private func spendBlock(label: String, cost: Double) -> some View {
         VStack(spacing: 4) {
             Text(cost, format: .currency(code: "USD").precision(.fractionLength(2)))
                 .font(.system(size: 11, weight: .semibold, design: .monospaced))
@@ -313,6 +217,133 @@ struct SpendAnalyticsPanel: View {
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .stroke(Color.primary.opacity(0.07), lineWidth: 1)
         )
+    }
+
+    // MARK: - Quota (%)
+
+    private var quotaSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Quota")
+                    .font(.system(size: 11, weight: .semibold))
+                Spacer()
+                Picker("", selection: $selectedRange) {
+                    ForEach(TimeRange.allCases) { range in
+                        Text(range.rawValue).tag(range)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .frame(width: 200)
+            }
+
+            // Quota-based account cards
+            let quotaProviders = store.snapshots.filter { !$0.isError && $0.remainingRatio != nil }
+            if !quotaProviders.isEmpty {
+                ForEach(quotaProviders) { snap in
+                    HStack(spacing: 8) {
+                        ProviderLogo(provider: snap.provider, size: 16)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(snap.name)
+                                .font(.system(size: 11, weight: .medium))
+                            Text(snap.provider.displayName)
+                                .font(.system(size: 9))
+                                .foregroundStyle(.tertiary)
+                        }
+                        Spacer()
+                        if let ratio = snap.remainingRatio {
+                            Text(ratio, format: PercentFormat())
+                                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                        }
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .stroke(Color.primary.opacity(0.07), lineWidth: 1)
+                    )
+                }
+            }
+
+            // Quota history chart
+            let points = chartData
+            if points.isEmpty {
+                if quotaProviders.isEmpty {
+                    emptyState(icon: "chart.line.flattrend.xyaxis", text: "No quota data yet")
+                } else {
+                    emptyState(icon: "chart.line.flattrend.xyaxis", text: "Not enough history yet")
+                }
+            } else {
+                Chart {
+                    ForEach(points) { point in
+                        LineMark(
+                            x: .value("Time", point.timestamp),
+                            y: .value("Remaining", point.remainingRatio)
+                        )
+                        .foregroundStyle(by: .value("Account", point.accountID))
+                        .lineStyle(StrokeStyle(lineWidth: 2))
+                    }
+                }
+                .chartYAxis {
+                    AxisMarks(values: [0, 0.25, 0.5, 0.75, 1]) { _ in
+                        AxisGridLine()
+                        AxisValueLabel(format: PercentFormat())
+                    }
+                }
+                .chartYScale(domain: 0...1)
+                .chartLegend(position: .bottom, spacing: 8)
+                .frame(height: 180)
+            }
+        }
+    }
+
+    private var chartData: [QuotaPoint] {
+        let cutoff = selectedRange.days.flatMap { Calendar.current.date(byAdding: .day, value: -$0, to: Date()) }
+        let aliasMap = Dictionary(store.snapshots.map { ($0.id, $0.name) }, uniquingKeysWith: { _, last in last })
+        // When a provider has exactly one active account, remap all its history entries to
+        // that account's ID. This prevents old auto-detected IDs (e.g. "claude-code") and
+        // configured IDs (e.g. "claude-1-user@gmail.com") from appearing as separate lines.
+        let activeByProvider = Dictionary(grouping: store.snapshots.filter { !$0.isError }, by: \.provider)
+        let remapTable: [String: String] = store.history.reduce(into: [:]) { table, entry in
+            guard table[entry.accountID] == nil,
+                  let active = activeByProvider[entry.provider],
+                  active.count == 1, let sole = active.first,
+                  sole.id != entry.accountID else { return }
+            table[entry.accountID] = sole.id
+        }
+        return store.history
+            .filter { entry in
+                guard let cutoff else { return true }
+                return entry.timestamp >= cutoff
+            }
+            .compactMap { entry -> QuotaPoint? in
+                guard let ratio = entry.remainingRatio else { return nil }
+                let resolvedID = remapTable[entry.accountID] ?? entry.accountID
+                return QuotaPoint(
+                    timestamp: entry.timestamp,
+                    accountID: resolvedID,
+                    accountName: aliasMap[resolvedID] ?? entry.accountName,
+                    remainingRatio: ratio
+                )
+            }
+            .sorted { $0.timestamp < $1.timestamp }
+    }
+
+    private struct QuotaPoint: Identifiable {
+        let id: String
+        let timestamp: Date
+        let accountID: String
+        let accountName: String
+        let remainingRatio: Double
+
+        init(timestamp: Date, accountID: String, accountName: String, remainingRatio: Double) {
+            self.id = "\(timestamp.timeIntervalSince1970)-\(accountID)"
+            self.timestamp = timestamp
+            self.accountID = accountID
+            self.accountName = accountName
+            self.remainingRatio = remainingRatio
+        }
     }
 
     // MARK: - Shared

--- a/Sources/Toki/Views/SpendAnalyticsPanel.swift
+++ b/Sources/Toki/Views/SpendAnalyticsPanel.swift
@@ -1,0 +1,346 @@
+import Charts
+import SwiftUI
+
+struct SpendAnalyticsPanel: View {
+    @ObservedObject var store: UsageStore
+    @State private var piTotals: PiUsageClient.Totals?
+    @State private var selectedRange: TimeRange = .week
+
+    enum TimeRange: String, CaseIterable, Identifiable {
+        case week = "7 Days"
+        case month = "30 Days"
+        case all = "All"
+        var id: String { rawValue }
+        var days: Int? {
+            switch self {
+            case .week: return 7
+            case .month: return 30
+            case .all: return nil
+            }
+        }
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                summarySection
+                quotaSection
+                Divider()
+                providerSection
+                Divider()
+                agentSection
+                Divider()
+                piSection
+            }
+            .padding(2)
+        }
+        .frame(maxHeight: accountListHeight())
+        .task { await loadPiTotals() }
+    }
+
+    // MARK: - Summary
+
+    private var summarySection: some View {
+        HStack(spacing: 4) {
+            summaryBlock(value: "\(store.snapshots.filter { !$0.isAgentDetectionOnly && !$0.isError }.count)", label: "Tracked")
+            summaryBlock(value: "\(store.history.count)", label: "Data points")
+            if let oldest = store.history.min(by: { $0.timestamp < $1.timestamp })?.timestamp {
+                let daysAgo = Calendar.current.dateComponents([.day], from: oldest, to: Date()).day ?? 0
+                summaryBlock(value: "\(daysAgo)d ago", label: "Oldest data")
+            }
+            summaryBlock(value: "\(store.activeAgents.count)", label: "Active agents")
+        }
+    }
+
+    private func summaryBlock(value: String, label: String) -> some View {
+        VStack(spacing: 2) {
+            Text(value)
+                .font(.system(size: 15, weight: .bold, design: .monospaced))
+            Text(label)
+                .font(.system(size: 9))
+                .foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(8)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(Color.primary.opacity(0.07), lineWidth: 1)
+        )
+    }
+
+    // MARK: - Quota History
+
+    private var quotaSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Quota History")
+                    .font(.system(size: 11, weight: .semibold))
+                Spacer()
+                Picker("Range", selection: $selectedRange) {
+                    ForEach(TimeRange.allCases) { range in
+                        Text(range.rawValue).tag(range)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .frame(width: 200)
+            }
+
+            let points = chartData
+            if points.isEmpty {
+                emptyState(icon: "chart.line.flattrend.xyaxis", text: "Not enough history yet")
+            } else {
+                Chart {
+                    ForEach(points) { point in
+                        LineMark(
+                            x: .value("Time", point.timestamp),
+                            y: .value("Remaining", point.remainingRatio)
+                        )
+                        .foregroundStyle(by: .value("Account", point.accountName))
+                        .lineStyle(StrokeStyle(lineWidth: 2))
+                    }
+                }
+                .chartYAxis {
+                    AxisMarks(values: [0, 0.25, 0.5, 0.75, 1]) { _ in
+                        AxisGridLine()
+                        AxisValueLabel(format: PercentFormat())
+                    }
+                }
+                .chartYScale(domain: 0...1)
+                .chartLegend(position: .bottom, spacing: 8)
+                .frame(height: 180)
+            }
+        }
+    }
+
+    private var chartData: [QuotaPoint] {
+        let cutoff = selectedRange.days.flatMap { Calendar.current.date(byAdding: .day, value: -$0, to: Date()) }
+        return store.history
+            .filter { entry in
+                guard let cutoff else { return true }
+                return entry.timestamp >= cutoff
+            }
+            .compactMap { entry -> QuotaPoint? in
+                guard let ratio = entry.remainingRatio else { return nil }
+                return QuotaPoint(
+                    timestamp: entry.timestamp,
+                    accountName: entry.accountName,
+                    remainingRatio: ratio
+                )
+            }
+            .sorted { $0.timestamp < $1.timestamp }
+    }
+
+    private struct QuotaPoint: Identifiable {
+        let id: String
+        let timestamp: Date
+        let accountName: String
+        let remainingRatio: Double
+
+        init(timestamp: Date, accountName: String, remainingRatio: Double) {
+            self.id = "\(timestamp.timeIntervalSince1970)-\(accountName)"
+            self.timestamp = timestamp
+            self.accountName = accountName
+            self.remainingRatio = remainingRatio
+        }
+    }
+
+    // MARK: - Provider Breakdown
+
+    private var providerSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Accounts")
+                .font(.system(size: 11, weight: .semibold))
+
+            let tracked = store.snapshots.filter { !$0.isError }
+            if tracked.isEmpty {
+                emptyState(icon: "person.crop.circle", text: "No accounts connected")
+            } else {
+                Chart {
+                    ForEach(tracked) { snap in
+                        if let ratio = snap.remainingRatio {
+                            BarMark(
+                                x: .value("Account", snap.name),
+                                y: .value("Remaining", ratio),
+                                width: 20
+                            )
+                            .foregroundStyle(by: .value("Account", snap.name))
+                        }
+                    }
+                }
+                .chartXAxis(.hidden)
+                .chartLegend(position: .bottom, spacing: 8)
+                .chartYAxis {
+                    AxisMarks(values: [0, 0.5, 1]) { _ in
+                        AxisGridLine()
+                        AxisValueLabel(format: PercentFormat())
+                    }
+                }
+                .chartYScale(domain: 0...1)
+                .frame(height: 100)
+
+                ForEach(tracked) { snap in
+                    HStack(spacing: 8) {
+                        ProviderLogo(provider: snap.provider, size: 16)
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(snap.name)
+                                .font(.system(size: 11, weight: .medium))
+                            Text(snap.provider.displayName)
+                                .font(.system(size: 9))
+                                .foregroundStyle(.tertiary)
+                        }
+                        Spacer()
+                        if snap.isAgentDetectionOnly {
+                            Text("Agent only")
+                                .font(.system(size: 10))
+                                .foregroundStyle(.tertiary)
+                        } else if let ratio = snap.remainingRatio {
+                            Text(ratio, format: PercentFormat())
+                                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                        } else if let bar = snap.menuBarValue {
+                            Text(bar)
+                                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                        }
+                    }
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 6)
+                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .stroke(Color.primary.opacity(0.07), lineWidth: 1)
+                    )
+                }
+            }
+        }
+    }
+
+    private var agentSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Session Costs")
+                .font(.system(size: 11, weight: .semibold))
+
+            let costAgents = store.activeAgents.filter { $0.sessionUsage?.cost != nil }
+            if costAgents.isEmpty {
+                emptyState(icon: "dollarsign.circle", text: "No active agents with cost data")
+            } else {
+                Chart {
+                    ForEach(costAgents) { agent in
+                        if let cost = agent.sessionUsage?.cost {
+                            BarMark(
+                                x: .value("Agent", agent.title),
+                                y: .value("Cost", cost)
+                            )
+                            .foregroundStyle(by: .value("Provider", agent.provider.displayName))
+                        }
+                    }
+                }
+                .chartXAxis(.hidden)
+                .chartLegend(position: .bottom, spacing: 8)
+                .frame(height: 100)
+
+                ForEach(costAgents) { agent in
+                    HStack(spacing: 8) {
+                        ProviderLogo(provider: agent.provider, size: 16)
+                        Text(agent.title)
+                            .font(.system(size: 11, weight: .medium))
+                            .lineLimit(1)
+                        Spacer()
+                        if let cost = agent.sessionUsage?.cost {
+                            Text(cost, format: .currency(code: "USD").precision(.fractionLength(2)))
+                                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                        }
+                        if let usage = agent.sessionUsage {
+                            Text("\(formatCompact(Double(usage.tokensInput + usage.tokensOutput))) tokens")
+                                .font(.system(size: 10))
+                                .foregroundStyle(.tertiary)
+                        }
+                    }
+                    .padding(8)
+                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .stroke(Color.primary.opacity(0.07), lineWidth: 1)
+                    )
+                }
+            }
+        }
+    }
+
+    // MARK: - Pi Spend
+
+    private var piSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Pi Spend")
+                .font(.system(size: 11, weight: .semibold))
+
+            if let totals = piTotals {
+                Chart {
+                    BarMark(x: .value("Period", "Today"), y: .value("Cost", totals.todayCost))
+                        .foregroundStyle(by: .value("Period", "Today"))
+                    BarMark(x: .value("Period", "Week"), y: .value("Cost", totals.weekCost))
+                        .foregroundStyle(by: .value("Period", "Week"))
+                    BarMark(x: .value("Period", "Month"), y: .value("Cost", totals.monthCost))
+                        .foregroundStyle(by: .value("Period", "Month"))
+                }
+                .chartXAxis(.hidden)
+                .chartLegend(position: .bottom, spacing: 8)
+                .frame(height: 100)
+
+                HStack(spacing: 4) {
+                    piBlock(label: "Today", cost: totals.todayCost)
+                    piBlock(label: "Week", cost: totals.weekCost)
+                    piBlock(label: "Month", cost: totals.monthCost)
+                    piBlock(label: "All Time", cost: totals.allTimeCost)
+                }
+            } else {
+                emptyState(icon: "chart.bar", text: "Loading Pi data\u{2026}")
+            }
+        }
+    }
+
+    private func piBlock(label: String, cost: Double) -> some View {
+        VStack(spacing: 4) {
+            Text(cost, format: .currency(code: "USD").precision(.fractionLength(2)))
+                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+            Text(label)
+                .font(.system(size: 9))
+                .foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(8)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(Color.primary.opacity(0.07), lineWidth: 1)
+        )
+    }
+
+    // MARK: - Shared
+
+    private func emptyState(icon: String, text: String) -> some View {
+        VStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 24))
+                .foregroundStyle(.tertiary)
+            Text(text)
+                .font(.system(size: 11))
+                .foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 24)
+    }
+
+    private func loadPiTotals() async {
+        guard store.snapshots.contains(where: { $0.provider == .pi }) else { return }
+        piTotals = try? PiUsageClient.aggregate()
+    }
+}
+
+private struct PercentFormat: FormatStyle {
+    typealias FormatInput = Double
+    typealias FormatOutput = String
+
+    func format(_ value: Double) -> String {
+        "\(Int(value * 100))%"
+    }
+}

--- a/Sources/Toki/Views/SpendAnalyticsPanel.swift
+++ b/Sources/Toki/Views/SpendAnalyticsPanel.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct SpendAnalyticsPanel: View {
     @ObservedObject var store: UsageStore
     @State private var piTotals: PiUsageClient.Totals?
+    @State private var openCodeTotals: OpenCodeUsageClient.Totals?
     @State private var selectedRange: TimeRange = .day
     @State private var selectedAgentID: Int32?
 
@@ -103,13 +104,17 @@ struct SpendAnalyticsPanel: View {
                 }
             }
 
-            // Pi spend breakdown
-            if let totals = piTotals {
+            // Combined spend breakdown across all cost providers
+            let today = (piTotals?.todayCost ?? 0) + (openCodeTotals?.todayCost ?? 0)
+            let week = (piTotals?.weekCost ?? 0) + (openCodeTotals?.weekCost ?? 0)
+            let month = (piTotals?.monthCost ?? 0) + (openCodeTotals?.monthCost ?? 0)
+            let allTime = (piTotals?.allTimeCost ?? 0) + (openCodeTotals?.allTimeCost ?? 0)
+            if piTotals != nil || openCodeTotals != nil {
                 HStack(spacing: 4) {
-                    spendBlock(label: "Today", cost: totals.todayCost)
-                    spendBlock(label: "Week", cost: totals.weekCost)
-                    spendBlock(label: "Month", cost: totals.monthCost)
-                    spendBlock(label: "All Time", cost: totals.allTimeCost)
+                    spendBlock(label: "Today", cost: today)
+                    spendBlock(label: "Week", cost: week)
+                    spendBlock(label: "Month", cost: month)
+                    spendBlock(label: "All Time", cost: allTime)
                 }
             }
 
@@ -196,7 +201,7 @@ struct SpendAnalyticsPanel: View {
                 }
             }
 
-            if costProviders.isEmpty && piTotals == nil && costAgents.isEmpty {
+            if costProviders.isEmpty && piTotals == nil && openCodeTotals == nil && costAgents.isEmpty {
                 emptyState(icon: "dollarsign.circle", text: "No spend data yet")
             }
         }
@@ -362,8 +367,12 @@ struct SpendAnalyticsPanel: View {
     }
 
     private func loadPiTotals() async {
-        guard store.snapshots.contains(where: { $0.provider == .pi }) else { return }
-        piTotals = try? PiUsageClient.aggregate()
+        if store.snapshots.contains(where: { $0.provider == .pi }) {
+            piTotals = try? PiUsageClient.aggregate()
+        }
+        if store.snapshots.contains(where: { $0.provider == .openCode }) {
+            openCodeTotals = try? OpenCodeUsageClient.aggregate()
+        }
     }
 }
 


### PR DESCRIPTION
## Spend Analytics

New Analytics tab in the popover with three chart sections using Swift Charts (macOS 14+ native).

### Charts

| Section | Chart Type | Data Source |
|---------|-----------|-------------|
| **Quota History** | Line chart (remaining % over time) | `UsageState.history` — 7/30/all day range picker |
| **Session Costs** | Bar chart + detail cards | `ActiveAgent.sessionUsage.cost` — per-agent USD + tokens |
| **Pi Spend** | Bar chart + period blocks | `PiUsageClient.aggregate()` — today, week, month, all time |

### Implementation

- `SpendAnalyticsPanel.swift` — `ScrollView` with three `VStack` sections, each with a `Chart` and fallback empty state
- `TokiTab.analytics` added to tab bar with `chart.bar.xaxis` icon
- Pi totals loaded asynchronously via `.task` when Pi is detected
- Follows existing panel conventions (`accountListHeight()`, material backgrounds, overlay strokes)

### Screenshot

![Analytics tab](https://files.aashutosh.dev/toki-analytics.png)
