### PR TITLE
v2.4.4: stable/beta update channels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,13 +75,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION=$(grep '^let appVersion' Sources/Toki/Config/Constants.swift | sed 's/.*"\(.*\)"/\1/')
+          # A hyphen in the tag (v2.5.0-beta.1) marks a GitHub prerelease: the in-app beta
+          # channel offers it, while releases/latest (the stable channel) never returns it.
+          PRERELEASE_FLAG=""
+          if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
           gh release create "${GITHUB_REF_NAME}" \
             ".build/Toki_${VERSION}_universal.dmg" \
             --title "${GITHUB_REF_NAME}" \
-            --generate-notes
+            --generate-notes $PRERELEASE_FLAG
 
       - name: Update Homebrew tap
-        if: ${{ env.HOMEBREW_TAP_TOKEN != '' }}
+        # The cask tracks the stable channel only, so prerelease tags must not rewrite it.
+        if: ${{ env.HOMEBREW_TAP_TOKEN != '' && !contains(github.ref_name, '-') }}
         run: |
           TAP_DIR="$(mktemp -d)"
           git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/aashutoshrathi/homebrew-tap.git" "$TAP_DIR"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Update channels. Settings > Updates now has a Stable/Beta picker: Beta offers GitHub pre-releases (tags like `v2.5.0-beta.1`) so upcoming builds can be tested before they ship, while Stable keeps ignoring them. Once the stable version is published, beta testers are offered it automatically and graduate back onto the production build.
+
+### Fixed
+
+- Update version comparison is now semver-aware. The old numeric string compare ranked `2.5.0-beta.1` above `2.5.0`, which would have kept re-offering a beta over its own final release.
+
 ## 2.4.3 - 2026-07-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.4.4 - 2026-07-26
 
 ### Added
 

--- a/Sources/Toki/Config/Constants.swift
+++ b/Sources/Toki/Config/Constants.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-let appVersion = "2.4.3"
+let appVersion = "2.4.4"
 let appUserAgent = "Toki/\(appVersion)"
 let defaultConfigPath = "~/.toki/config.json"
 let defaultStatePath = "~/.toki/usage-state.json"

--- a/Sources/Toki/Updates/UpdateChecker.swift
+++ b/Sources/Toki/Updates/UpdateChecker.swift
@@ -1,10 +1,30 @@
 import AppKit
 import Foundation
 
