### PR TITLE
Settings card redesign + quota rings polish (on by default)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - **Desktop widgets.** Two new widgets you can add from the macOS widget gallery, in small and medium sizes. One shows your account quota, how many agents are waiting on you, and a nudge to take a break once everything's used up; the other draws your remaining quota as colorful rings.
-- **Quota rings in the app.** An optional ring view — turn it on in Settings — shows how much of each provider you have left at a glance, with the provider name and percentage on hover.
+- **Quota rings in the app.** Provider-colored rings show how much of each provider you have left at a glance, with the provider name and percentage on hover. On by default — hide them with the button on the panel or the toggle in Settings.
 - **"What's New" on the update banner.** When an update is ready, a button takes you straight to the release notes on GitHub before you install.
 - **Hide the AI insight card.** A Settings toggle hides the insight card at the top of the panel; its prompt instructions now sit in the same card, only showing when the insight is on.
 
@@ -13,6 +13,7 @@
 
 - Toki keeps showing your last known usage when you lose internet, and refreshes on its own the moment you're back online. The refresh button now shows an offline icon instead of spinning for nothing.
 - The header is simpler: the session-tracking button is gone, and Save buttons across the app use a floppy-disk icon.
+- Settings is now a consistent set of cards: every row shares the same icon, title, and right-aligned control, so it reads as one tidy stack. The update channel is tinted apart as a developer setting, and "Check for updates" is its own card.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ scripts/install-app.sh        # build a bundle and install to ~/Applications
 
 **Desktop widgets.** Small and medium macOS WidgetKit widgets put account quota, agents awaiting input, and break suggestions on your desktop or in Notification Center — plus a separate quota-rings widget for percentage-based accounts. They refresh from Toki's live data while it runs.
 
-**Quota health rings.** Opt-in, provider-colored rings that show remaining percentage at a glance, in the Accounts panel and as the standalone macOS widget, with provider details on hover.
+**Quota rings.** Provider-colored rings that show remaining percentage at a glance, in the Accounts panel and as the standalone macOS widget, with provider details on hover. On by default; hide them from the panel or Settings.
 
 **Experimental notch mode.** Off by default, notched Macs only — moves the readout into the display notch, expanding on hover.
 

