### PR TITLE
v2.4.2: agent navigation & naming fixes, Codex reset controls, PII hiding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.4.2 - Unreleased
 
+### Added
+
+- An eye button in the header masks account emails and org info across the cards, so you can share a screenshot or demo without leaking PII. It resets on relaunch.
+
 ### Changed
 
 - Release builds now strip symbol tables from the binary before signing, cutting the shipped app bundle from 5.3MB to 2.3MB.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Clicking an active agent running inside tmux did nothing. tmux runs panes under a detached server, so the walk up from the agent to its terminal dead-ended; Toki now hops through tmux to the attached client and focuses the terminal hosting it.
 - Clicking an agent hosted in VS Code's integrated terminal did nothing: the walk resolved a "Code Helper" process whose activation policy is .prohibited. Toki now raises the real app instead, and picks the right one when VS Code and VS Code Insiders are both open.
+- An agent's "in" token count showed only uncached input, reading as a few hundred tokens against a six-figure context. It now includes cache reads and writes, matching how the session cost is already computed.
 
 ## 2.4.1 - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Clicking an active agent running inside tmux did nothing. tmux runs panes under a detached server, so the walk up from the agent to its terminal dead-ended; Toki now hops through tmux to the attached client and focuses the terminal hosting it.
+- Clicking an agent hosted in VS Code's integrated terminal did nothing: the walk resolved a "Code Helper" process whose activation policy is .prohibited. Toki now raises the real app instead, and picks the right one when VS Code and VS Code Insiders are both open.
 
 ## 2.4.1 - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Codex
 
-- A banked rate-limit reset now shows as a badge on the collapsed Codex card, so you can see one is available without expanding the card to reach the "Reset now" button. The soonest window reset also appears in the card's subtitle.
+- A banked rate-limit reset now shows as a badge on the collapsed Codex card, and the badge is itself the redeem control: clicking it confirms first, stating how much of the window is still left, so a reset is never spent by accident. The old rule that greyed the control out until the window was 80% spent is gone. The soonest window reset also appears in the card's subtitle.
 
 ## 2.4.1 - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.4.2 - Unreleased
 
+### Changed
+
+- Release builds now strip symbol tables from the binary before signing, cutting the shipped app bundle from 5.3MB to 2.3MB.
+
 ## 2.4.1 - 2026-07-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Clicking an active agent running inside tmux did nothing. tmux runs panes under a detached server, so the walk up from the agent to its terminal dead-ended; Toki now hops through tmux to the attached client and focuses the terminal hosting it.
 - Clicking an agent hosted in VS Code's integrated terminal did nothing: the walk resolved a "Code Helper" process whose activation policy is .prohibited. Toki now raises the real app instead, and picks the right one when VS Code and VS Code Insiders are both open.
 - An agent's "in" token count showed only uncached input, reading as a few hundred tokens against a six-figure context. It now includes cache reads and writes, matching how the session cost is already computed.
+- Agents in auto-accept mode showed a false "Allow Bash?" prompt: a tool running without asking looks the same on disk as one awaiting permission. Toki now reads the session's permission mode and only flags a prompt in a mode that would actually ask.
 
 ## 2.4.1 - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - Agents in auto-accept mode showed a false "Allow Bash?" prompt: a tool running without asking looks the same on disk as one awaiting permission. Toki now reads the session's permission mode and only flags a prompt in a mode that would actually ask.
 - Several agents in one project folder all showed the same title and token usage, because Toki could only find the folder's newest session. Each agent now prefers the session file created closest to when it launched, and any titles that still match get a terminal-tty marker so the rows stay distinct.
 
+### Codex
+
+- A banked rate-limit reset now shows as a badge on the collapsed Codex card, so you can see one is available without expanding the card to reach the "Reset now" button. The soonest window reset also appears in the card's subtitle.
+
 ## 2.4.1 - 2026-07-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 2.4.2 - Unreleased
+
 ## 2.4.1 - 2026-07-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Clicking an agent hosted in VS Code's integrated terminal did nothing: the walk resolved a "Code Helper" process whose activation policy is .prohibited. Toki now raises the real app instead, and picks the right one when VS Code and VS Code Insiders are both open.
 - An agent's "in" token count showed only uncached input, reading as a few hundred tokens against a six-figure context. It now includes cache reads and writes, matching how the session cost is already computed.
 - Agents in auto-accept mode showed a false "Allow Bash?" prompt: a tool running without asking looks the same on disk as one awaiting permission. Toki now reads the session's permission mode and only flags a prompt in a mode that would actually ask.
+- Several agents in one project folder all showed the same title and token usage, because Toki could only find the folder's newest session. Each agent now prefers the session file created closest to when it launched, and any titles that still match get a terminal-tty marker so the rows stay distinct.
 
 ## 2.4.1 - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Release builds now strip symbol tables from the binary before signing, cutting the shipped app bundle from 5.3MB to 2.3MB.
 
+### Fixed
+
+- Clicking an active agent running inside tmux did nothing. tmux runs panes under a detached server, so the walk up from the agent to its terminal dead-ended; Toki now hops through tmux to the attached client and focuses the terminal hosting it.
+
 ## 2.4.1 - 2026-07-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - An agent's "in" token count showed only uncached input, reading as a few hundred tokens against a six-figure context. It now includes cache reads and writes, matching how the session cost is already computed.
 - Agents in auto-accept mode showed a false "Allow Bash?" prompt: a tool running without asking looks the same on disk as one awaiting permission. Toki now reads the session's permission mode and only flags a prompt in a mode that would actually ask.
 - Several agents in one project folder all showed the same title and token usage, because Toki could only find the folder's newest session. Each agent now prefers the session file created closest to when it launched, and any titles that still match get a terminal-tty marker so the rows stay distinct.
+- With the menu bar set to auto-hide, opening Toki could drop the popover in the top-left corner: the status item reports an unsettled far-left position mid-reveal. Toki now rejects that jump and anchors near the icon instead.
 
 ### Codex
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version 2.4.1" src="https://img.shields.io/badge/version-2.4.1-2f80ed">
+  <img alt="Version 2.4.2" src="https://img.shields.io/badge/version-2.4.2-2f80ed">
   <img alt="Downloads" src="https://img.shields.io/github/downloads/aashutoshrathi/toki/total">
   <img alt="Stars" src="https://img.shields.io/github/stars/aashutoshrathi/toki">
   <img alt="macOS 14+" src="https://img.shields.io/badge/macOS-14%2B-111111">
@@ -25,7 +25,7 @@
   <tr><th style="width:50%">Menu bar</th><th style="width:50%">CLI</th></tr>
   <tr>
     <td><img src="https://files.aashutosh.dev/toki-preview.png" alt="Toki menu bar popover preview" width="360"></td>
-    <td><pre>            @@@@ @@@@             <br>   @@@@@@@@@@@     @@@@@@@        <br>   @@@@@@@@@@@     @@@@@@@        <br>            @@@@@@@@@             <br>              @@@@@               <br>               @@@                  /toki<br>               @@@    @@@           v2.4.1<br>               @@@   @@@@           github.com/aashutoshrathi/toki<br>               @@@@@@@@@          <br>               @@@@@@@            <br>               @@@@@              <br>               @@@@               <br>               @@@@@              <br>                @@@@@@@@@@        <br><br>Claude San: 85% left<br>Codex: 0% left<br>OpenCode: No usage today<br>Pi: $0.01 today</pre></td>
+    <td><pre>            @@@@ @@@@             <br>   @@@@@@@@@@@     @@@@@@@        <br>   @@@@@@@@@@@     @@@@@@@        <br>            @@@@@@@@@             <br>              @@@@@               <br>               @@@                  /toki<br>               @@@    @@@           v2.4.2<br>               @@@   @@@@           github.com/aashutoshrathi/toki<br>               @@@@@@@@@          <br>               @@@@@@@            <br>               @@@@@              <br>               @@@@               <br>               @@@@@              <br>                @@@@@@@@@@        <br><br>Claude San: 85% left<br>Codex: 0% left<br>OpenCode: No usage today<br>Pi: $0.01 today</pre></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@
 </p>
 
 <table>
-  <tr><th style="width:60%"">Menu bar</th><th style="width:50%">CLI</th></tr>
+  <tr><th style="width:50%">Menu bar</th><th style="width:50%">CLI</th></tr>
   <tr>
-    <td><img src="https://files.aashutosh.dev/toki-preview.png" alt="Toki menu bar popover preview" width="60%"></td>
+    <td><img src="https://files.aashutosh.dev/toki-preview.png" alt="Toki menu bar popover preview" width="100%"></td>
     <td><pre>            @@@@ @@@@             <br>   @@@@@@@@@@@     @@@@@@@        <br>   @@@@@@@@@@@     @@@@@@@        <br>            @@@@@@@@@             <br>              @@@@@               <br>               @@@                  /toki<br>               @@@    @@@           v2.4.2<br>               @@@   @@@@           github.com/aashutoshrathi/toki<br>               @@@@@@@@@          <br>               @@@@@@@            <br>               @@@@@              <br>               @@@@               <br>               @@@@@              <br>                @@@@@@@@@@        <br><br>Claude San: 85% left<br>Codex: 0% left<br>OpenCode: No usage today<br>Pi: $0.01 today</pre></td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@
 </p>
 
 <table>
-  <tr><th style="width:50%">Menu bar</th><th style="width:50%">CLI</th></tr>
+  <tr><th style="width:60%"">Menu bar</th><th style="width:50%">CLI</th></tr>
   <tr>
-    <td><img src="https://files.aashutosh.dev/toki-preview.png" alt="Toki menu bar popover preview" width="360"></td>
+    <td><img src="https://files.aashutosh.dev/toki-preview.png" alt="Toki menu bar popover preview" width="60%"></td>
     <td><pre>            @@@@ @@@@             <br>   @@@@@@@@@@@     @@@@@@@        <br>   @@@@@@@@@@@     @@@@@@@        <br>            @@@@@@@@@             <br>              @@@@@               <br>               @@@                  /toki<br>               @@@    @@@           v2.4.2<br>               @@@   @@@@           github.com/aashutoshrathi/toki<br>               @@@@@@@@@          <br>               @@@@@@@            <br>               @@@@@              <br>               @@@@               <br>               @@@@@              <br>                @@@@@@@@@@        <br><br>Claude San: 85% left<br>Codex: 0% left<br>OpenCode: No usage today<br>Pi: $0.01 today</pre></td>
   </tr>
 </table>