+/// Which GitHub releases the updater is willing to offer.
+///
+/// Beta maps onto GitHub prereleases (tags like `v2.5.0-beta.1`). Stable keeps using the
+/// `releases/latest` endpoint, which GitHub already restricts to full releases, so stable
+/// users never see a prerelease no matter what is published.
+enum UpdateChannel: String, CaseIterable, Identifiable {
+    case stable
+    case beta
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .stable: return "Stable"
+        case .beta: return "Beta"
+        }
+    }
+}
+
 struct AvailableUpdate: Equatable {
     let version: String
     let releaseURL: URL
     let downloadURL: URL
+    let isPrerelease: Bool
 }
 
 private struct GitHubRelease: Decodable {
@@ -20,11 +40,15 @@ private struct GitHubRelease: Decodable {
 
     let tagName: String
     let htmlURL: URL
+    let prerelease: Bool
+    let draft: Bool
     let assets: [Asset]
 
     enum CodingKeys: String, CodingKey {
         case tagName = "tag_name"
         case htmlURL = "html_url"
+        case prerelease
+        case draft
         case assets
     }
 }
@@ -37,10 +61,12 @@ final class UpdateChecker: ObservableObject {
     @Published private(set) var isChecking = false
     @Published private(set) var lastCheckedAt: Date?
     @Published private(set) var checkMessage: String?
+    @Published private(set) var channel: UpdateChannel
 
     private let session: URLSession
     private let currentVersion: String
     private let latestReleaseURL: URL
+    private let releaseListURL: URL
     private let defaults: UserDefaults
     private let mockVersion: String?
     private var checkTimer: Timer?
@@ -48,15 +74,19 @@ final class UpdateChecker: ObservableObject {
     init(
         session: URLSession = .shared,
         currentVersion: String = appVersion,
-        latestReleaseURL: URL = URL(string: "https://api.github.com/repos/aashutoshrathi/toki/releases/latest")!,
+        apiBaseURL: URL = URL(string: "https://api.github.com/repos/aashutoshrathi/toki")!,
         defaults: UserDefaults = .standard,
         mockVersion: String? = ProcessInfo.processInfo.environment["TOKI_MOCK_UPDATE_VERSION"]
     ) {
         self.session = session
         self.currentVersion = currentVersion
-        self.latestReleaseURL = latestReleaseURL
+        self.latestReleaseURL = apiBaseURL.appendingPathComponent("releases/latest")
+        // Enough pages of history that a stable release stays visible behind a run of betas;
+        // the newest published release is first, so 20 is generous.
+        self.releaseListURL = URL(string: apiBaseURL.appendingPathComponent("releases").absoluteString + "?per_page=20")!
         self.defaults = defaults
         self.mockVersion = mockVersion
+        self.channel = UpdateChannel(rawValue: defaults.string(forKey: updateChannelKey) ?? "") ?? .stable
         lastCheckedAt = defaults.object(forKey: lastUpdateCheckKey) as? Date
     }
 
@@ -75,6 +105,17 @@ final class UpdateChecker: ObservableObject {
 
     func checkNow() {
         runCheck(isManual: true)
+    }
+
+    /// Switching channels re-checks immediately: the point of opting into beta is to get the
+    /// prerelease now, not at the next five-minute tick. The stale offer is cleared first so a
+    /// beta banner can't linger after switching back to stable.
+    func setChannel(_ newChannel: UpdateChannel) {
+        guard newChannel != channel else { return }
+        channel = newChannel
+        defaults.set(newChannel.rawValue, forKey: updateChannelKey)
+        availableUpdate = nil
+        checkNow()
     }
 
     func dismiss() {
@@ -177,39 +218,25 @@ final class UpdateChecker: ObservableObject {
 
     private func checkForUpdates() async {
         if let mockVersion {
-            let version = normalizedVersion(mockVersion)
-            guard isNewerVersion(version, than: currentVersion),
+            let version = Self.normalizedVersion(mockVersion)
+            guard Self.isNewerVersion(version, than: currentVersion),
                   let url = URL(string: "https://github.com/aashutoshrathi/toki/releases/tag/v\(version)"),
                   let downloadURL = URL(string: "https://github.com/aashutoshrathi/toki/releases/download/v\(version)/Toki_\(version)_universal.dmg") else {
                 return
             }
-            availableUpdate = AvailableUpdate(version: version, releaseURL: url, downloadURL: downloadURL)
+            availableUpdate = AvailableUpdate(
+                version: version,
+                releaseURL: url,
+                downloadURL: downloadURL,
+                isPrerelease: version.contains("-")
+            )
             checkMessage = nil
             return
         }
 
         do {
-            var request = URLRequest(url: latestReleaseURL)
-            request.setValue(appUserAgent, forHTTPHeaderField: "User-Agent")
-            request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
-            request.timeoutInterval = 10
-
-            let (data, response) = try await session.data(for: request)
-            guard let http = response as? HTTPURLResponse else {
-                checkMessage = "Couldn't check for updates."
-                return
-            }
-            if http.statusCode == 429 {
-                checkMessage = nil
-                return
-            }
-            guard (200..<300).contains(http.statusCode) else {
-                checkMessage = "Couldn't check for updates."
-                return
-            }
-
-            let release = try JSONDecoder().decode(GitHubRelease.self, from: data)
-            let releaseVersion = normalizedVersion(release.tagName)
+            guard let release = try await fetchCandidateRelease() else { return }
+            let releaseVersion = Self.normalizedVersion(release.tagName)
             guard let asset = release.assets.first(where: { $0.name.lowercased().hasSuffix(".dmg") }) else {
                 checkMessage = "The latest release has no DMG."
                 return
@@ -220,7 +247,7 @@ final class UpdateChecker: ObservableObject {
                 return
             }
 
-            guard isNewerVersion(releaseVersion, than: currentVersion) else {
+            guard Self.isNewerVersion(releaseVersion, than: currentVersion) else {
                 availableUpdate = nil
                 checkMessage = "Toki is up to date."
                 return
@@ -246,7 +273,8 @@ final class UpdateChecker: ObservableObject {
             availableUpdate = AvailableUpdate(
                 version: releaseVersion,
                 releaseURL: release.htmlURL,
-                downloadURL: asset.browserDownloadURL
+                downloadURL: asset.browserDownloadURL,
+                isPrerelease: release.prerelease
             )
             checkMessage = nil
         } catch {
@@ -255,25 +283,116 @@ final class UpdateChecker: ObservableObject {
             // Update checks must never interrupt normal app startup.
         }
     }
+
+    /// Stable asks GitHub for `releases/latest`, which excludes prereleases and drafts by
+    /// definition. Beta has no equivalent endpoint, so it lists recent releases and picks the
+    /// highest version among them - prereleases included. Picking by version rather than list
+    /// order matters for graduation: once `2.5.0` ships, someone on `2.5.0-beta.2` must be
+    /// offered the stable build even if a stray older beta was published after it.
+    private func fetchCandidateRelease() async throws -> GitHubRelease? {
+        if channel == .stable {
+            guard let data = try await fetch(latestReleaseURL) else { return nil }
+            return try JSONDecoder().decode(GitHubRelease.self, from: data)
+        }
+        guard let data = try await fetch(releaseListURL) else { return nil }
+        let releases = try JSONDecoder().decode([GitHubRelease].self, from: data)
+        return releases
+            .filter { !$0.draft }
+            .max { Self.compareVersions(Self.normalizedVersion($0.tagName), Self.normalizedVersion($1.tagName)) == .orderedAscending }
+    }
+
+    /// Returns nil when the response was handled as a status message (rate limit, HTTP error).
+    private func fetch(_ url: URL) async throws -> Data? {
+        var request = URLRequest(url: url)
+        request.setValue(appUserAgent, forHTTPHeaderField: "User-Agent")
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = 10
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            checkMessage = "Couldn't check for updates."
+            return nil
+        }
+        if http.statusCode == 429 {
+            checkMessage = nil
+            return nil
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            checkMessage = "Couldn't check for updates."
+            return nil
+        }
+        return data
+    }
+
+    nonisolated static func normalizedVersion(_ value: String) -> String {
+        var version = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if version.lowercased().hasPrefix("v") {
+            version.removeFirst()
+        }
+        return version
+    }
+
+    nonisolated static func isNewerVersion(_ candidate: String, than current: String) -> Bool {
+        compareVersions(candidate, normalizedVersion(current)) == .orderedDescending
+    }
+
+    /// Semver-aware ordering, which the previous `String.compare(options: .numeric)` was not:
+    /// that ordering ranks `2.5.0-beta.1` above `2.5.0` because the prerelease tag makes the
+    /// string longer. Getting this right is what lets a beta build graduate - `2.5.0` must beat
+    /// `2.5.0-beta.2` so the stable release is offered to beta testers, and must NOT beat itself
+    /// so stable users aren't reinstalled in a loop.
+    nonisolated static func compareVersions(_ lhs: String, _ rhs: String) -> ComparisonResult {
+        let left = parseVersion(lhs)
+        let right = parseVersion(rhs)
+
+        for index in 0..<max(left.core.count, right.core.count) {
+            let a = index < left.core.count ? left.core[index] : 0
+            let b = index < right.core.count ? right.core[index] : 0
+            if a != b { return a < b ? .orderedAscending : .orderedDescending }
+        }
+
+        // Same core version: a full release outranks any of its prereleases.
+        switch (left.prerelease.isEmpty, right.prerelease.isEmpty) {
+        case (true, true): return .orderedSame
+        case (true, false): return .orderedDescending
+        case (false, true): return .orderedAscending
+        case (false, false): break
+        }
+
+        for index in 0..<max(left.prerelease.count, right.prerelease.count) {
+            // Fewer identifiers sorts first (semver: `-beta` < `-beta.1`).
+            guard index < left.prerelease.count else { return .orderedAscending }
+            guard index < right.prerelease.count else { return .orderedDescending }
+            let a = left.prerelease[index]
+            let b = right.prerelease[index]
+            switch (Int(a), Int(b)) {
+            case let (numA?, numB?):
+                if numA != numB { return numA < numB ? .orderedAscending : .orderedDescending }
+            case (.some, nil):
+                // Numeric identifiers sort below alphanumeric ones (semver spec rule 11).
+                return .orderedAscending
+            case (nil, .some):
+                return .orderedDescending
+            case (nil, nil):
+                if a != b { return a < b ? .orderedAscending : .orderedDescending }
+            }
+        }
+        return .orderedSame
+    }
+
+    private nonisolated static func parseVersion(_ value: String) -> (core: [Int], prerelease: [String]) {
+        // Build metadata (`+sha`) never affects precedence, so it is stripped outright.
+        let withoutBuild = value.split(separator: "+", maxSplits: 1).first ?? ""
+        let parts = withoutBuild.split(separator: "-", maxSplits: 1)
+        let core = (parts.first ?? "").split(separator: ".").map { Int($0) ?? 0 }
+        let prerelease = parts.count > 1 ? parts[1].split(separator: ".").map(String.init) : []
+        return (core, prerelease)
+    }
 }
 
 private let dismissedVersionKey = "dismissedUpdateVersion"
 private let snoozedVersionKey = "snoozedUpdateVersion"
 private let snoozedUntilKey = "snoozedUpdateUntil"
 private let lastUpdateCheckKey = "lastUpdateCheckAt"
+private let updateChannelKey = "updateChannel"
 private let updateCheckInterval: TimeInterval = 5 * 60
-
-private func normalizedVersion(_ value: String) -> String {
-    var version = value.trimmingCharacters(in: .whitespacesAndNewlines)
-    if version.lowercased().hasPrefix("v") {
-        version.removeFirst()
-    }
-    return version
-}
-
-private func isNewerVersion(_ candidate: String, than current: String) -> Bool {
-    candidate.compare(
-        normalizedVersion(current),
-        options: [.numeric, .caseInsensitive]
-    ) == .orderedDescending
-}

--- a/Sources/Toki/Views/Components.swift
+++ b/Sources/Toki/Views/Components.swift
@@ -16,9 +16,11 @@ struct UpdateAvailableBanner: View {
                     .foregroundStyle(.blue)
 
                 VStack(alignment: .leading, spacing: 1) {
-                    Text("Toki \(update.version) is available")
+                    Text(update.isPrerelease ? "Toki \(update.version) (beta) is available" : "Toki \(update.version) is available")
                         .font(.system(size: 11, weight: .semibold))
-                    Text(updateChecker.isInstalling ? "Downloading and verifying update…" : "Install the latest GitHub release.")
+                    Text(updateChecker.isInstalling
+                        ? "Downloading and verifying update…"
+                        : (update.isPrerelease ? "Install the latest pre-release from GitHub." : "Install the latest GitHub release."))
                         .font(.system(size: 10))
                         .foregroundStyle(.secondary)
                 }

--- a/Sources/Toki/Views/Components.swift
+++ b/Sources/Toki/Views/Components.swift
@@ -28,6 +28,16 @@ struct UpdateAvailableBanner: View {
                 Spacer()
 
                 Button {
+                    updateChecker.openRelease()
+                } label: {
+                    Text("What's New")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .help("Open this release's notes on GitHub")
+                .accessibilityLabel("What's new in Toki \(update.version)")
+
+                Button {
                     updateChecker.installUpdate()
                 } label: {
                     if updateChecker.isInstalling {

--- a/Sources/Toki/Views/SettingsPanel.swift
+++ b/Sources/Toki/Views/SettingsPanel.swift
@@ -210,15 +210,15 @@ struct SettingsPanel: View {
                 HStack(spacing: 8) {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Channel")
-                            .font(.system(size: 11, weight: .semibold))
+                            .font(.system(size: 12, weight: .semibold))
                         Text(updateChecker.channel == .beta
                             ? "Includes pre-releases for early testing."
                             : "Stable releases only.")
+                            .font(.system(size: 9))
                             .foregroundStyle(.secondary)
                     }
-                    .font(.system(size: 10))
 
-                    Spacer()
+                    Spacer(minLength: 8)
 
                     Picker("Update channel", selection: Binding(
                         get: { updateChecker.channel },
@@ -228,12 +228,18 @@ struct SettingsPanel: View {
                             Text(channel.displayName).tag(channel)
                         }
                     }
-                    .pickerStyle(.segmented)
+                    .pickerStyle(.menu)
                     .labelsHidden()
                     .controlSize(.small)
-                    .frame(width: 130)
+                    .fixedSize()
                     .pointerOnHover()
                 }
+                .padding(10)
+                .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+                )
 
                 if let update = updateChecker.availableUpdate {
                     UpdateAvailableBanner(update: update, updateChecker: updateChecker)

--- a/Sources/Toki/Views/SettingsPanel.swift
+++ b/Sources/Toki/Views/SettingsPanel.swift
@@ -207,6 +207,34 @@ struct SettingsPanel: View {
                     .pointerOnHover()
                 }
 
+                HStack(spacing: 8) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Channel")
+                            .font(.system(size: 11, weight: .semibold))
+                        Text(updateChecker.channel == .beta
+                            ? "Includes pre-releases for early testing."
+                            : "Stable releases only.")
+                            .foregroundStyle(.secondary)
+                    }
+                    .font(.system(size: 10))
+
+                    Spacer()
+
+                    Picker("Update channel", selection: Binding(
+                        get: { updateChecker.channel },
+                        set: { updateChecker.setChannel($0) }
+                    )) {
+                        ForEach(UpdateChannel.allCases) { channel in
+                            Text(channel.displayName).tag(channel)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    .controlSize(.small)
+                    .frame(width: 130)
+                    .pointerOnHover()
+                }
+
                 if let update = updateChecker.availableUpdate {
                     UpdateAvailableBanner(update: update, updateChecker: updateChecker)
                 }

--- a/Tests/TokiTests/UpdateChannelTests.swift
+++ b/Tests/TokiTests/UpdateChannelTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import Toki
+
+final class UpdateChannelTests: XCTestCase {
+    // MARK: - Core version ordering
+
+    func testPlainVersionOrdering() {
+        XCTAssertTrue(UpdateChecker.isNewerVersion("2.5.0", than: "2.4.3"))
+        XCTAssertFalse(UpdateChecker.isNewerVersion("2.4.3", than: "2.5.0"))
+        XCTAssertFalse(UpdateChecker.isNewerVersion("2.4.3", than: "2.4.3"))
+        XCTAssertTrue(UpdateChecker.isNewerVersion("2.10.0", than: "2.9.0"))
+    }
+
+    func testShorterCoreIsPaddedWithZeros() {
+        XCTAssertEqual(UpdateChecker.compareVersions("2.5", "2.5.0"), .orderedSame)
+        XCTAssertTrue(UpdateChecker.isNewerVersion("2.5.1", than: "2.5"))
+    }
+
+    func testCurrentVersionMayCarryTagPrefix() {
+        XCTAssertTrue(UpdateChecker.isNewerVersion("2.5.0", than: "v2.4.3"))
+        XCTAssertFalse(UpdateChecker.isNewerVersion("2.4.3", than: "v2.4.3"))
+    }
+
+    // MARK: - Prerelease ordering (the beta channel's contract)
+
+    func testPrereleaseIsOlderThanItsRelease() {
+        // The old numeric string compare got this exactly backwards, which would have
+        // reinstalled 2.5.0-beta.1 on top of the shipped 2.5.0 forever.
+        XCTAssertFalse(UpdateChecker.isNewerVersion("2.5.0-beta.1", than: "2.5.0"))
+        XCTAssertTrue(UpdateChecker.isNewerVersion("2.5.0", than: "2.5.0-beta.1"))
+    }
+
+    func testPrereleaseIsNewerThanPreviousRelease() {
+        XCTAssertTrue(UpdateChecker.isNewerVersion("2.5.0-beta.1", than: "2.4.3"))
+    }
+
+    func testPrereleaseIterationsOrderNumerically() {
+        XCTAssertTrue(UpdateChecker.isNewerVersion("2.5.0-beta.2", than: "2.5.0-beta.1"))
+        XCTAssertTrue(UpdateChecker.isNewerVersion("2.5.0-beta.10", than: "2.5.0-beta.9"))
+        XCTAssertFalse(UpdateChecker.isNewerVersion("2.5.0-beta.1", than: "2.5.0-beta.1"))
+    }
+
+    func testPrereleaseIdentifierRules() {
+        // Fewer identifiers sort first: -beta < -beta.1 (semver spec rule 11).
+        XCTAssertTrue(UpdateChecker.isNewerVersion("2.5.0-beta.1", than: "2.5.0-beta"))
+        // Numeric identifiers sort below alphanumeric ones: -1 < -beta.
+        XCTAssertTrue(UpdateChecker.isNewerVersion("2.5.0-beta", than: "2.5.0-1"))
+        // Alphanumeric identifiers compare lexically: -alpha < -beta < -rc.
+        XCTAssertTrue(UpdateChecker.isNewerVersion("2.5.0-beta.1", than: "2.5.0-alpha.4"))
+        XCTAssertTrue(UpdateChecker.isNewerVersion("2.5.0-rc.1", than: "2.5.0-beta.9"))
+    }
+
+    func testBuildMetadataIsIgnored() {
+        XCTAssertEqual(UpdateChecker.compareVersions("2.5.0+abc123", "2.5.0"), .orderedSame)
+        XCTAssertFalse(UpdateChecker.isNewerVersion("2.5.0+abc123", than: "2.5.0"))
+    }
+
+    func testMalformedVersionsDoNotTrap() {
+        XCTAssertFalse(UpdateChecker.isNewerVersion("", than: "2.4.3"))
+        XCTAssertFalse(UpdateChecker.isNewerVersion("nonsense", than: "2.4.3"))
+    }
+
+    // MARK: - Graduation scenarios
+
+    func testBetaBuildGraduatesToStableRelease() {
+        // A tester on the beta channel running 2.5.0-beta.2 must be offered the shipped
+        // 2.5.0, both while still on beta and after switching back to stable.
+        XCTAssertTrue(UpdateChecker.isNewerVersion("2.5.0", than: "2.5.0-beta.2"))
+    }
+
+    func testStableUserNeverDowngradedByOldBeta() {
+        XCTAssertFalse(UpdateChecker.isNewerVersion("2.5.0-beta.2", than: "2.5.0"))
+        XCTAssertFalse(UpdateChecker.isNewerVersion("2.5.0-beta.2", than: "2.5.1"))
+    }
+
+    func testBetaChannelPicksHighestVersionNotListOrder() {
+        // Mirrors fetchCandidateRelease's max-by-version selection: a stable release
+        // published after a newer beta must not shadow it, and vice versa.
+        let published = ["2.5.0-beta.1", "2.4.3", "2.5.0-beta.2"]
+        let best = published.max {
+            UpdateChecker.compareVersions($0, $1) == .orderedAscending
+        }
+        XCTAssertEqual(best, "2.5.0-beta.2")
+    }
+
+    // MARK: - Channel defaults
+
+    func testChannelParsesFromStoredRawValue() {
+        XCTAssertEqual(UpdateChannel(rawValue: "beta"), .beta)
+        XCTAssertEqual(UpdateChannel(rawValue: "stable"), .stable)
+        XCTAssertNil(UpdateChannel(rawValue: "nightly"))
+    }
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -25,6 +25,22 @@ scripts/build-app.sh
 plutil -p .build/Toki.app/Contents/Info.plist
 ```
 
+## Releases and update channels
+
+Every release starts from a tag push; `.github/workflows/release.yml` builds the DMG and publishes the GitHub release. The tag decides the channel:
+
+- **Stable** — tag `vX.Y.Z` (e.g. `v2.5.0`). Published as a full GitHub release, offered to everyone, and the Homebrew cask is updated.
+- **Beta** — tag with a prerelease suffix (e.g. `v2.5.0-beta.1`). Published as a GitHub prerelease, offered only to users who picked the Beta channel in Settings > Updates. The Homebrew cask is not touched.
+
+Set `appVersion` in `Sources/Toki/Config/Constants.swift` to match the tag (without the `v`) before tagging — the packaging script, the in-app updater's version check, and the DMG verification all read it.
+
+To graduate a beta to production:
+
+1. Tag `v2.5.0-beta.1` (with `appVersion = "2.5.0-beta.1"`) and test on the Beta channel. Iterate with `-beta.2`, `-beta.3`, … as needed.
+2. When it's ready, set `appVersion = "2.5.0"` and tag `v2.5.0`. That build ships to everyone: stable users see it as a normal update, and beta users are offered it too, because `2.5.0` outranks `2.5.0-beta.N` — so testers land back on the production build without touching their channel setting.
+
+Version ordering is semver-aware (`2.4.3` < `2.5.0-beta.1` < `2.5.0-beta.2` < `2.5.0`); the logic and its tests live in `UpdateChecker.compareVersions` and `Tests/TokiTests/UpdateChannelTests.swift`.
+
 ## Concurrency checking
 
 CI builds with stricter concurrency than a plain `swift build`, and the difference has broken this project's CI more than once — a pure static helper on a `@MainActor` type needs `nonisolated`, which only the stricter mode catches. Reproduce it locally before pushing:

--- a/docs/features.md
+++ b/docs/features.md
@@ -38,6 +38,8 @@ Backed by `SMAppService`, reflecting what System Settings → General → Login 
 
 Toki checks the latest public GitHub release every five minutes while running; Settings has a "Check now" that bypasses the schedule. An update banner you aren't ready to act on can be snoozed for six hours.
 
+Settings > Updates also has a channel picker. Stable (the default) only ever offers full releases. Beta additionally offers GitHub pre-releases — early builds of the next version, published for testing before they ship. When a beta version is finalized as a stable release, beta users are offered that release like everyone else, so staying on the Beta channel never strands you on an abandoned build.
+
 A newer release shows an Update button that downloads the DMG, verifies bundle identity, version, and code signature, stages the app, and replaces the installed bundle after Toki exits, then relaunches. Set `TOKI_MOCK_UPDATE_VERSION=9.9.9` to preview the banner while developing.
 
 Rotating diagnostics go to `~/.toki/logs/toki.log` — error categories and status codes only, never credentials, config, prompts, session titles, workspace names, or full paths. "Send debug report" creates a local attachment and opens the share picker; nothing is sent automatically.


### PR DESCRIPTION
## What changed

Adds Stable/Beta update channels.

- **Settings → Updates** gains a **Stable / Beta** picker.
- **Beta** offers GitHub pre-releases (hyphenated tags like `v2.5.0-beta.1`), chosen by highest semver rather than publish order. **Stable** ignores pre-releases (uses `releases/latest`).
- Version comparison is now semver-aware, so `2.5.0` correctly outranks `2.5.0-beta.1` — publishing the stable tag graduates beta testers back onto production automatically.
- The release workflow marks hyphenated tags as GitHub prereleases and skips the Homebrew cask update for them, so the cask keeps tracking stable only.

## Release

Ships as **2.4.4**. The wider widgets/quota-rings work ships separately as **2.5.0** (#35), which merges this feature in.

## Validation

- `swift build` and `swift test` (incl. `UpdateChannelTests`) pass.
