### PR TITLE
Remove redundant glass tile behind the header logo

### DIFF
--- a/Sources/Toki/Views/MenuContentView.swift
+++ b/Sources/Toki/Views/MenuContentView.swift
@@ -76,12 +76,6 @@ struct MenuContentView: View {
     private var header: some View {
         HStack(alignment: .center, spacing: 9) {
             TokiLogoMark(size: 34)
-                .padding(5)
-                .glassSurface(
-                    fallbackFill: .regularMaterial,
-                    fallbackStroke: .primary,
-                    fallbackStrokeOpacity: 0.08
-                )
 
             VStack(alignment: .leading, spacing: 3) {
                 HStack(spacing: 6) {


### PR DESCRIPTION
The Liquid Glass pass wrapped the header logo mark in a glass surface, which reads as a redundant card on top of the panel. Drop the wrapper (and its padding) so the top-left shows just the Toki mark.

Pairs with the 2.5.1 Liquid Glass work already in the beta.