### PR TITLE
Fix beta update verification rejecting prerelease tags

### DIFF
--- a/Sources/Toki/Updates/UpdateInstaller.swift
+++ b/Sources/Toki/Updates/UpdateInstaller.swift
@@ -129,10 +129,18 @@ enum UpdateInstaller {
     private static func verify(app: URL, expectedVersion: String) throws {
         guard let bundle = Bundle(url: app),
               bundle.bundleIdentifier == "local.toki",
-              bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String == expectedVersion else {
+              let bundleVersion = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String,
+              versionMatchesRelease(bundleVersion: bundleVersion, releaseVersion: expectedVersion) else {
             throw LocalizedErrorMessage("The downloaded app identity or version does not match the release.")
         }
         _ = try run("/usr/bin/codesign", arguments: ["--verify", "--deep", "--strict", app.path])
+    }
+
+    // A prerelease tag (`2.5.0-beta.1`) carries a suffix the app's `CFBundleShortVersionString`
+    // (`2.5.0`) never does, so compare against the base version. Stable tags match exactly.
+    static func versionMatchesRelease(bundleVersion: String, releaseVersion: String) -> Bool {
+        let base = releaseVersion.split(separator: "-", maxSplits: 1, omittingEmptySubsequences: false).first.map(String.init) ?? releaseVersion
+        return bundleVersion == base
     }
 
     private static func mount(_ dmgURL: URL) throws -> URL {

--- a/Tests/TokiTests/StateCompatibilityTests.swift
+++ b/Tests/TokiTests/StateCompatibilityTests.swift
@@ -106,3 +106,20 @@ final class UpdateSnoozeTests: XCTestCase {
         ))
     }
 }
+
+// A prerelease tag (2.5.0-beta.1) must verify against the app's base marketing version (2.5.0).
+final class UpdateVerifyVersionTests: XCTestCase {
+    func testStableTagMatchesExactly() {
+        XCTAssertTrue(UpdateInstaller.versionMatchesRelease(bundleVersion: "2.5.0", releaseVersion: "2.5.0"))
+    }
+
+    func testBetaTagMatchesTheBaseVersion() {
+        XCTAssertTrue(UpdateInstaller.versionMatchesRelease(bundleVersion: "2.5.0", releaseVersion: "2.5.0-beta.1"))
+        XCTAssertTrue(UpdateInstaller.versionMatchesRelease(bundleVersion: "2.5.0", releaseVersion: "2.5.0-rc.2"))
+    }
+
+    func testDifferentBaseVersionStillFails() {
+        XCTAssertFalse(UpdateInstaller.versionMatchesRelease(bundleVersion: "2.4.4", releaseVersion: "2.5.0-beta.1"))
+        XCTAssertFalse(UpdateInstaller.versionMatchesRelease(bundleVersion: "2.5.1", releaseVersion: "2.5.0"))
+    }
+}


### PR DESCRIPTION
## Problem

Updating to a beta build failed with:

> The downloaded app identity or version does not match the release.

`UpdateInstaller.verify` compared the downloaded app's `CFBundleShortVersionString` against the release version **verbatim**. A prerelease tag like `v2.5.0-beta.1` normalizes to `2.5.0-beta.1`, but the app bundle's marketing version is `2.5.0` (a `CFBundleShortVersionString` can't carry a `-beta.1` suffix). So the equality check could never pass for a beta, and every beta update was rejected after downloading.

The DMG asset is named for the base version (`Toki_2.5.0_universal.dmg`) and the download URL comes from the release asset, so the download itself succeeded — only the post-download version check failed.

## Fix

Compare the app version against the **base** of the release version (everything before the first `-`). Stable tags have no suffix, so they still match exactly; betas now match on `2.5.0`. Bundle-identity and codesign checks are unchanged.

Extracted the comparison into `versionMatchesRelease(bundleVersion:releaseVersion:)` and covered it with tests (stable exact match, beta/rc base match, and mismatched base still rejected).

## Verification

- `swift build` + `swift test` pass, including the new `UpdateVerifyVersionTests`.