--- a/Sources/Toki/API/AnthropicUsageClient.swift
+++ b/Sources/Toki/API/AnthropicUsageClient.swift
@@ -10,37 +10,17 @@ struct AnthropicUsageClient {
         async let rateLimits = fetchRateLimits(apiKey: key)
         let (tokenUsage, monthlyCost, tokenLimitPerMinute) = try await (usage, costs, rateLimits)
 
-        let tokenBudget = account.dailyTokenBudget
-        let tokenRemaining = tokenBudget.map { max($0 - tokenUsage.totalTokens, 0) }
-        let tokenRatio: Double?
-        if let tokenBudget, tokenBudget > 0, let tokenRemaining {
-            tokenRatio = tokenRemaining / tokenBudget
-        } else {
-            tokenRatio = nil
-        }
-
-        var metrics = [
-            MetricLine(label: "Today", value: "\(formatCompact(tokenUsage.totalTokens)) tokens"),
-            MetricLine(label: "Input", value: formatCompact(tokenUsage.inputTokens)),
-            MetricLine(label: "Output", value: formatCompact(tokenUsage.outputTokens)),
-            MetricLine(label: "Month", value: formatUSD(monthlyCost))
-        ]
-
+        var extraMetrics: [MetricLine] = []
         if tokenLimitPerMinute > 0 {
-            metrics.append(MetricLine(label: "Rate limit", value: "\(formatCompact(tokenLimitPerMinute)) tok/min"))
-        }
-        if let budget = account.monthlyUsdBudget {
-            metrics.append(MetricLine(label: "Budget", value: "\(formatUSD(max(budget - monthlyCost, 0))) left"))
+            extraMetrics.append(MetricLine(label: "Rate limit", value: "\(formatCompact(tokenLimitPerMinute)) tok/min"))
         }
 
-        return AccountSnapshot(
-            id: account.id,
-            name: account.name,
+        return account.tokenBudgetSnapshot(
             provider: .anthropic,
-            primary: tokenRemaining.map { "\(formatCompact($0)) tokens left" } ?? "\(formatCompact(tokenUsage.totalTokens)) today",
-            subtitle: tokenRatio.map { "\(Int(($0 * 100).rounded()))% of daily token budget" } ?? "Usage from Anthropic Admin API",
-            remainingRatio: tokenRatio,
-            metrics: metrics
+            usage: tokenUsage,
+            monthlyCost: monthlyCost,
+            subtitleFallback: "Usage from Anthropic Admin API",
+            extraMetrics: extraMetrics
         )
     }
 

--- a/Sources/Toki/API/OpenAIUsageClient.swift
+++ b/Sources/Toki/API/OpenAIUsageClient.swift
@@ -9,34 +9,11 @@ struct OpenAIUsageClient {
         async let costs = fetchCosts(apiKey: key)
         let (tokenUsage, monthlyCost) = try await (usage, costs)
 
-        let tokenBudget = account.dailyTokenBudget
-        let tokenRemaining = tokenBudget.map { max($0 - tokenUsage.totalTokens, 0) }
-        let tokenRatio: Double?
-        if let tokenBudget, tokenBudget > 0, let tokenRemaining {
-            tokenRatio = tokenRemaining / tokenBudget
-        } else {
-            tokenRatio = nil
-        }
-
-        var metrics = [
-            MetricLine(label: "Today", value: "\(formatCompact(tokenUsage.totalTokens)) tokens"),
-            MetricLine(label: "Input", value: formatCompact(tokenUsage.inputTokens)),
-            MetricLine(label: "Output", value: formatCompact(tokenUsage.outputTokens)),
-            MetricLine(label: "Month", value: formatUSD(monthlyCost))
-        ]
-
-        if let budget = account.monthlyUsdBudget {
-            metrics.append(MetricLine(label: "Budget", value: "\(formatUSD(max(budget - monthlyCost, 0))) left"))
-        }
-
-        return AccountSnapshot(
-            id: account.id,
-            name: account.name,
+        return account.tokenBudgetSnapshot(
             provider: .openai,
-            primary: tokenRemaining.map { "\(formatCompact($0)) tokens left" } ?? "\(formatCompact(tokenUsage.totalTokens)) today",
-            subtitle: tokenRatio.map { "\(Int(($0 * 100).rounded()))% of daily token budget" } ?? "Usage from organization admin API",
-            remainingRatio: tokenRatio,
-            metrics: metrics
+            usage: tokenUsage,
+            monthlyCost: monthlyCost,
+            subtitleFallback: "Usage from organization admin API"
         )
     }
 

--- a/Sources/Toki/API/TokenBudgetSnapshot.swift
+++ b/Sources/Toki/API/TokenBudgetSnapshot.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+extension AccountConfig {
+    // The Anthropic and OpenAI admin APIs return the same shape — a day's token usage plus a
+    // month-to-date cost — and turn it into an identical card. This builds that card once:
+    // the daily-budget ratio, the Today/Input/Output/Month metrics, an optional monthly-budget
+    // line, and the primary/subtitle text. Providers pass their own `extraMetrics` (e.g. a rate
+    // limit), which land after Month and before Budget, and a `subtitleFallback` for when no
+    // daily budget is configured.
+    func tokenBudgetSnapshot(
+        provider: Provider,
+        usage: TokenUsage,
+        monthlyCost: Double,
+        subtitleFallback: String,
+        extraMetrics: [MetricLine] = []
+    ) -> AccountSnapshot {
+        let tokenRemaining = dailyTokenBudget.map { max($0 - usage.totalTokens, 0) }
+        let tokenRatio: Double?
+        if let dailyTokenBudget, dailyTokenBudget > 0, let tokenRemaining {
+            tokenRatio = tokenRemaining / dailyTokenBudget
+        } else {
+            tokenRatio = nil
+        }
+
+        var metrics = [
+            MetricLine(label: "Today", value: "\(formatCompact(usage.totalTokens)) tokens"),
+            MetricLine(label: "Input", value: formatCompact(usage.inputTokens)),
+            MetricLine(label: "Output", value: formatCompact(usage.outputTokens)),
+            MetricLine(label: "Month", value: formatUSD(monthlyCost))
+        ]
+        metrics.append(contentsOf: extraMetrics)
+        if let monthlyUsdBudget {
+            metrics.append(MetricLine(label: "Budget", value: "\(formatUSD(max(monthlyUsdBudget - monthlyCost, 0))) left"))
+        }
+
+        return AccountSnapshot(
+            id: id,
+            name: name,
+            provider: provider,
+            primary: tokenRemaining.map { "\(formatCompact($0)) tokens left" } ?? "\(formatCompact(usage.totalTokens)) today",
+            subtitle: tokenRatio.map { "\(Int(($0 * 100).rounded()))% of daily token budget" } ?? subtitleFallback,
+            remainingRatio: tokenRatio,
+            metrics: metrics
+        )
+    }
+}

--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -241,11 +241,16 @@ enum ActiveAgentScanner {
         let cwd = reusable?.directory
             ?? AgentSessionResolver.workingDirectory(fromCommand: c.command)
             ?? AgentSessionResolver.workingDirectory(ofPID: c.pid)
-        // Only when the cache can't answer: this walks the process tree with up to eight
-        // `ps` calls per agent.
-        let resolvedHost = reusable == nil ? AgentSessionResolver.hostApp(ofPID: c.pid, terminalTTY: c.tty) : nil
-        let hostApp = reusable?.hostApp ?? resolvedHost?.app
-        let hostProcessID = reusable?.hostProcessID ?? resolvedHost?.processID
+        // Resolving walks the process tree with up to eight `ps` calls, so it's cached. Reuse a
+        // cached host only when it actually resolved, or when there's no tty to resolve one from
+        // (a ttyless background agent has no host, and re-walking every scan is the cost the
+        // cache exists to avoid). A cached-nil host on a tty-bearing agent is usually a detached
+        // tmux session that has no attached client yet; re-resolve those each scan so navigation
+        // starts working once the user attaches one, rather than staying nil for the PID's life.
+        let cachedHost = reusable.flatMap { $0.hostApp != nil || c.tty == nil ? $0 : nil }
+        let resolvedHost = cachedHost == nil ? AgentSessionResolver.hostApp(ofPID: c.pid, terminalTTY: c.tty) : nil
+        let hostApp = cachedHost?.hostApp ?? resolvedHost?.app
+        let hostProcessID = cachedHost?.hostProcessID ?? resolvedHost?.processID
         // When agents share a project folder, the session file created nearest this process's
         // launch is the one it opened; pass the start time so each resolves its own session.
         let startTime = startDate(fromETime: c.runtime)

--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -262,26 +262,38 @@ enum ActiveAgentNavigator {
 
     private static func activateHostApp(for agent: ActiveAgent) {
         // By PID first: two builds of a terminal share a bundle identifier, so an
-        // identifier lookup can raise the copy that does not hold this agent.
+        // identifier lookup can raise the copy that does not hold this agent. Only when
+        // that PID is a regular activatable app, though: VS Code's integrated terminal runs
+        // under a "Code Helper" process whose activation policy is .prohibited, so activating
+        // it silently does nothing - the click has to fall through to the real app below.
         if let hostProcessID = agent.hostProcessID,
-           let running = NSRunningApplication(processIdentifier: pid_t(hostProcessID)) {
+           let running = NSRunningApplication(processIdentifier: pid_t(hostProcessID)),
+           running.activationPolicy == .regular {
             running.activate(options: [.activateAllWindows])
             return
         }
 
-        // Fall back to identity when the ancestry walk found nothing.
-        var bundleIDs: [String] = []
-        if let host = agent.hostApp {
-            bundleIDs.append(host.bundleID)
+        // Fall back to identity: for a helper-hosted app (VS Code) this raises the real app.
+        // The host's own bundle id is matched first and exactly, so with both VS Code and VS
+        // Code Insiders running the click lands on the variant that actually holds the agent
+        // rather than whichever the system happens to list first.
+        if let host = agent.hostApp, activate(bundleID: host.bundleID) {
+            return
         }
-        bundleIDs.append(contentsOf: ["com.googlecode.iterm2", "com.apple.Terminal", "com.microsoft.VSCode"])
-        if let application = NSWorkspace.shared.runningApplications.first(where: { app in
-            app.bundleIdentifier.map(bundleIDs.contains) == true
-        }) {
-            application.activate(options: [.activateAllWindows])
-        } else {
-            DiagnosticLogger.shared.record(.warning, component: "agents", code: "navigation_unavailable")
+        // Only when the ancestry walk named no host: raise any known terminal that's running.
+        for bundleID in ["com.googlecode.iterm2", "com.apple.Terminal", "com.microsoft.VSCode"] where activate(bundleID: bundleID) {
+            return
         }
+        DiagnosticLogger.shared.record(.warning, component: "agents", code: "navigation_unavailable")
+    }
+
+    @discardableResult
+    private static func activate(bundleID: String) -> Bool {
+        guard let application = NSWorkspace.shared.runningApplications.first(where: {
+            $0.activationPolicy == .regular && $0.bundleIdentifier == bundleID
+        }) else { return false }
+        application.activate(options: [.activateAllWindows])
+        return true
     }
 
     nonisolated private static func isSafeTTY(_ value: String) -> Bool {

--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -200,7 +200,7 @@ enum ActiveAgentScanner {
             ?? AgentSessionResolver.workingDirectory(ofPID: c.pid)
         // Only when the cache can't answer: this walks the process tree with up to eight
         // `ps` calls per agent.
-        let resolvedHost = reusable == nil ? AgentSessionResolver.hostApp(ofPID: c.pid) : nil
+        let resolvedHost = reusable == nil ? AgentSessionResolver.hostApp(ofPID: c.pid, terminalTTY: c.tty) : nil
         let hostApp = reusable?.hostApp ?? resolvedHost?.app
         let hostProcessID = reusable?.hostProcessID ?? resolvedHost?.processID
         let chatTitle = AgentSessionResolver.chatTitle(provider: c.provider, command: c.command, cwd: cwd)

--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -110,12 +110,15 @@ enum ActiveAgentScanner {
         let memoryKB: Int
     }
 
-    // Immutable-per-process fields cached by PID; `command` guards against PID reuse.
+    // Immutable-per-process fields cached by PID; `command` guards against PID reuse. A tmux
+    // host is the exception - it can change under a stable PID - so `hostViaTmux` marks entries
+    // that must be re-resolved each scan rather than reused.
     private struct CacheEntry {
         let command: String
         let directory: String?
         let hostApp: HostApp?
         let hostProcessID: Int32?
+        let hostViaTmux: Bool
     }
     private nonisolated(unsafe) static var cache: [Int32: CacheEntry] = [:]
 
@@ -242,15 +245,20 @@ enum ActiveAgentScanner {
             ?? AgentSessionResolver.workingDirectory(fromCommand: c.command)
             ?? AgentSessionResolver.workingDirectory(ofPID: c.pid)
         // Resolving walks the process tree with up to eight `ps` calls, so it's cached. Reuse a
-        // cached host only when it actually resolved, or when there's no tty to resolve one from
-        // (a ttyless background agent has no host, and re-walking every scan is the cost the
-        // cache exists to avoid). A cached-nil host on a tty-bearing agent is usually a detached
-        // tmux session that has no attached client yet; re-resolve those each scan so navigation
-        // starts working once the user attaches one, rather than staying nil for the PID's life.
-        let cachedHost = reusable.flatMap { $0.hostApp != nil || c.tty == nil ? $0 : nil }
+        // cached host only when it's a settled one: a resolved, non-tmux host (a stable terminal
+        // like iTerm or VS Code), or a ttyless agent that has no host to find (re-walking those
+        // every scan is the cost the cache exists to avoid). Re-resolve everything else each
+        // scan - a cached-nil host on a tty-bearing agent (a detached tmux pane awaiting a
+        // client) and any tmux host (whose client can change under a stable PID).
+        let cachedHost = reusable.flatMap { entry -> CacheEntry? in
+            if entry.hostApp != nil, !entry.hostViaTmux { return entry }
+            if entry.hostApp == nil, c.tty == nil { return entry }
+            return nil
+        }
         let resolvedHost = cachedHost == nil ? AgentSessionResolver.hostApp(ofPID: c.pid, terminalTTY: c.tty) : nil
         let hostApp = cachedHost?.hostApp ?? resolvedHost?.app
         let hostProcessID = cachedHost?.hostProcessID ?? resolvedHost?.processID
+        let hostViaTmux = cachedHost?.hostViaTmux ?? (resolvedHost?.viaTmux ?? false)
         // When agents share a project folder, the session file created nearest this process's
         // launch is the one it opened; pass the start time so each resolves its own session.
         let startTime = startDate(fromETime: c.runtime)
@@ -271,7 +279,7 @@ enum ActiveAgentScanner {
             sessionUsage: AgentSessionResolver.sessionUsage(provider: c.provider, command: c.command, cwd: cwd, startTime: startTime),
             attention: AgentSessionResolver.attention(provider: c.provider, command: c.command, cwd: cwd, startTime: startTime)
         )
-        cache[c.pid] = CacheEntry(command: c.command, directory: cwd, hostApp: hostApp, hostProcessID: hostProcessID)
+        cache[c.pid] = CacheEntry(command: c.command, directory: cwd, hostApp: hostApp, hostProcessID: hostProcessID, hostViaTmux: hostViaTmux)
         return agent
     }
 }

--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -60,11 +60,20 @@ struct ActiveAgent: Identifiable, Hashable, Sendable {
     let sessionUsage: AgentSessionUsage?
     // Set when the session is parked waiting on the user (a question or a permission prompt).
     let attention: AgentAttention?
+    // A short marker (the terminal tty) appended to the title only when another agent would
+    // otherwise show the same one - several agents in one project can resolve to the same
+    // session, and identical rows can't be told apart. Set by a post-scan pass.
+    var disambiguator: String? = nil
 
     var needsInput: Bool { attention != nil }
 
     // Primary label: the conversation title, else the project folder, else the provider.
     var title: String {
+        guard let disambiguator else { return baseTitle }
+        return "\(baseTitle) · \(disambiguator)"
+    }
+
+    private var baseTitle: String {
         if let chatTitle { return chatTitle }
         if let folder = directory.map({ ($0 as NSString).lastPathComponent }), !folder.isEmpty, folder != "/" {
             return folder
@@ -122,7 +131,7 @@ enum ActiveAgentScanner {
                     possibleParent.pid == candidate.parentPID && possibleParent.provider == candidate.provider
                 }
             }
-            let agents = roots.map(enrich)
+            let agents = disambiguate(roots.map(enrich))
             // Drop cache entries for PIDs that are no longer running.
             let alive = Set(candidates.map(\.pid))
             cache = cache.filter { alive.contains($0.key) }
@@ -191,6 +200,40 @@ enum ActiveAgentScanner {
         return nil
     }
 
+    // Appends the terminal tty to any title shared by two or more agents, so several sessions
+    // in one project folder (which can resolve to the same title) render as distinct rows that
+    // each still open their own terminal.
+    static func disambiguate(_ agents: [ActiveAgent]) -> [ActiveAgent] {
+        let collisions = Dictionary(grouping: agents, by: \.title).filter { $0.value.count > 1 }
+        guard !collisions.isEmpty else { return agents }
+        return agents.map { agent in
+            guard collisions[agent.title] != nil, let tty = agent.terminalTTY else { return agent }
+            var marked = agent
+            marked.disambiguator = tty.hasPrefix("/dev/") ? String(tty.dropFirst(5)) : tty
+            return marked
+        }
+    }
+
+    // A process's launch time, from `ps etime` ([[dd-]hh:]mm:ss) counted back from now, so a
+    // session file's creation time can be matched to the agent that opened it.
+    static func startDate(fromETime etime: String) -> Date? {
+        var rest = Substring(etime)
+        var days = 0
+        if let dash = rest.firstIndex(of: "-") {
+            days = Int(rest[..<dash]) ?? 0
+            rest = rest[rest.index(after: dash)...]
+        }
+        let parts = rest.split(separator: ":").map { Int($0) ?? 0 }
+        let hms: Int
+        switch parts.count {
+        case 3: hms = parts[0] * 3600 + parts[1] * 60 + parts[2]
+        case 2: hms = parts[0] * 60 + parts[1]
+        case 1: hms = parts[0]
+        default: return nil
+        }
+        return Date().addingTimeInterval(-TimeInterval(days * 86400 + hms))
+    }
+
     // cwd and host app are cached; title and activity change as the session evolves.
     private static func enrich(_ c: Candidate) -> ActiveAgent {
         let cached = cache[c.pid]
@@ -203,7 +246,10 @@ enum ActiveAgentScanner {
         let resolvedHost = reusable == nil ? AgentSessionResolver.hostApp(ofPID: c.pid, terminalTTY: c.tty) : nil
         let hostApp = reusable?.hostApp ?? resolvedHost?.app
         let hostProcessID = reusable?.hostProcessID ?? resolvedHost?.processID
-        let chatTitle = AgentSessionResolver.chatTitle(provider: c.provider, command: c.command, cwd: cwd)
+        // When agents share a project folder, the session file created nearest this process's
+        // launch is the one it opened; pass the start time so each resolves its own session.
+        let startTime = startDate(fromETime: c.runtime)
+        let chatTitle = AgentSessionResolver.chatTitle(provider: c.provider, command: c.command, cwd: cwd, startTime: startTime)
         let agent = ActiveAgent(
             id: c.pid,
             provider: c.provider,
@@ -211,14 +257,14 @@ enum ActiveAgentScanner {
             chatTitle: chatTitle,
             hostApp: hostApp,
             hostProcessID: hostProcessID,
-            lastActivity: AgentSessionResolver.lastActivity(provider: c.provider, command: c.command, cwd: cwd),
+            lastActivity: AgentSessionResolver.lastActivity(provider: c.provider, command: c.command, cwd: cwd, startTime: startTime),
             processID: c.pid,
             runtime: c.runtime,
             terminalTTY: c.tty,
             memoryKB: c.memoryKB,
             command: c.command,
-            sessionUsage: AgentSessionResolver.sessionUsage(provider: c.provider, command: c.command, cwd: cwd),
-            attention: AgentSessionResolver.attention(provider: c.provider, command: c.command, cwd: cwd)
+            sessionUsage: AgentSessionResolver.sessionUsage(provider: c.provider, command: c.command, cwd: cwd, startTime: startTime),
+            attention: AgentSessionResolver.attention(provider: c.provider, command: c.command, cwd: cwd, startTime: startTime)
         )
         cache[c.pid] = CacheEntry(command: c.command, directory: cwd, hostApp: hostApp, hostProcessID: hostProcessID)
         return agent

--- a/Sources/Toki/Agents/AgentSessionResolver.swift
+++ b/Sources/Toki/Agents/AgentSessionResolver.swift
@@ -293,20 +293,88 @@ enum AgentSessionResolver {
 
     // Walks the process ancestry for the hosting app. Returns the PID too: two builds of a
     // terminal share a bundle identifier, so identity alone cannot pick the right copy.
-    static func hostApp(ofPID pid: Int32) -> (app: HostApp, processID: Int32)? {
+    //
+    // tmux breaks the ancestry: a pane's processes descend from the detached tmux *server*
+    // (parented to launchd), not from the terminal displaying them. When the walk reaches
+    // the server, `terminalTTY` (the pane's tty) lets us ask tmux which client is attached
+    // to this pane's session and resume from there — that client does descend from the
+    // real terminal app.
+    static func hostApp(ofPID pid: Int32, terminalTTY: String? = nil) -> (app: HostApp, processID: Int32)? {
         var current = pid
         for _ in 0..<8 {
             guard let output = Shell.output("/bin/ps", ["-o", "ppid=,comm=", "-p", "\(current)"]) else { return nil }
             let parts = output.trimmingCharacters(in: .whitespacesAndNewlines)
                 .split(maxSplits: 1, whereSeparator: { $0.isWhitespace })
             guard parts.count == 2, let ppid = Int32(parts[0]) else { return nil }
-            if let app = HostApp.match(comm: String(parts[1]).lowercased()) {
+            let comm = String(parts[1]).lowercased()
+            if let app = HostApp.match(comm: comm) {
                 return (app, current)
+            }
+            if comm.contains("tmux") {
+                return tmuxClientHostApp(paneTTY: terminalTTY, serverPID: current)
             }
             if ppid <= 1 { return nil }
             current = ppid
         }
         return nil
+    }
+
+    // Resolves the terminal hosting a tmux pane by finding a client attached to the pane's
+    // session and walking up from that client's process. Best effort: it needs a client
+    // currently attached (a detached session isn't shown anywhere to focus) and the tmux
+    // binary present in a standard location.
+    private static func tmuxClientHostApp(paneTTY: String?, serverPID: Int32) -> (app: HostApp, processID: Int32)? {
+        guard let paneTTY,
+              let tmux = tmuxBinary(),
+              let socket = tmuxSocket(serverPID: serverPID) else { return nil }
+        let wantedTTY = normalizedTTY(paneTTY)
+
+        guard let session = tmuxField(tmux, socket, ["list-panes", "-a", "-F", "#{pane_tty}\t#{session_name}"])
+            .first(where: { normalizedTTY($0.0) == wantedTTY })?.1 else { return nil }
+
+        for (clientSession, clientPID) in tmuxField(tmux, socket, ["list-clients", "-F", "#{session_name}\t#{client_pid}"])
+        where clientSession == session {
+            // The client process is itself named `tmux`, so start one level up to avoid
+            // re-detecting tmux and looping; its parent chain descends from the terminal.
+            guard let pid = Int32(clientPID), let parent = parentPID(ofPID: pid) else { continue }
+            if let resolved = hostApp(ofPID: parent) { return resolved }
+        }
+        return nil
+    }
+
+    // Splits a two-column tab-separated tmux `-F` listing into pairs. The server is targeted
+    // by its own socket so a custom `-L`/`-S` server resolves like the default one.
+    private static func tmuxField(_ tmux: String, _ socket: String, _ args: [String]) -> [(String, String)] {
+        guard let output = Shell.output(tmux, ["-S", socket] + args) else { return [] }
+        return output.split(separator: "\n").compactMap { line in
+            let cols = line.split(separator: "\t", maxSplits: 1, omittingEmptySubsequences: false).map(String.init)
+            return cols.count == 2 ? (cols[0], cols[1]) : nil
+        }
+    }
+
+    private static func tmuxBinary() -> String? {
+        ["/opt/homebrew/bin/tmux", "/usr/local/bin/tmux", "/opt/local/bin/tmux", "/usr/bin/tmux"]
+            .first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+
+    // The server's listening socket, read from its open unix-domain sockets so `-S` can
+    // target this exact server rather than assuming the default socket path.
+    private static func tmuxSocket(serverPID: Int32) -> String? {
+        guard let output = Shell.output("/usr/sbin/lsof", ["-a", "-p", "\(serverPID)", "-U", "-Fn"]) else { return nil }
+        for line in output.split(separator: "\n") where line.hasPrefix("n") {
+            let path = String(line.dropFirst())
+            if path.contains("/tmux-") { return path }
+        }
+        return nil
+    }
+
+    private static func parentPID(ofPID pid: Int32) -> Int32? {
+        guard let output = Shell.output("/bin/ps", ["-o", "ppid=", "-p", "\(pid)"]) else { return nil }
+        return Int32(output.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    private static func normalizedTTY(_ tty: String) -> String {
+        tty.hasPrefix("/dev/") ? String(tty.dropFirst(5)) : tty
     }
 
     static func workingDirectory(ofPID pid: Int32) -> String? {

--- a/Sources/Toki/Agents/AgentSessionResolver.swift
+++ b/Sources/Toki/Agents/AgentSessionResolver.swift
@@ -147,15 +147,21 @@ enum AgentSessionResolver {
                    .map({ seenMessages.insert($0).inserted }) ?? true {
                 let input = (usage["input_tokens"] as? Int) ?? 0
                 let output = (usage["output_tokens"] as? Int) ?? 0
-                totalInput += input
+                let cacheWrite = (usage["cache_creation_input_tokens"] as? Int) ?? 0
+                let cacheRead = (usage["cache_read_input_tokens"] as? Int) ?? 0
+                // Cache reads and writes are input the model processed, and dominate a Claude
+                // Code turn - the raw `input_tokens` alone reads as a few hundred tokens against
+                // a real six-figure context. Counting them keeps "in" honest and consistent
+                // with the cost below, which already prices all four token classes.
+                totalInput += input + cacheWrite + cacheRead
                 totalOutput += output
                 if let model = message["model"] as? String,
                    let cost = ModelPricing.costUSD(
                        model: model,
                        inputTokens: input,
                        outputTokens: output,
-                       cacheWriteTokens: (usage["cache_creation_input_tokens"] as? Int) ?? 0,
-                       cacheReadTokens: (usage["cache_read_input_tokens"] as? Int) ?? 0
+                       cacheWriteTokens: cacheWrite,
+                       cacheReadTokens: cacheRead
                    ) {
                     totalCost = (totalCost ?? 0) + cost
                 }

--- a/Sources/Toki/Agents/AgentSessionResolver.swift
+++ b/Sources/Toki/Agents/AgentSessionResolver.swift
@@ -4,10 +4,10 @@ import Foundation
 // stores.
 enum AgentSessionResolver {
     // The human/AI-assigned conversation title, if the provider records one.
-    static func chatTitle(provider: Provider, command: String, cwd: String?) -> String? {
+    static func chatTitle(provider: Provider, command: String, cwd: String?, startTime: Date? = nil) -> String? {
         switch provider {
         case .claudeCode, .claude, .anthropic:
-            return claudeChatTitle(command: command, cwd: cwd)
+            return claudeChatTitle(command: command, cwd: cwd, startTime: startTime)
         case .openCode:
             return openCodeChatTitle(cwd: cwd)
         case .grok:
@@ -20,24 +20,24 @@ enum AgentSessionResolver {
     }
 
     // Per-session cost and token usage, resolved from local session data when available.
-    static func sessionUsage(provider: Provider, command: String, cwd: String?) -> AgentSessionUsage? {
+    static func sessionUsage(provider: Provider, command: String, cwd: String?, startTime: Date? = nil) -> AgentSessionUsage? {
         switch provider {
         case .openCode:
             return openCodeSessionUsage(cwd: cwd)
         case .pi:
             return piSessionUsage(cwd: cwd)
         case .claudeCode, .claude, .anthropic:
-            return claudeSessionUsage(command: command, cwd: cwd)
+            return claudeSessionUsage(command: command, cwd: cwd, startTime: startTime)
         default:
             return nil
         }
     }
 
     // Whether the session is parked waiting on the user, and what it's waiting for.
-    static func attention(provider: Provider, command: String, cwd: String?) -> AgentAttention? {
+    static func attention(provider: Provider, command: String, cwd: String?, startTime: Date? = nil) -> AgentAttention? {
         switch provider {
         case .claudeCode, .claude, .anthropic:
-            guard let session = newestClaudeSession(command: command, cwd: cwd),
+            guard let session = newestClaudeSession(command: command, cwd: cwd, nearStart: startTime),
                   let parsed = claudeSession(at: session.path, modified: session.modified) else { return nil }
             return attention(from: parsed, modified: session.modified, now: Date())
         case .openCode:
@@ -215,10 +215,10 @@ enum AgentSessionResolver {
     }
 
     // When the agent's session was last written - used to sort most-recent first.
-    static func lastActivity(provider: Provider, command: String, cwd: String?) -> Date? {
+    static func lastActivity(provider: Provider, command: String, cwd: String?, startTime: Date? = nil) -> Date? {
         switch provider {
         case .claudeCode, .claude, .anthropic:
-            return newestClaudeSession(command: command, cwd: cwd)?.modified
+            return newestClaudeSession(command: command, cwd: cwd, nearStart: startTime)?.modified
         case .openCode:
             return openCodeLastActivity(cwd: cwd)
         case .grok:
@@ -265,8 +265,8 @@ enum AgentSessionResolver {
         return Date(timeIntervalSince1970: ms / 1000)
     }
 
-    private static func claudeChatTitle(command: String, cwd: String?) -> String? {
-        guard let file = newestClaudeSession(command: command, cwd: cwd)?.path,
+    private static func claudeChatTitle(command: String, cwd: String?, startTime: Date? = nil) -> String? {
+        guard let file = newestClaudeSession(command: command, cwd: cwd, nearStart: startTime)?.path,
               let contents = try? String(contentsOfFile: file, encoding: .utf8) else {
             return nil
         }
@@ -290,7 +290,7 @@ enum AgentSessionResolver {
         return latestCustom ?? latestAI
     }
 
-    private static func newestClaudeSession(command: String, cwd: String?) -> (path: String, modified: Date?)? {
+    private static func newestClaudeSession(command: String, cwd: String?, nearStart: Date? = nil) -> (path: String, modified: Date?)? {
         // An explicit --resume path wins; otherwise pick the newest file in the project dir.
         if let resume = firstMatch(in: command, pattern: #"--resume\s+([^\s]+\.jsonl)"#) {
             return (resume, modifiedDate(resume))
@@ -303,11 +303,34 @@ enum AgentSessionResolver {
         guard let cwd else { return nil }
         let dir = projectDir(cwd)
         guard let files = try? FileManager.default.contentsOfDirectory(atPath: dir) else { return nil }
-        let newest = files.filter { $0.hasSuffix(".jsonl") }
+        let sessions = files.filter { $0.hasSuffix(".jsonl") }
             .map { (path: "\(dir)/\($0)", modified: modifiedDate("\(dir)/\($0)")) }
-            .max { ($0.modified ?? .distantPast) < ($1.modified ?? .distantPast) }
-        return newest
+
+        // When several agents share one project folder, "newest" hands them all the same file.
+        // If we know when this process launched, prefer the session file created closest to
+        // then - the one this process opened - so same-folder agents resolve distinctly. Only
+        // within a window: a resumed session's file predates the process and must not steal it.
+        if let nearStart {
+            var best: (path: String, modified: Date?)?
+            var bestDistance = sessionStartMatchWindow
+            for session in sessions {
+                guard let created = creationDate(session.path) else { continue }
+                let distance = abs(created.timeIntervalSince(nearStart))
+                if distance <= bestDistance {
+                    bestDistance = distance
+                    best = (session.path, session.modified)
+                }
+            }
+            if let best { return best }
+        }
+
+        return sessions.max { ($0.modified ?? .distantPast) < ($1.modified ?? .distantPast) }
     }
+
+    // How close a session file's creation must be to a process's launch to call it that
+    // process's session. Claude Code writes the file within moments of starting; the margin
+    // absorbs scan latency and clock coarseness without matching an unrelated older session.
+    private static let sessionStartMatchWindow: TimeInterval = 120
 
     private static func openCodeChatTitle(cwd: String?) -> String? {
         guard let cwd, let safe = safeSQLPath(cwd) else { return nil }
@@ -435,6 +458,10 @@ enum AgentSessionResolver {
         (try? FileManager.default.attributesOfItem(atPath: path)[.modificationDate]) as? Date
     }
 
+    private static func creationDate(_ path: String) -> Date? {
+        (try? FileManager.default.attributesOfItem(atPath: path)[.creationDate]) as? Date
+    }
+
     private static func safeSQLPath(_ value: String) -> String? {
         guard value.hasPrefix("/"), !value.contains("'") else { return nil }
         return value
@@ -482,8 +509,8 @@ enum AgentSessionResolver {
         return PiUsageClient.sessionUsage(path: session.path)
     }
 
-    private static func claudeSessionUsage(command: String, cwd: String?) -> AgentSessionUsage? {
-        guard let session = newestClaudeSession(command: command, cwd: cwd) else { return nil }
+    private static func claudeSessionUsage(command: String, cwd: String?, startTime: Date? = nil) -> AgentSessionUsage? {
+        guard let session = newestClaudeSession(command: command, cwd: cwd, nearStart: startTime) else { return nil }
 
         return claudeSession(at: session.path, modified: session.modified)?.usage
     }

--- a/Sources/Toki/Agents/AgentSessionResolver.swift
+++ b/Sources/Toki/Agents/AgentSessionResolver.swift
@@ -52,6 +52,11 @@ enum AgentSessionResolver {
         /// Whether this counts as "blocked" depends on elapsed time, so that is left to the
         /// caller - baking it in here would expire the cache every second.
         var pendingTool: (name: String, question: String?)?
+        /// The session's current permission mode ("auto", "acceptEdits", "plan", "default"),
+        /// last value wins. In auto mode tools run without a prompt, so a pending tool_use is
+        /// executing rather than waiting - the caller uses this to avoid a false permission
+        /// attention.
+        var permissionMode: String?
     }
 
     // Session files reach tens of megabytes and both usage and attention need the same parse.
@@ -122,9 +127,17 @@ enum AgentSessionResolver {
         case "ExitPlanMode", "EnterPlanMode":
             return AgentAttention(kind: .question, prompt: "Waiting on plan approval")
         default:
-            // Any other unanswered tool call is a pending permission prompt.
+            // Auto mode runs every tool without a prompt, and acceptEdits does the same for
+            // file edits, so a lingering tool_use there is a command still executing - not one
+            // waiting on you. Only a mode that would actually prompt yields a permission alert.
+            if parsed.permissionMode == "auto" { return nil }
+            if parsed.permissionMode == "acceptEdits", isAutoAcceptedEdit(pending.name) { return nil }
             return AgentAttention(kind: .permission, prompt: "Allow \(pending.name)?")
         }
+    }
+
+    private static func isAutoAcceptedEdit(_ tool: String) -> Bool {
+        ["Edit", "Write", "MultiEdit", "NotebookEdit"].contains(tool)
     }
 
     static func parseClaudeSession(data: Data) -> ParsedClaudeSession {
@@ -136,10 +149,14 @@ enum AgentSessionResolver {
         // One turn spans several content-block lines that repeat the same cumulative usage;
         // counting each inflated totals ~78%.
         var seenMessages: Set<String> = []
+        var permissionMode: String?
 
         for lineBytes in data.split(separator: 0x0A) {
-            guard let json = try? JSONSerialization.jsonObject(with: Data(lineBytes)) as? [String: Any],
-                  let message = json["message"] as? [String: Any] else { continue }
+            guard let json = try? JSONSerialization.jsonObject(with: Data(lineBytes)) as? [String: Any] else { continue }
+            // Mode-change events and user lines both carry this, and neither has a `message`,
+            // so read it before the guard below skips them.
+            if let mode = json["permissionMode"] as? String { permissionMode = mode }
+            guard let message = json["message"] as? [String: Any] else { continue }
 
             if json["type"] as? String == "assistant",
                let usage = message["usage"] as? [String: Any],
@@ -186,6 +203,7 @@ enum AgentSessionResolver {
         }
 
         var session = ParsedClaudeSession()
+        session.permissionMode = permissionMode
         if totalInput > 0 || totalOutput > 0 {
             session.usage = AgentSessionUsage(cost: totalCost, tokensInput: totalInput, tokensOutput: totalOutput)
         }

--- a/Sources/Toki/Agents/AgentSessionResolver.swift
+++ b/Sources/Toki/Agents/AgentSessionResolver.swift
@@ -295,7 +295,10 @@ enum AgentSessionResolver {
         if let resume = firstMatch(in: command, pattern: #"--resume\s+([^\s]+\.jsonl)"#) {
             return (resume, modifiedDate(resume))
         }
-        if let sid = firstMatch(in: command, pattern: #"--session-id\s+([a-f0-9-]+)"#),
+        // A session id from --resume/-r/--session-id resolves to that file directly. Handling
+        // the bare-id --resume form (the common one) also keeps a resumed process out of the
+        // start-time match below, whose freshly-created sibling would otherwise steal it.
+        if let sid = firstMatch(in: command, pattern: #"(?:--resume|--session-id|-r)\s+([a-f0-9]{8}-[a-f0-9-]+)"#),
            let cwd, case let path = "\(projectDir(cwd))/\(sid).jsonl",
            FileManager.default.fileExists(atPath: path) {
             return (path, modifiedDate(path))
@@ -306,11 +309,15 @@ enum AgentSessionResolver {
         let sessions = files.filter { $0.hasSuffix(".jsonl") }
             .map { (path: "\(dir)/\($0)", modified: modifiedDate("\(dir)/\($0)")) }
 
+        // `--continue` reopens the most recently active session, so newest-by-mtime is right and
+        // the start-time match (which hunts for a freshly created file) would mis-assign a sibling.
+        let resumesMostRecent = firstMatch(in: command, pattern: #"(?:^|\s)(--continue|-c)(?:\s|$)"#) != nil
+
         // When several agents share one project folder, "newest" hands them all the same file.
         // If we know when this process launched, prefer the session file created closest to
         // then - the one this process opened - so same-folder agents resolve distinctly. Only
         // within a window: a resumed session's file predates the process and must not steal it.
-        if let nearStart {
+        if let nearStart, !resumesMostRecent {
             var best: (path: String, modified: Date?)?
             var bestDistance = sessionStartMatchWindow
             for session in sessions {
@@ -346,7 +353,10 @@ enum AgentSessionResolver {
     // the server, `terminalTTY` (the pane's tty) lets us ask tmux which client is attached
     // to this pane's session and resume from there — that client does descend from the
     // real terminal app.
-    static func hostApp(ofPID pid: Int32, terminalTTY: String? = nil) -> (app: HostApp, processID: Int32)? {
+    // `viaTmux` marks a host reached by hopping through the tmux server. Such a host can change
+    // without the agent's PID changing (detach/reattach from another terminal), so the caller
+    // must re-resolve it rather than trust a cached value.
+    static func hostApp(ofPID pid: Int32, terminalTTY: String? = nil) -> (app: HostApp, processID: Int32, viaTmux: Bool)? {
         var current = pid
         for _ in 0..<8 {
             guard let output = Shell.output("/bin/ps", ["-o", "ppid=,comm=", "-p", "\(current)"]) else { return nil }
@@ -355,10 +365,11 @@ enum AgentSessionResolver {
             guard parts.count == 2, let ppid = Int32(parts[0]) else { return nil }
             let comm = String(parts[1]).lowercased()
             if let app = HostApp.match(comm: comm) {
-                return (app, current)
+                return (app, current, false)
             }
             if comm.contains("tmux") {
-                return tmuxClientHostApp(paneTTY: terminalTTY, serverPID: current)
+                guard let resolved = tmuxClientHostApp(paneTTY: terminalTTY, serverPID: current) else { return nil }
+                return (resolved.app, resolved.processID, true)
             }
             if ppid <= 1 { return nil }
             current = ppid
@@ -384,7 +395,7 @@ enum AgentSessionResolver {
             // The client process is itself named `tmux`, so start one level up to avoid
             // re-detecting tmux and looping; its parent chain descends from the terminal.
             guard let pid = Int32(clientPID), let parent = parentPID(ofPID: pid) else { continue }
-            if let resolved = hostApp(ofPID: parent) { return resolved }
+            if let resolved = hostApp(ofPID: parent) { return (resolved.app, resolved.processID) }
         }
         return nil
     }

--- a/Sources/Toki/App/AppDelegate.swift
+++ b/Sources/Toki/App/AppDelegate.swift
@@ -194,12 +194,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         }
     }
 
+    // The status item's last settled on-screen frame, used both to reject a bad transient
+    // position and to anchor the fallback near the icon rather than the screen's centre.
+    private var lastKnownStatusFrame: NSRect?
+
     // `bounds` stays non-empty even off-screen, so convert and require a real display.
     private func hasValidScreenPosition(_ button: NSStatusBarButton) -> Bool {
         guard !button.bounds.isEmpty, let window = button.window else { return false }
         let screenRect = window.convertToScreen(button.convert(button.bounds, to: nil))
         guard screenRect.width > 0, screenRect.height > 0 else { return false }
-        return NSScreen.screens.contains { $0.frame.intersects(screenRect) }
+        guard NSScreen.screens.contains(where: { $0.frame.intersects(screenRect) }) else { return false }
+        // While an auto-hidden menu bar is revealing, the item can briefly report a far-left
+        // origin; anchoring there drops the popover in the top-left corner. A status item doesn't
+        // jump horizontally between clicks, so if this is far from where we last saw it, treat it
+        // as not-yet-settled and let the retry (then fallback) place it near the icon instead.
+        if let last = lastKnownStatusFrame, abs(screenRect.midX - last.midX) > 200 {
+            return false
+        }
+        lastKnownStatusFrame = screenRect
+        return true
     }
 
     // A 1x1 click-through window parked under the menu bar, used only when the status item
@@ -225,7 +238,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         let screen = NSScreen.screens.first { $0.frame.contains(mouse) } ?? NSScreen.main ?? NSScreen.screens.first
         guard let screen, let anchorView = fallbackAnchorWindow.contentView else { return }
 
-        let origin = NSPoint(x: screen.frame.midX, y: screen.visibleFrame.maxY - 1)
+        // Anchor under the icon's last-known x when we have one, so a menu-bar reveal that never
+        // settles still drops the popover near the status item rather than at the screen centre.
+        let anchorX = lastKnownStatusFrame.map { min(max($0.midX, screen.frame.minX + 1), screen.frame.maxX - 1) } ?? screen.frame.midX
+        let origin = NSPoint(x: anchorX, y: screen.visibleFrame.maxY - 1)
         fallbackAnchorWindow.setFrame(NSRect(origin: origin, size: NSSize(width: 1, height: 1)), display: false)
         fallbackAnchorWindow.orderFrontRegardless()
 

--- a/Sources/Toki/App/AppDelegate.swift
+++ b/Sources/Toki/App/AppDelegate.swift
@@ -27,9 +27,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
 
         popover.behavior = .transient
         popover.contentSize = NSSize(width: popoverWidth(), height: popoverHeight())
-        popover.contentViewController = NSHostingController(
+        let hostingController = NSHostingController(
             rootView: MenuContentView(store: store, updateChecker: updateChecker)
         )
+        // Let the popover shrink to the SwiftUI content's height (capped in the view) instead
+        // of always standing at the full popoverHeight and padding out below short content.
+        hostingController.sizingOptions = [.preferredContentSize]
+        popover.contentViewController = hostingController
         popover.delegate = self
 
         updateChecker.startAutomaticChecks()

--- a/Sources/Toki/Config/Constants.swift
+++ b/Sources/Toki/Config/Constants.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-let appVersion = "2.4.1"
+let appVersion = "2.4.2"
 let appUserAgent = "Toki/\(appVersion)"
 let defaultConfigPath = "~/.toki/config.json"
 let defaultStatePath = "~/.toki/usage-state.json"

--- a/Sources/Toki/Models/CodexModels.swift
+++ b/Sources/Toki/Models/CodexModels.swift
@@ -100,6 +100,10 @@ struct CodexRateLimits {
     var resetCreditsAvailable: Int = 0
     var primaryWindow: RateLimitWindow?
     var secondaryWindow: RateLimitWindow?
+    // The soonest reset across all windows, tracked as a unix timestamp so the earliest wins
+    // even when the weekly window rolls over before the 5-hour one.
+    private var earliestResetAt: Double?
+    private var earliestResetText: String?
 
     var hasUsage: Bool {
         !metrics.isEmpty || primary != nil
@@ -119,7 +123,7 @@ struct CodexRateLimits {
         }
         // Surface the soonest window reset in the subtitle too, so the expanded card's header
         // states when quota returns without having to read it off a metric row.
-        if let reset = primaryWindow?.resetHint, let base = subtitle {
+        if let reset = earliestResetText, let base = subtitle {
             subtitle = "\(base) · \(reset.prefix(1).uppercased() + reset.dropFirst())"
         }
         if let resetCredits = data["rateLimitResetCredits"] as? [String: Any],
@@ -165,6 +169,14 @@ struct CodexRateLimits {
         let clampedUsed = max(0, min(100, usedPercent))
         let percentLeft = Int((100 - clampedUsed).rounded())
         let resetText = resetDescriptionFromUnix(firstValue(window, keys: ["resetsAt"])).map { "resets in \($0)" }
+
+        // Track the soonest reset across every window for the subtitle, comparing the raw
+        // timestamps rather than assuming the primary window rolls over first.
+        if let resetsAt = optionalNumber(firstValue(window, keys: ["resetsAt"])), let resetText,
+           resetsAt < (earliestResetAt ?? .greatestFiniteMagnitude) {
+            earliestResetAt = resetsAt
+            earliestResetText = resetText
+        }
 
         if primary == nil {
             primary = "\(percentLeft)% left"

--- a/Sources/Toki/Models/CodexModels.swift
+++ b/Sources/Toki/Models/CodexModels.swift
@@ -117,6 +117,11 @@ struct CodexRateLimits {
         if let secondaryData = limits["secondary"] as? [String: Any] {
             appendWindow(secondaryData, slot: .secondary)
         }
+        // Surface the soonest window reset in the subtitle too, so the expanded card's header
+        // states when quota returns without having to read it off a metric row.
+        if let reset = primaryWindow?.resetHint, let base = subtitle {
+            subtitle = "\(base) · \(reset.prefix(1).uppercased() + reset.dropFirst())"
+        }
         if let resetCredits = data["rateLimitResetCredits"] as? [String: Any],
            let count = optionalNumber(firstValue(resetCredits, keys: ["availableCount"])) {
             resetCreditsAvailable = Int(count)

--- a/Sources/Toki/Store/UsageStore.swift
+++ b/Sources/Toki/Store/UsageStore.swift
@@ -7,6 +7,10 @@ final class UsageStore: ObservableObject {
     @Published var lastUpdated: Date?
     @Published var configError: String?
     @Published var debugMode = false
+    // Masks emails and org identifiers across the UI so screenshots and demos can be shared
+    // without leaking PII. Transient by design - it resets on relaunch so the app never
+    // quietly stays redacted.
+    @Published var hidesSensitiveInfo = false
     @Published var debugLog: [DebugLogEntry] = []
     @Published var preferences = AppPreferences()
     @Published var events: [TokiEvent] = []

--- a/Sources/Toki/Utilities/Formatting.swift
+++ b/Sources/Toki/Utilities/Formatting.swift
@@ -163,3 +163,26 @@ func compactIdentifier(_ value: String) -> String {
     guard value.count > 16 else { return value }
     return "\(value.prefix(8))...\(value.suffix(6))"
 }
+
+// Redaction for sharing screenshots and demos. Masks personally identifying values while
+// keeping their shape recognizable, so a redacted card still reads as "an email" or "an org".
+enum SensitiveText {
+    private static let emailPattern = try? NSRegularExpression(
+        pattern: #"[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}"#,
+        options: .caseInsensitive
+    )
+
+    // Replaces any email address inside `text` with a fixed mask, leaving surrounding text
+    // (e.g. a provider name in a subtitle) intact.
+    static func redactingEmails(_ text: String) -> String {
+        guard let emailPattern else { return text }
+        let range = NSRange(text.startIndex..., in: text)
+        return emailPattern.stringByReplacingMatches(in: text, range: range, withTemplate: "•••••@•••••")
+    }
+
+    // A generic mask for a whole value (org name, org id) - a short run of bullets rather
+    // than the real length, so the character count itself leaks nothing.
+    static func redactedValue(_ value: String) -> String {
+        String(repeating: "•", count: 6)
+    }
+}

--- a/Sources/Toki/Views/AccountCard.swift
+++ b/Sources/Toki/Views/AccountCard.swift
@@ -393,6 +393,9 @@ struct AccountCard: View {
                 ForEach(codexWindows) { window in
                     QuotaSummaryLine(label: window.label, value: "\(window.percentLeft)% left", resetHint: window.resetHint)
                 }
+                if snapshot.resetCreditsAvailable > 0 {
+                    ResetCreditBadge(count: snapshot.resetCreditsAvailable)
+                }
             }
         } else {
             QuotaSummaryLine(label: "current", value: currentSessionAvailability, resetHint: currentResetTime)

--- a/Sources/Toki/Views/AccountCard.swift
+++ b/Sources/Toki/Views/AccountCard.swift
@@ -9,6 +9,7 @@ struct AccountCard: View {
     @State private var aliasDraft = ""
     @FocusState private var aliasFocused: Bool
     @State private var expandedTab: ExpandedTab
+    @State private var confirmingReset = false
 
     private enum ExpandedTab: String, CaseIterable, Identifiable {
         case usage = "Usage"
@@ -190,7 +191,9 @@ struct AccountCard: View {
                 if snapshot.resetCreditsAvailable > 0 {
                     HStack(spacing: 8) {
                         Button {
-                            store.consumeCodexResetCredit(accountID: snapshot.id)
+                            // Same confirm-first flow as the collapsed-card badge; a reset is a
+                            // limited credit, so redeeming always asks first.
+                            confirmingReset = true
                         } label: {
                             if isResetting {
                                 ProgressView()
@@ -202,7 +205,7 @@ struct AccountCard: View {
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
-                        .disabled(isResetting || !canUseResetCredit)
+                        .disabled(isResetting)
                         .help(resetButtonHelp)
                         .pointerOnHover()
                         Spacer()
@@ -394,7 +397,23 @@ struct AccountCard: View {
                     QuotaSummaryLine(label: window.label, value: "\(window.percentLeft)% left", resetHint: window.resetHint)
                 }
                 if snapshot.resetCreditsAvailable > 0 {
-                    ResetCreditBadge(count: snapshot.resetCreditsAvailable)
+                    Button {
+                        confirmingReset = true
+                    } label: {
+                        ResetCreditBadge(count: snapshot.resetCreditsAvailable)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(isResetting)
+                    .pointerOnHover()
+                    .help("Redeem a banked reset to reset this rate-limit window now")
+                    .confirmationDialog("Spend a reset now?", isPresented: $confirmingReset, titleVisibility: .visible) {
+                        Button("Redeem reset", role: .destructive) {
+                            store.consumeCodexResetCredit(accountID: snapshot.id)
+                        }
+                        Button("Cancel", role: .cancel) {}
+                    } message: {
+                        Text(resetWasteWarning)
+                    }
                 }
             }
         } else {
@@ -482,27 +501,23 @@ struct AccountCard: View {
         store.resettingAccountIDs.contains(snapshot.id)
     }
 
-    // Resets are a limited, banked resource - redeeming one while plenty of quota remains
-    // just throws it away. Only allow it once the window is mostly spent. Uses the same
-    // progressRatio (used fraction) the progress bar renders, so it works whether the
-    // snapshot populated progressRatio or only remainingRatio.
-    private var canUseResetCredit: Bool {
-        guard let progressRatio else { return false }
-        return progressRatio >= 0.80
-    }
-
     private var resetButtonTitle: String {
         snapshot.resetCreditsAvailable > 1 ? "Reset now (\(snapshot.resetCreditsAvailable) available)" : "Reset now"
     }
 
     private var resetButtonHelp: String {
-        if canUseResetCredit {
-            return "Redeem a banked reset credit to reset this rate limit window now"
+        "Redeem a banked reset credit to reset this rate limit window now"
+    }
+
+    // A reset is a limited, banked resource: redeeming while quota remains discards the rest
+    // of the current window. State how much is still left so the confirmation is an informed
+    // choice rather than a bare warning.
+    private var resetWasteWarning: String {
+        let leftRatio = snapshot.remainingRatio ?? progressRatio.map { 1 - $0 }
+        guard let percentLeft = leftRatio.map({ Int(($0 * 100).rounded()) }) else {
+            return "A reset is a limited banked credit and redeeming it now discards the quota you haven't used yet. Redeem anyway?"
         }
-        if progressRatio == nil {
-            return "Current usage is unavailable, so Toki can't confirm this reset would be worth spending"
-        }
-        return "Save this reset for when you're closer to the limit (usage must be at least 80% used)"
+        return "You still have \(percentLeft)% of this window left. A reset is a limited banked credit, and redeeming it now discards that remaining quota. Redeem anyway?"
     }
 
     private var statusColor: Color {

--- a/Sources/Toki/Views/AccountCard.swift
+++ b/Sources/Toki/Views/AccountCard.swift
@@ -306,7 +306,7 @@ struct AccountCard: View {
                 .help("Save alias")
                 .pointerOnHover()
             } else {
-                Text(accountIdentifier)
+                Text(displayedAccountIdentifier)
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(.primary)
                     .lineLimit(1)
@@ -329,6 +329,12 @@ struct AccountCard: View {
 
     private var accountIdentifier: String {
         return snapshot.name
+    }
+
+    // Default Claude records name the account "Claude - <email>", so the primary title leaks
+    // the email too. Mask it for display while leaving the real name for the alias editor.
+    private var displayedAccountIdentifier: String {
+        store.hidesSensitiveInfo ? SensitiveText.redactingEmails(accountIdentifier) : accountIdentifier
     }
 
     private var secondaryIdentifier: String? {

--- a/Sources/Toki/Views/AccountCard.swift
+++ b/Sources/Toki/Views/AccountCard.swift
@@ -182,7 +182,7 @@ struct AccountCard: View {
                         .padding(.vertical, 1)
                     VStack(spacing: 3) {
                         ForEach(snapshot.accountInfo) { metric in
-                            MetricRow(metric: metric)
+                            MetricRow(metric: maskedAccountInfo(metric))
                         }
                     }
                     .font(.system(size: 11, weight: .medium))
@@ -332,7 +332,23 @@ struct AccountCard: View {
     }
 
     private var secondaryIdentifier: String? {
-        emailAddress(in: snapshot) ?? (snapshot.subtitle.isEmpty ? nil : snapshot.subtitle)
+        let raw = emailAddress(in: snapshot) ?? (snapshot.subtitle.isEmpty ? nil : snapshot.subtitle)
+        guard let raw else { return nil }
+        return store.hidesSensitiveInfo ? SensitiveText.redactingEmails(raw) : raw
+    }
+
+    // Masks the value of an account-info row when it names something identifying (email, org),
+    // so the expanded card is safe to screenshot with sensitive info hidden.
+    private func maskedAccountInfo(_ metric: MetricLine) -> MetricLine {
+        guard store.hidesSensitiveInfo else { return metric }
+        switch metric.label {
+        case "Email":
+            return MetricLine(label: metric.label, value: SensitiveText.redactingEmails(metric.value))
+        case "Org", "Org ID":
+            return MetricLine(label: metric.label, value: SensitiveText.redactedValue(metric.value))
+        default:
+            return metric
+        }
     }
 
     private var collapsedStatus: String {

--- a/Sources/Toki/Views/Components.swift
+++ b/Sources/Toki/Views/Components.swift
@@ -304,6 +304,33 @@ struct StatusBadge: View {
     }
 }
 
+// MARK: - ResetCreditBadge
+
+// Flags a banked Codex rate-limit reset on the collapsed card, so a redeemable reset is
+// visible at a glance rather than only inside the expanded card. The redeem button itself
+// stays in the expanded view, gated on the window being mostly spent.
+struct ResetCreditBadge: View {
+    var count: Int
+
+    var body: some View {
+        HStack(spacing: 3) {
+            Image(systemName: "arrow.counterclockwise")
+                .font(.system(size: 8, weight: .bold))
+            Text(count > 1 ? "\(count) resets" : "1 reset")
+                .font(.system(size: 9, weight: .semibold))
+        }
+        .foregroundStyle(Color.blue)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 2)
+        .background(Color.blue.opacity(0.10), in: Capsule())
+        .overlay(Capsule().stroke(Color.blue.opacity(0.22), lineWidth: 1))
+        .fixedSize()
+        .help(count > 1 ? "\(count) rate-limit resets are banked and ready to redeem"
+                        : "A rate-limit reset is banked and ready to redeem")
+        .accessibilityLabel(count > 1 ? "\(count) resets available" : "1 reset available")
+    }
+}
+
 // MARK: - ProviderPill
 
 struct ProviderPill: View {

--- a/Sources/Toki/Views/MenuContentView.swift
+++ b/Sources/Toki/Views/MenuContentView.swift
@@ -143,6 +143,21 @@ struct MenuContentView: View {
             .pointerOnHover()
 
             Button {
+                store.hidesSensitiveInfo.toggle()
+            } label: {
+                Image(systemName: store.hidesSensitiveInfo ? "eye.slash" : "eye")
+                    .frame(width: 25, height: 25)
+                    .background((store.hidesSensitiveInfo ? Color.blue : Color.primary).opacity(store.hidesSensitiveInfo ? 0.12 : 0.06), in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+                    .contentShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+            }
+            .buttonStyle(.plain)
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(store.hidesSensitiveInfo ? Color.blue : Color.primary)
+            .help(store.hidesSensitiveInfo ? "Showing masked emails and org info - click to reveal" : "Hide emails and org info for screenshots")
+            .accessibilityLabel(store.hidesSensitiveInfo ? "Reveal sensitive info" : "Hide sensitive info")
+            .pointerOnHover()
+
+            Button {
                 showChangelog = true
             } label: {
                 Image(systemName: "doc.text")

--- a/Sources/Toki/Views/MenuContentView.swift
+++ b/Sources/Toki/Views/MenuContentView.swift
@@ -35,7 +35,11 @@ struct MenuContentView: View {
                 mainContent
             }
         }
-        .frame(width: popoverWidth(), height: popoverHeight(), alignment: .top)
+        // Fixed width, but only a max height: the popover shrinks to fit short content (e.g. a
+        // couple of accounts) instead of padding out to the full height, and caps + scrolls when
+        // there's more. Pairs with .preferredContentSize on the hosting controller.
+        .frame(width: popoverWidth(), alignment: .top)
+        .frame(maxHeight: popoverHeight(), alignment: .top)
         .background(.regularMaterial)
     }
 
@@ -64,7 +68,7 @@ struct MenuContentView: View {
             }
         }
         .padding(12)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .frame(maxWidth: .infinity, alignment: .top)
     }
 
     private var header: some View {

--- a/Tests/TokiTests/AgentAttentionTests.swift
+++ b/Tests/TokiTests/AgentAttentionTests.swift
@@ -54,6 +54,38 @@ final class AgentAttentionTests: XCTestCase {
         XCTAssertNil(attention(jsonl, modified: nil))
     }
 
+    func testAutoModeSuppressesPermissionPrompt() {
+        // In auto mode Bash runs without asking, so a lingering tool_use is executing.
+        let jsonl = """
+        {"type":"permission-mode","permissionMode":"auto"}
+        {"message":{"content":[{"type":"tool_use","id":"t1","name":"Bash","input":{}}]}}
+        """
+        XCTAssertNil(attention(jsonl, modified: quiet))
+    }
+
+    func testAutoModeStillSurfacesAskedQuestions() {
+        // A question waits on the user regardless of permission mode.
+        let jsonl = """
+        {"type":"permission-mode","permissionMode":"auto"}
+        {"message":{"content":[{"type":"tool_use","id":"t1","name":"AskUserQuestion","input":{"questions":[{"question":"Which one?"}]}}]}}
+        """
+        XCTAssertEqual(attention(jsonl, modified: quiet)?.kind, .question)
+    }
+
+    func testAcceptEditsSuppressesEditsButNotBash() {
+        let edit = """
+        {"type":"permission-mode","permissionMode":"acceptEdits"}
+        {"message":{"content":[{"type":"tool_use","id":"t1","name":"Edit","input":{}}]}}
+        """
+        XCTAssertNil(attention(edit, modified: quiet))
+
+        let bash = """
+        {"type":"permission-mode","permissionMode":"acceptEdits"}
+        {"message":{"content":[{"type":"tool_use","id":"t1","name":"Bash","input":{}}]}}
+        """
+        XCTAssertEqual(attention(bash, modified: quiet)?.kind, .permission)
+    }
+
     func testPlanApprovalIsAQuestion() {
         let jsonl = """
         {"message":{"content":[{"type":"tool_use","id":"t1","name":"ExitPlanMode","input":{}}]}}

--- a/Tests/TokiTests/AgentAttentionTests.swift
+++ b/Tests/TokiTests/AgentAttentionTests.swift
@@ -113,6 +113,46 @@ final class AgentAttentionTests: XCTestCase {
     }
 }
 
+final class AgentDisambiguationTests: XCTestCase {
+    private func agent(pid: Int32, title: String, tty: String?) -> ActiveAgent {
+        ActiveAgent(
+            id: pid, provider: .claudeCode, directory: nil, chatTitle: title,
+            hostApp: nil, hostProcessID: nil, lastActivity: nil, processID: pid, runtime: "1:00",
+            terminalTTY: tty, memoryKB: 1000, command: "claude", sessionUsage: nil, attention: nil
+        )
+    }
+
+    func testSharedTitlesGetTtyMarkers() {
+        let result = ActiveAgentScanner.disambiguate([
+            agent(pid: 1, title: "Audit database", tty: "/dev/ttys004"),
+            agent(pid: 2, title: "Audit database", tty: "ttys007"),
+            agent(pid: 3, title: "Unique task", tty: "/dev/ttys009"),
+        ])
+        XCTAssertEqual(result[0].title, "Audit database · ttys004")
+        XCTAssertEqual(result[1].title, "Audit database · ttys007")
+        // A title nobody else shares is left alone.
+        XCTAssertEqual(result[2].title, "Unique task")
+    }
+
+    func testUniqueTitlesAreUnchanged() {
+        let result = ActiveAgentScanner.disambiguate([
+            agent(pid: 1, title: "A", tty: "/dev/ttys004"),
+            agent(pid: 2, title: "B", tty: "/dev/ttys007"),
+        ])
+        XCTAssertEqual(result.map(\.title), ["A", "B"])
+    }
+
+    func testStartDateParsesETimeFormats() {
+        let now = Date()
+        // mm:ss
+        XCTAssertEqual(ActiveAgentScanner.startDate(fromETime: "05:00")!.timeIntervalSince(now), -300, accuracy: 2)
+        // hh:mm:ss
+        XCTAssertEqual(ActiveAgentScanner.startDate(fromETime: "01:00:00")!.timeIntervalSince(now), -3600, accuracy: 2)
+        // dd-hh:mm:ss
+        XCTAssertEqual(ActiveAgentScanner.startDate(fromETime: "1-00:00:00")!.timeIntervalSince(now), -86400, accuracy: 2)
+    }
+}
+
 // Guards the click regression: promoting blocked agents to the top re-ordered the list while
 // the user was looking at it, and a row moving out from under the pointer mid-press cancels
 // the click - so the cards silently stopped being clickable.

--- a/Tests/TokiTests/SensitiveTextTests.swift
+++ b/Tests/TokiTests/SensitiveTextTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import Toki
+
+final class SensitiveTextTests: XCTestCase {
+    func testRedactsEmailButKeepsSurroundingText() {
+        XCTAssertEqual(SensitiveText.redactingEmails("me@example.com"), "•••••@•••••")
+        // An email embedded in a subtitle: only the address is masked.
+        XCTAssertEqual(
+            SensitiveText.redactingEmails("OpenAI Codex - a.b+tag@work.co · Resets in 3h"),
+            "OpenAI Codex - •••••@••••• · Resets in 3h"
+        )
+    }
+
+    func testLeavesNonEmailTextUntouched() {
+        XCTAssertEqual(SensitiveText.redactingEmails("OpenAI Codex - Plus"), "OpenAI Codex - Plus")
+    }
+
+    func testRedactedValueHidesLength() {
+        // A fixed-length mask so the character count itself leaks nothing.
+        XCTAssertEqual(SensitiveText.redactedValue("Acme, Inc."), "••••••")
+        XCTAssertEqual(SensitiveText.redactedValue("x"), "••••••")
+    }
+}

--- a/Tests/TokiTests/SessionUsageTests.swift
+++ b/Tests/TokiTests/SessionUsageTests.swift
@@ -91,7 +91,8 @@ final class SessionUsageTests: XCTestCase {
         """
         let data = Data(jsonl.utf8)
         let usage = AgentSessionResolver.claudeUsage(fromJSONLData: data)
-        XCTAssertEqual(usage?.tokensInput, 50)
+        // input_tokens + cache_creation + cache_read = 50 + 100 + 20.
+        XCTAssertEqual(usage?.tokensInput, 170)
         XCTAssertEqual(usage?.tokensOutput, 30)
     }
 

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -15,6 +15,9 @@ rm -rf "$APP_DIR"
 mkdir -p "$MACOS_DIR"
 mkdir -p "$RESOURCES_DIR"
 cp "$ROOT_DIR/.build/release/Toki" "$MACOS_DIR/Toki"
+# Strip symbols before signing (stripping invalidates the signature). The Swift
+# release binary carries ~3MB of symbol tables it never needs at runtime.
+strip "$MACOS_DIR/Toki"
 cp "$ROOT_DIR/Sources/Toki/Resources/"* "$RESOURCES_DIR/"
 
 cat > "$CONTENTS_DIR/Info.plist" <<PLIST

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -29,6 +29,10 @@ lipo -create \
   "$BUILD_DIR/x86_64/release/Toki" \
   -output "$APP_DIR/Contents/MacOS/Toki"
 
+# Strip symbols from the universal binary before signing (stripping invalidates
+# the signature). Each slice carries ~3MB of symbol tables unused at runtime.
+strip "$APP_DIR/Contents/MacOS/Toki"
+
 echo "==> Copying resources"
 cp "$ROOT_DIR/Sources/Toki/Resources/"* "$APP_DIR/Contents/Resources/"
 


### PR DESCRIPTION
## 2.4.2 — maintenance release

### Added
- **Hide PII** — an eye button in the header masks account emails and org info across the cards, so screenshots and demos can be shared without leaking PII. Resets on relaunch.

### Fixed / Changed
- **Package size** (#28) — release builds `strip` the binary before signing. App bundle **5.3MB → 2.3MB**; signature verified valid.
- **Dedupe** — Anthropic/OpenAI snapshot building extracted into a shared `AccountConfig.tokenBudgetSnapshot`.
- **tmux agents** (#27) — hop across the detached tmux server to the attached client so clicking an agent focuses its terminal; re-resolve a cached-nil host once a client attaches.
- **VS Code agents** (#24) — activate the real app instead of a `.prohibited` helper PID; pick the right variant so VS Code and VS Code Insiders stay distinct.
- **Agent token "in"** (#24) — count cache reads/writes, not just uncached input.
- **Auto-mode permission** (#26) — read the session's `permissionMode` and stop showing a false "Allow Bash?" when tools auto-run.
- **Same-folder agents** (#24) — match each agent to the session file created nearest its launch; tty marker when titles still collide.
- **Codex resets** (#25) — reset badge on the collapsed card, itself the redeem control (confirms first, stating quota left); soonest window reset in the subtitle.

### Review
- Reviewed the highest comment-density files; comments are substantive "why" notes, not rot — no cleanup commit.
- A Codex review flagged two runtime bugs (stale tmux host cache; wrong "soonest reset" when the weekly window rolls over first) — both fixed.

### Closes
Closes #28
Closes #27
Closes #26
Closes #25
Closes #24

### Deferred
- #31 — active-agents list trims from the top in full-screen. Split out of #24; not currently reproducible, so it needs a real repro before fixing.