--- a/Sources/Toki/API/ClaudeCodeUsageClient.swift
+++ b/Sources/Toki/API/ClaudeCodeUsageClient.swift
@@ -72,8 +72,16 @@ struct ClaudeCodeUsageClient {
         let primaryMetric = usage.primaryMetric ?? UsageMetric(label: "Daily", utilization: usage.worstUtilization ?? 0, resetDescription: nil)
         let usedRatio = max(0, min(1, primaryMetric.utilization / 100))
         let remainingRatio = max(0, min(1, 1 - usedRatio))
-        let primary = "\(Int((remainingRatio * 100).rounded()))% left"
+        let percentLeft = Int((remainingRatio * 100).rounded())
+        let primary = "\(percentLeft)% left"
         let email = record.email ?? ClaudeCodeCredentialReader.emailIdentifier(from: credentials)
+
+        // Surface Claude Code's single rolling window the same way Codex exposes its windows,
+        // so consumers like the quota-rings panel can show "resets in <time>" beside it. The
+        // main account card reads its reset line from `metrics`, so this doesn't duplicate there.
+        let primaryWindow = primaryMetric.resetDescription.map {
+            RateLimitWindow(label: primaryMetric.label, percentLeft: percentLeft, resetHint: "resets in \($0)")
+        }
 
         return AccountSnapshot(
             id: record.id,
@@ -88,7 +96,8 @@ struct ClaudeCodeUsageClient {
             switchTarget: switchTarget(for: record),
             switchCommand: account.claudeSwapCommand,
             emoji: record.label?.emoji,
-            colorHex: record.label?.color
+            colorHex: record.label?.color,
+            primaryWindow: primaryWindow
         )
     }
 

--- a/Sources/Toki/Models/UsageState.swift
+++ b/Sources/Toki/Models/UsageState.swift
@@ -110,7 +110,7 @@ struct AppPreferences: Codable, Equatable {
     var aiInsightEnabled = true
     /// Shows the provider availability rings in the Accounts panel. The standalone macOS
     /// widget is independently opt-in through the system widget gallery.
-    var quotaRingsEnabled = false
+    var quotaRingsEnabled = true
     /// Experimental: render the status readout at the display notch instead of the menu bar.
     /// Off by default - it relocates the whole app, so it is opt-in.
     var notchModeEnabled = false

--- a/Sources/Toki/Views/MenuContentView.swift
+++ b/Sources/Toki/Views/MenuContentView.swift
@@ -282,7 +282,11 @@ struct MenuContentView: View {
             case .accounts:
                 VStack(spacing: 10) {
                     if showsQuotaRings {
-                        QuotaRingsPanel(snapshots: store.snapshots)
+                        QuotaRingsPanel(snapshots: store.snapshots) {
+                            var next = store.preferences
+                            next.quotaRingsEnabled = false
+                            store.updatePreferences(next)
+                        }
                     }
                     accountList
                 }

--- a/Sources/Toki/Views/QuotaRingsPanel.swift
+++ b/Sources/Toki/Views/QuotaRingsPanel.swift
@@ -6,27 +6,36 @@ struct QuotaRingsPanel: View {
     @State private var hoveredSnapshotID: String?
 
     var body: some View {
-        HStack(alignment: .center, spacing: 12) {
-            VStack(spacing: 6) {
-                ForEach(ringSnapshots) { snapshot in
-                    card(snapshot)
-                }
-                Spacer(minLength: 0)
+        // A header row ("QUOTA" left, Hide right) keeps those two clear of the ring below, so
+        // nothing crowds. Cards and ring sit in the row underneath and are vertically centered,
+        // so the card's height follows its content instead of a fixed, oversized ring.
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Text("Quota")
+                    .font(.system(size: 9, weight: .bold))
+                    .tracking(0.5)
+                    .foregroundStyle(.tertiary)
+                Spacer(minLength: 8)
+                hideButton
             }
-            .frame(width: 150, alignment: .leading)
 
-            Spacer(minLength: 8)
+            HStack(alignment: .center, spacing: 12) {
+                VStack(spacing: 6) {
+                    ForEach(ringSnapshots) { snapshot in
+                        card(snapshot)
+                    }
+                }
+                .frame(width: 150, alignment: .leading)
 
-            QuotaRingsView(
-                snapshots: ringSnapshots,
-                size: 100,
-                hoveredSnapshotID: $hoveredSnapshotID
-            )
-            // Extra trailing space nudges the ring in from the edge so it isn't jammed
-            // against the panel border and the hide button has room in the corner.
-            .padding(.leading, 6)
-            .padding(.trailing, 22)
-            .padding(.vertical, 2)
+                Spacer(minLength: 8)
+
+                QuotaRingsView(
+                    snapshots: ringSnapshots,
+                    size: 84,
+                    hoveredSnapshotID: $hoveredSnapshotID
+                )
+                .padding(.trailing, 8)
+            }
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
@@ -42,10 +51,6 @@ struct QuotaRingsPanel: View {
         .overlay {
             RoundedRectangle(cornerRadius: 11, style: .continuous)
                 .stroke(Color.primary.opacity(0.085), lineWidth: 1)
-        }
-        .overlay(alignment: .topTrailing) {
-            hideButton
-                .padding(8)
         }
         .animation(.easeOut(duration: 0.12), value: hoveredSnapshotID)
     }
@@ -80,9 +85,16 @@ struct QuotaRingsPanel: View {
                     .font(.system(size: 11, weight: .semibold))
                     .lineLimit(1)
                     .truncationMode(.tail)
-                Text(percentText(snapshot.remainingRatio ?? 0))
+                Text("\(percentText(snapshot.remainingRatio ?? 0)) left")
                     .font(.system(size: 9, weight: .medium, design: .rounded))
                     .foregroundStyle(.secondary)
+                if let resetHint = snapshot.primaryWindow?.resetHint {
+                    Text(resetHint)
+                        .font(.system(size: 8, weight: .medium))
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
             }
             Spacer(minLength: 0)
         }

--- a/Sources/Toki/Views/QuotaRingsPanel.swift
+++ b/Sources/Toki/Views/QuotaRingsPanel.swift
@@ -18,9 +18,11 @@ struct QuotaRingsPanel: View {
 
             QuotaRingsView(
                 snapshots: ringSnapshots,
-                size: 140,
+                size: 118,
                 hoveredSnapshotID: $hoveredSnapshotID
             )
+            .padding(.horizontal, 6)
+            .padding(.vertical, 4)
         }
         .padding(12)
         .background(

--- a/Sources/Toki/Views/QuotaRingsPanel.swift
+++ b/Sources/Toki/Views/QuotaRingsPanel.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct QuotaRingsPanel: View {
     let snapshots: [AccountSnapshot]
+    var onHide: () -> Void = {}
     @State private var hoveredSnapshotID: String?
 
     var body: some View {
@@ -18,13 +19,17 @@ struct QuotaRingsPanel: View {
 
             QuotaRingsView(
                 snapshots: ringSnapshots,
-                size: 118,
+                size: 100,
                 hoveredSnapshotID: $hoveredSnapshotID
             )
-            .padding(.horizontal, 6)
-            .padding(.vertical, 4)
+            // Extra trailing space nudges the ring in from the edge so it isn't jammed
+            // against the panel border and the hide button has room in the corner.
+            .padding(.leading, 6)
+            .padding(.trailing, 22)
+            .padding(.vertical, 2)
         }
-        .padding(12)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
         .background(
             RadialGradient(
                 colors: [panelAccent.opacity(0.11), Color.primary.opacity(0.035)],
@@ -38,7 +43,31 @@ struct QuotaRingsPanel: View {
             RoundedRectangle(cornerRadius: 11, style: .continuous)
                 .stroke(Color.primary.opacity(0.085), lineWidth: 1)
         }
+        .overlay(alignment: .topTrailing) {
+            hideButton
+                .padding(8)
+        }
         .animation(.easeOut(duration: 0.12), value: hoveredSnapshotID)
+    }
+
+    private var hideButton: some View {
+        Button(action: onHide) {
+            HStack(spacing: 3) {
+                Image(systemName: "eye.slash")
+                    .font(.system(size: 9, weight: .semibold))
+                Text("Hide")
+                    .font(.system(size: 10, weight: .medium))
+            }
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(Color.primary.opacity(0.06), in: Capsule())
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .help("Hide the quota rings — turn them back on in Settings")
+        .accessibilityLabel("Hide quota rings")
+        .pointerOnHover()
     }
 
     private func card(_ snapshot: AccountSnapshot) -> some View {

--- a/Sources/Toki/Views/SettingsPanel.swift
+++ b/Sources/Toki/Views/SettingsPanel.swift
@@ -338,23 +338,12 @@ struct SettingsPanel: View {
                 ConfigEditor(store: store)
 
                 HStack(spacing: 8) {
-                    Button {
+                    advancedButton("Send debug report", icon: "paperclip") {
                         DiagnosticsReporter.presentSharePicker()
-                    } label: {
-                        Label("Send debug report", systemImage: "paperclip")
                     }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                    .pointerOnHover()
-
-                    Button {
+                    advancedButton("Logs", icon: "folder") {
                         DiagnosticsReporter.openLogFolder()
-                    } label: {
-                        Label("Logs", systemImage: "folder")
                     }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                    .pointerOnHover()
                 }
             }
             .font(.system(size: 12))
@@ -540,6 +529,30 @@ struct SettingsPanel: View {
                 .font(.system(size: 11, weight: .semibold, design: .monospaced))
             control()
         }
+    }
+
+    // Advanced actions are buttons, not settings, so they get a lighter treatment than the
+    // cards above: equal-width, subtly bordered, so the pair reads as one tidy row.
+    private func advancedButton(_ title: String, icon: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                Image(systemName: icon)
+                    .font(.system(size: 11, weight: .semibold))
+                Text(title)
+                    .font(.system(size: 11, weight: .medium))
+            }
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 7)
+            .background(Color.primary.opacity(0.05), in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 7, style: .continuous)
+                    .stroke(Color.primary.opacity(0.09), lineWidth: 1)
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .pointerOnHover()
     }
 
     private func intBinding(_ keyPath: WritableKeyPath<AppPreferences, Int>) -> Binding<Int> {

--- a/Sources/Toki/Views/SettingsPanel.swift
+++ b/Sources/Toki/Views/SettingsPanel.swift
@@ -374,51 +374,75 @@ struct SettingsPanel: View {
         )
     }
 
-    // Given its own row rather than a plain checkbox line: it is the one setting that visibly
-    // relocates the whole app, and it is unfinished, so it needs room to say both.
+    // A proper card rather than a plain checkbox line: it is the one setting that visibly
+    // relocates the whole app, and it is unfinished, so it needs room to say both. The switch
+    // sits right-aligned to match the "Show AI insight" / "Show quota health rings" cards, and
+    // when enabled the placement picker drops in as an aligned sub-row inside the same card.
     @ViewBuilder
     private var notchModeRow: some View {
-        Toggle(isOn: binding(\.notchModeEnabled)) {
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 5) {
-                    Text("Live in the notch")
-                        .font(.system(size: 11, weight: .semibold))
-                    Text("BETA")
-                        .font(.system(size: 8, weight: .heavy))
-                        .tracking(0.4)
-                        .foregroundStyle(.white)
-                        .padding(.horizontal, 4)
-                        .padding(.vertical, 1)
-                        .background(
-                            LinearGradient(
-                                colors: [Color(red: 0.45, green: 0.35, blue: 0.95),
-                                         Color(red: 0.85, green: 0.35, blue: 0.65)],
-                                startPoint: .leading,
-                                endPoint: .trailing
-                            ),
-                            in: Capsule()
-                        )
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 8) {
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 5) {
+                        Text("Live in the notch")
+                            .font(.system(size: 12, weight: .semibold))
+                        Text("BETA")
+                            .font(.system(size: 8, weight: .heavy))
+                            .tracking(0.4)
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 1)
+                            .background(
+                                LinearGradient(
+                                    colors: [Color(red: 0.45, green: 0.35, blue: 0.95),
+                                             Color(red: 0.85, green: 0.35, blue: 0.65)],
+                                    startPoint: .leading,
+                                    endPoint: .trailing
+                                ),
+                                in: Capsule()
+                            )
+                    }
+                    Text(store.preferences.notchModeEnabled
+                         ? "Toki is hanging out up there. Hover it for more."
+                         : "Move Toki into the notch, Dynamic Island style.")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.secondary)
                 }
-                Text(store.preferences.notchModeEnabled
-                     ? "Toki is hanging out up there. Hover it for more."
-                     : "Move Toki into the notch, Dynamic Island style.")
-                    .font(.system(size: 9))
-                    .foregroundStyle(.tertiary)
+                Spacer(minLength: 8)
+                Toggle("", isOn: binding(\.notchModeEnabled))
+                    .labelsHidden()
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+            }
+            .padding(8)
+
+            if store.preferences.notchModeEnabled {
+                Divider()
+                    .padding(.horizontal, 8)
+                HStack(spacing: 8) {
+                    Text("Rests")
+                        .font(.system(size: 11, weight: .semibold))
+                    Spacer(minLength: 8)
+                    Picker("Rests", selection: binding(\.notchPlacement)) {
+                        ForEach(NotchPlacement.allCases) { placement in
+                            Text(placement.label).tag(placement)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    .fixedSize()
+                    .help("Hanging drops below the notch; Sideways sits in the menu bar beside it")
+                }
+                .padding(8)
             }
         }
+        .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        )
         .help("Replaces the menu bar item with a panel that hangs from the display notch")
         .pointerOnHover()
-
-        if store.preferences.notchModeEnabled {
-            Picker("Rests", selection: binding(\.notchPlacement)) {
-                ForEach(NotchPlacement.allCases) { placement in
-                    Text(placement.label).tag(placement)
-                }
-            }
-            .pickerStyle(.segmented)
-            .padding(.leading, 18)
-            .help("Hanging drops below the notch; Sideways sits in the menu bar beside it")
-        }
     }
 
     private func sectionHeader(_ title: String) -> some View {

--- a/Sources/Toki/Views/SettingsPanel.swift
+++ b/Sources/Toki/Views/SettingsPanel.swift
@@ -46,18 +46,15 @@ struct SettingsPanel: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 10) {
+                // AI insight — the one card that expands (its prompt editor drops in below).
                 VStack(alignment: .leading, spacing: 0) {
                     HStack(spacing: 8) {
-                        Image(systemName: "sparkles")
-                            .font(.system(size: 12, weight: .semibold))
-                            .foregroundStyle(.purple)
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Show AI insight")
-                                .font(.system(size: 12, weight: .semibold))
-                            Text("Show the insight card at the top of the main panel.")
-                                .font(.system(size: 9))
-                                .foregroundStyle(.secondary)
-                        }
+                        cardLabel(
+                            icon: "sparkles",
+                            iconColor: .purple,
+                            title: "Show AI insight",
+                            subtitle: "Show the insight card at the top of the main panel."
+                        )
                         Spacer(minLength: 8)
                         Button {
                             isEditingPrompt.toggle()
@@ -89,23 +86,15 @@ struct SettingsPanel: View {
                             .padding(.bottom, 8)
                     }
                 }
-                .background(Color.purple.opacity(0.06), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .stroke(Color.purple.opacity(0.14), lineWidth: 1)
-                )
+                .settingsCard(tint: .purple, fill: 0.06, stroke: 0.14)
 
                 HStack(spacing: 8) {
-                    Image(systemName: "bolt.ring.closed")
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundStyle(.blue)
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Show quota rings")
-                            .font(.system(size: 12, weight: .semibold))
-                        Text("Display provider availability rings in the Accounts panel.")
-                            .font(.system(size: 9))
-                            .foregroundStyle(.secondary)
-                    }
+                    cardLabel(
+                        icon: "bolt.ring.closed",
+                        iconColor: .blue,
+                        title: "Show quota rings",
+                        subtitle: "Display provider availability rings in the Accounts panel."
+                    )
                     Spacer(minLength: 8)
                     Toggle("", isOn: binding(\.quotaRingsEnabled))
                         .labelsHidden()
@@ -113,46 +102,72 @@ struct SettingsPanel: View {
                         .controlSize(.small)
                 }
                 .padding(8)
-                .background(Color.blue.opacity(0.055), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .stroke(Color.blue.opacity(0.13), lineWidth: 1)
-                )
-
-                Divider()
+                .settingsCard(tint: .blue, fill: 0.055, stroke: 0.13)
 
                 sectionHeader("General")
 
-                Toggle("Launch at login", isOn: launchAtLoginBinding)
-                    .toggleStyle(.switch)
-                    .controlSize(.small)
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 8) {
+                        cardLabel(
+                            icon: "power",
+                            iconColor: .secondary,
+                            title: "Launch at login",
+                            subtitle: "Start Toki automatically after you sign in."
+                        )
+                        Spacer(minLength: 8)
+                        Toggle("", isOn: launchAtLoginBinding)
+                            .labelsHidden()
+                            .toggleStyle(.switch)
+                            .controlSize(.small)
+                    }
 
-                if launchAtLoginNeedsApproval {
-                    HStack(spacing: 4) {
-                        Text("Needs approval in System Settings > General > Login Items.")
-                            .font(.system(size: 9))
-                            .foregroundStyle(.secondary)
-                        Button("Open") {
-                            LaunchAtLogin.openSystemSettings()
+                    if launchAtLoginNeedsApproval {
+                        HStack(spacing: 4) {
+                            Text("Needs approval in System Settings > General > Login Items.")
+                                .font(.system(size: 9))
+                                .foregroundStyle(.secondary)
+                            Button("Open") {
+                                LaunchAtLogin.openSystemSettings()
+                            }
+                            .buttonStyle(.plain)
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundStyle(.blue)
+                            .pointerOnHover()
                         }
-                        .buttonStyle(.plain)
-                        .font(.system(size: 9, weight: .semibold))
-                        .foregroundStyle(.blue)
-                        .pointerOnHover()
+                        .padding(.leading, 26)
+                    }
+
+                    if let launchAtLoginError {
+                        Text(launchAtLoginError)
+                            .font(.system(size: 9))
+                            .foregroundStyle(.red)
+                            .padding(.leading, 26)
                     }
                 }
+                .padding(8)
+                .settingsCard()
 
-                if let launchAtLoginError {
-                    Text(launchAtLoginError)
-                        .font(.system(size: 9))
-                        .foregroundStyle(.red)
-                }
-
-                Picker("Menu bar", selection: binding(\.menuBarMode)) {
-                    ForEach(MenuBarDisplayMode.allCases) { mode in
-                        Text(mode.label).tag(mode)
+                HStack(spacing: 8) {
+                    cardLabel(
+                        icon: "menubar.rectangle",
+                        iconColor: .secondary,
+                        title: "Menu bar",
+                        subtitle: "What the menu bar item shows at a glance."
+                    )
+                    Spacer(minLength: 8)
+                    Picker("Menu bar", selection: binding(\.menuBarMode)) {
+                        ForEach(MenuBarDisplayMode.allCases) { mode in
+                            Text(mode.label).tag(mode)
+                        }
                     }
+                    .pickerStyle(.menu)
+                    .labelsHidden()
+                    .controlSize(.small)
+                    .fixedSize()
+                    .pointerOnHover()
                 }
+                .padding(8)
+                .settingsCard()
 
                 // Sits directly under the menu bar picker: it decides where the readout lives,
                 // so it belongs with the other placement settings rather than below the
@@ -161,34 +176,80 @@ struct SettingsPanel: View {
                     notchModeRow
                 }
 
-                Divider()
                 sectionHeader("Notifications")
 
-                Toggle("Notifications", isOn: binding(\.notificationsEnabled))
+                HStack(spacing: 8) {
+                    cardLabel(
+                        icon: "bell",
+                        iconColor: .secondary,
+                        title: "Notifications",
+                        subtitle: "Show low-quota and session warnings."
+                    )
+                    Spacer(minLength: 8)
+                    Toggle("", isOn: binding(\.notificationsEnabled))
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                        .controlSize(.small)
+                }
+                .padding(8)
+                .settingsCard()
+
+                HStack(spacing: 8) {
+                    cardLabel(
+                        icon: "moon",
+                        iconColor: .secondary,
+                        title: "Do not disturb",
+                        subtitle: "Silence notifications until you turn it back off."
+                    )
+                    Spacer(minLength: 8)
+                    Toggle("", isOn: Binding(
+                        get: { store.preferences.dndEnabled },
+                        set: { store.setDND($0) }
+                    ))
+                    .labelsHidden()
                     .toggleStyle(.switch)
                     .controlSize(.small)
+                }
+                .padding(8)
+                .settingsCard()
 
-                Toggle("Do not disturb", isOn: Binding(
-                    get: { store.preferences.dndEnabled },
-                    set: { store.setDND($0) }
-                ))
-                .toggleStyle(.switch)
-                .controlSize(.small)
-
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Low quota threshold \(percentText(store.preferences.lowQuotaThreshold))")
-                        .font(.system(size: 11, weight: .semibold))
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 8) {
+                        cardLabel(
+                            icon: "speedometer",
+                            iconColor: .secondary,
+                            title: "Low quota threshold",
+                            subtitle: "Warn when a provider's remaining quota falls below this."
+                        )
+                        Spacer(minLength: 8)
+                        Text(percentText(store.preferences.lowQuotaThreshold))
+                            .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                    }
                     Slider(value: binding(\.lowQuotaThreshold), in: 0.05...0.50, step: 0.05)
                 }
+                .padding(8)
+                .settingsCard()
 
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Session warning \(percentText(store.preferences.sessionWarningThreshold))")
-                        .font(.system(size: 11, weight: .semibold))
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 8) {
+                        cardLabel(
+                            icon: "hourglass",
+                            iconColor: .secondary,
+                            title: "Session warning",
+                            subtitle: "Warn when the active session's quota falls below this."
+                        )
+                        Spacer(minLength: 8)
+                        Text(percentText(store.preferences.sessionWarningThreshold))
+                            .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                    }
                     Slider(value: binding(\.sessionWarningThreshold), in: 0.05...0.40, step: 0.05)
                 }
+                .padding(8)
+                .settingsCard()
 
                 VStack(spacing: 10) {
                     steppedSetting(
+                        icon: "timer",
                         title: "Cooldown",
                         explanation: "Minimum time between repeat notifications.",
                         value: "\(store.preferences.notificationCooldownMinutes)m"
@@ -198,6 +259,7 @@ struct SettingsPanel: View {
                     }
                     Divider()
                     steppedSetting(
+                        icon: "clock.arrow.circlepath",
                         title: "History",
                         explanation: "Days of usage history kept for the heatmap.",
                         value: "\(store.preferences.historyRetentionDays)d"
@@ -206,38 +268,19 @@ struct SettingsPanel: View {
                             .labelsHidden()
                     }
                 }
-                .padding(10)
-                .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-                )
+                .padding(8)
+                .settingsCard()
 
-                Divider()
                 sectionHeader("Updates")
 
                 HStack(spacing: 8) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("App updates")
-                            .font(.system(size: 11, weight: .semibold))
-                        if updateChecker.isChecking {
-                            Text("Checking GitHub…")
-                                .foregroundStyle(.secondary)
-                        } else if let message = updateChecker.checkMessage {
-                            Text(message)
-                                .foregroundStyle(.secondary)
-                        } else if updateChecker.lastCheckedAt != nil {
-                            Text("Checked")
-                                .foregroundStyle(.secondary)
-                        } else {
-                            Text("Checks automatically every 5 minutes")
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                    .font(.system(size: 10))
-
-                    Spacer()
-
+                    cardLabel(
+                        icon: "arrow.triangle.2.circlepath",
+                        iconColor: .secondary,
+                        title: "App updates",
+                        subtitle: appUpdatesStatus
+                    )
+                    Spacer(minLength: 8)
                     Button {
                         updateChecker.checkNow()
                     } label: {
@@ -253,20 +296,22 @@ struct SettingsPanel: View {
                     .disabled(updateChecker.isChecking)
                     .pointerOnHover()
                 }
+                .padding(8)
+                .settingsCard()
 
+                // Tinted differently from the neutral cards: the channel picker is a
+                // developer/early-tester setting (it opts into pre-release builds), so it
+                // reads as distinct from everyday preferences.
                 HStack(spacing: 8) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Channel")
-                            .font(.system(size: 12, weight: .semibold))
-                        Text(updateChecker.channel == .beta
+                    cardLabel(
+                        icon: "hammer",
+                        iconColor: .orange,
+                        title: "Channel",
+                        subtitle: updateChecker.channel == .beta
                             ? "Includes pre-releases for early testing."
-                            : "Stable releases only.")
-                            .font(.system(size: 9))
-                            .foregroundStyle(.secondary)
-                    }
-
+                            : "Stable releases only."
+                    )
                     Spacer(minLength: 8)
-
                     Picker("Update channel", selection: Binding(
                         get: { updateChecker.channel },
                         set: { updateChecker.setChannel($0) }
@@ -281,18 +326,13 @@ struct SettingsPanel: View {
                     .fixedSize()
                     .pointerOnHover()
                 }
-                .padding(10)
-                .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-                )
+                .padding(8)
+                .settingsCard(tint: .orange, fill: 0.07, stroke: 0.16)
 
                 if let update = updateChecker.availableUpdate {
                     UpdateAvailableBanner(update: update, updateChecker: updateChecker)
                 }
 
-                Divider()
                 sectionHeader("Advanced")
 
                 ConfigEditor(store: store)
@@ -334,6 +374,14 @@ struct SettingsPanel: View {
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             resyncLaunchAtLoginFromSystem()
         }
+    }
+
+    // Status line shown as the App updates card's subtitle.
+    private var appUpdatesStatus: String {
+        if updateChecker.isChecking { return "Checking GitHub…" }
+        if let message = updateChecker.checkMessage { return message }
+        if updateChecker.lastCheckedAt != nil { return "Checked." }
+        return "Checks automatically every 5 minutes."
     }
 
     // Only for external resync (view appearing, app regaining focus) - also clears any
@@ -379,37 +427,43 @@ struct SettingsPanel: View {
 
     // A proper card rather than a plain checkbox line: it is the one setting that visibly
     // relocates the whole app, and it is unfinished, so it needs room to say both. The switch
-    // sits right-aligned to match the "Show AI insight" / "Show quota health rings" cards, and
-    // when enabled the placement picker drops in as an aligned sub-row inside the same card.
+    // sits right-aligned like every other card, and when enabled the placement picker drops in
+    // as an aligned sub-row inside the same card.
     @ViewBuilder
     private var notchModeRow: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 8) {
-                VStack(alignment: .leading, spacing: 2) {
-                    HStack(spacing: 5) {
-                        Text("Live in the notch")
-                            .font(.system(size: 12, weight: .semibold))
-                        Text("BETA")
-                            .font(.system(size: 8, weight: .heavy))
-                            .tracking(0.4)
-                            .foregroundStyle(.white)
-                            .padding(.horizontal, 4)
-                            .padding(.vertical, 1)
-                            .background(
-                                LinearGradient(
-                                    colors: [Color(red: 0.45, green: 0.35, blue: 0.95),
-                                             Color(red: 0.85, green: 0.35, blue: 0.65)],
-                                    startPoint: .leading,
-                                    endPoint: .trailing
-                                ),
-                                in: Capsule()
-                            )
-                    }
-                    Text(store.preferences.notchModeEnabled
-                         ? "Toki is hanging out up there. Hover it for more."
-                         : "Move Toki into the notch, Dynamic Island style.")
-                        .font(.system(size: 9))
+                HStack(spacing: 8) {
+                    Image(systemName: "macbook")
+                        .font(.system(size: 12, weight: .semibold))
                         .foregroundStyle(.secondary)
+                        .frame(width: 18, alignment: .center)
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 5) {
+                            Text("Live in the notch")
+                                .font(.system(size: 12, weight: .semibold))
+                            Text("BETA")
+                                .font(.system(size: 8, weight: .heavy))
+                                .tracking(0.4)
+                                .foregroundStyle(.white)
+                                .padding(.horizontal, 4)
+                                .padding(.vertical, 1)
+                                .background(
+                                    LinearGradient(
+                                        colors: [Color(red: 0.45, green: 0.35, blue: 0.95),
+                                                 Color(red: 0.85, green: 0.35, blue: 0.65)],
+                                        startPoint: .leading,
+                                        endPoint: .trailing
+                                    ),
+                                    in: Capsule()
+                                )
+                        }
+                        Text(store.preferences.notchModeEnabled
+                             ? "Toki is hanging out up there. Hover it for more."
+                             : "Move Toki into the notch, Dynamic Island style.")
+                            .font(.system(size: 9))
+                            .foregroundStyle(.secondary)
+                    }
                 }
                 Spacer(minLength: 8)
                 Toggle("", isOn: binding(\.notchModeEnabled))
@@ -425,6 +479,7 @@ struct SettingsPanel: View {
                 HStack(spacing: 8) {
                     Text("Rests")
                         .font(.system(size: 11, weight: .semibold))
+                        .padding(.leading, 26)
                     Spacer(minLength: 8)
                     Picker("Rests", selection: binding(\.notchPlacement)) {
                         ForEach(NotchPlacement.allCases) { placement in
@@ -439,13 +494,28 @@ struct SettingsPanel: View {
                 .padding(8)
             }
         }
-        .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-        )
+        .settingsCard()
         .help("Replaces the menu bar item with a panel that hangs from the display notch")
         .pointerOnHover()
+    }
+
+    // Shared card header so every settings card lines its title/subtitle up at the same x,
+    // whatever control sits on the right. The icon lives in a fixed-width slot so the text
+    // columns match across cards even when the glyphs differ in width.
+    private func cardLabel(icon: String, iconColor: Color, title: String, subtitle: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(iconColor)
+                .frame(width: 18, alignment: .center)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.system(size: 12, weight: .semibold))
+                Text(subtitle)
+                    .font(.system(size: 9))
+                    .foregroundStyle(.secondary)
+            }
+        }
     }
 
     private func sectionHeader(_ title: String) -> some View {
@@ -453,22 +523,18 @@ struct SettingsPanel: View {
             .font(.system(size: 9, weight: .bold))
             .foregroundStyle(.tertiary)
             .tracking(0.5)
+            .padding(.top, 2)
     }
 
     private func steppedSetting<Control: View>(
+        icon: String,
         title: String,
         explanation: String,
         value: String,
         @ViewBuilder control: () -> Control
     ) -> some View {
         HStack(spacing: 8) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .font(.system(size: 12, weight: .semibold))
-                Text(explanation)
-                    .font(.system(size: 9))
-                    .foregroundStyle(.secondary)
-            }
+            cardLabel(icon: icon, iconColor: .secondary, title: title, subtitle: explanation)
             Spacer(minLength: 8)
             Text(value)
                 .font(.system(size: 11, weight: .semibold, design: .monospaced))
@@ -485,5 +551,17 @@ struct SettingsPanel: View {
                 store.updatePreferences(next)
             }
         )
+    }
+}
+
+private extension View {
+    // Shared card chrome so every settings row is the same rounded, bordered shape. Defaults
+    // are the neutral tint; colored cards (AI insight, quota rings, dev channel) pass their own.
+    func settingsCard(tint: Color = .primary, fill: Double = 0.04, stroke: Double = 0.08) -> some View {
+        background(tint.opacity(fill), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(tint.opacity(stroke), lineWidth: 1)
+            )
     }
 }

--- a/Sources/Toki/Views/SettingsPanel.swift
+++ b/Sources/Toki/Views/SettingsPanel.swift
@@ -96,8 +96,11 @@ struct SettingsPanel: View {
                 )
 
                 HStack(spacing: 8) {
+                    Image(systemName: "bolt.ring.closed")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(.blue)
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Show quota health rings")
+                        Text("Show quota rings")
                             .font(.system(size: 12, weight: .semibold))
                         Text("Display provider availability rings in the Accounts panel.")
                             .font(.system(size: 9))

--- a/docs/features.md
+++ b/docs/features.md
@@ -25,9 +25,9 @@ Two macOS WidgetKit widgets, each in small and medium sizes, live on the desktop
 
 Toki writes a compact, privacy-safe snapshot (provider labels and percentages only — never account names or emails) and asks WidgetKit to reload after usage or attention changes. A widget whose snapshot is older than five minutes falls back to an "Open Toki" prompt, so the readout is never silently stale. Properly signed release builds share the snapshot through the App Group; ad-hoc local builds route it through Toki's Application Support folder instead, which the extension reads with narrowly scoped read-only access.
 
-## Quota health rings
+## Quota rings
 
-Opt-in from Settings. The same provider-colored rings render inside the Accounts panel, showing remaining percentage at a glance and revealing the provider and live percentage on hover. The standalone macOS widget above is enabled independently through the system widget gallery.
+On by default. The same provider-colored rings render inside the Accounts panel, showing remaining percentage at a glance and revealing the provider and live percentage on hover. Hide them with the button on the panel or the toggle in Settings. The standalone macOS widget above is enabled independently through the system widget gallery.
 
 ## Live in the notch (experimental)
 


### PR DESCRIPTION
Settings/UI polish for the in-flight 2.5.0 release. Grew from two tweaks into a full Settings pass plus quota-ring changes.

## Settings — one consistent card system
Every setting is the same bordered card with a shared header (fixed-width icon slot + title + subtitle) and a right-aligned control, so titles line up and rows read as one stack.

- **Live in the notch** is a proper card; when enabled its placement picker drops in as an aligned sub-row.
- **Show quota rings** gains a `bolt.ring.closed` icon and drops "health" from the title.
- Launch at login, Menu bar, Notifications, Do not disturb, and the two threshold sliders become cards.
- **App updates** is its own card with a refresh icon and right-aligned "Check now".
- **Channel** is tinted orange with a hammer icon to mark it as a developer/early-tester setting.
- **Advanced** actions stay buttons, restyled into clean, equal-width bordered buttons.
- New helpers: `cardLabel`, `settingsCard`, `advancedButton`.

## Quota rings
- **On by default** now (`quotaRingsEnabled` defaults to `true`).
- Panel gets a header row: **"Quota"** label left, **Hide** button right (flips the setting off) — so neither crowds the ring below.
- Height now follows content: cards vertically centered, filler spacer dropped, ring `140 → 84`.
- Side cards read **"n% left"** with a **"resets in <time>"** line beneath, from the provider's primary rate-limit window.
- Claude Code now populates a `primaryWindow` (it only lived in `metrics` before), so its reset time shows in the rings panel like Codex.

## Docs
- CHANGELOG: rings entry updated (on by default + hideable); Changed note for the Settings card redesign.
- README + docs/features.md: "Quota health rings" → "Quota rings", "opt-in" → "on by default, hideable".

## Verification
- `swift build` passes; built and launched the `.app` after each change.