### PR TITLE
v2.5.1 Beta 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- The header now keeps its version/debug affordance, uses aligned glass squircle controls and a layered glass Toki mark, while quota rings stay pinned and loading states no longer shift nearby content.
 - Quota rings now draw one ring per account instead of collapsing accounts that share a provider, so two Claude (or two Codex) accounts each get their own ring and side card. Each is given a distinct color (the account's label color, or a shaded provider color), and multiple accounts of a provider show their alias to tell them apart. The same fix applies to the quota-rings widget and the usage widget.
 - The quota rings now scale to the available height so they read clearly next to the account cards.
 - With multiple Claude Code accounts, a running session was shown on every Claude card. It is now attributed to the active account only (the one `claude-swap` has switched to), so inactive accounts no longer double-count it.

--- a/Sources/Toki/Resources/toki-router-mark.svg
+++ b/Sources/Toki/Resources/toki-router-mark.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1024 1024">
+  <g fill="black" transform="translate(0 6)">
+    <path d="M268 245H454V319H268C248 319 232 303 232 282C232 261 248 245 268 245Z"/>
+    <path d="M550 245H704L682 282L704 319H550Z"/>
+    <path d="M520 600L636 484" fill="none" stroke="black" stroke-width="74" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M465 354H539V626C539 664 558 671 600 671H704L684 708L704 745H566C502 745 465 708 465 636Z"/>
+    <circle cx="502" cy="282" r="72" fill="none" stroke="black" stroke-width="48"/>
+    <circle cx="636" cy="484" r="39"/>
+  </g>
+</svg>

--- a/Sources/Toki/Store/UsageStore+Refresh.swift
+++ b/Sources/Toki/Store/UsageStore+Refresh.swift
@@ -1,4 +1,4 @@
-import SwiftUI
+import Foundation
 
 extension UsageStore {
     func refresh(keepsExistingSnapshots: Bool = true, minimumRefreshInterval: TimeInterval? = nil) {
@@ -56,9 +56,7 @@ extension UsageStore {
             evaluateEventsAndNotifications(for: sorted, previous: previousSnapshots, at: response.fetchedAt)
             pruneState(now: response.fetchedAt)
             StateLoader.save(usageState)
-            withAnimation(.spring(response: 0.32, dampingFraction: 0.86)) {
-                snapshots = sorted
-            }
+            snapshots = sorted
             lastUpdated = Date()
             updateDerivedState(for: sorted)
         }

--- a/Sources/Toki/Utilities/Formatting.swift
+++ b/Sources/Toki/Utilities/Formatting.swift
@@ -137,14 +137,18 @@ func colorFromHex(_ raw: String?) -> Color? {
     return Color(red: red, green: green, blue: blue)
 }
 
-func availabilityColor(for percent: Int) -> Color {
+func availabilityColor(for percent: Int, colorScheme: ColorScheme) -> Color {
     if percent > 75 {
         return .primary
     }
     if percent > 42 {
-        return Color(red: 1.0, green: 0.64, blue: 0.18)
+        return colorScheme == .dark
+            ? Color(red: 1.0, green: 0.64, blue: 0.18)
+            : Color(red: 0.55, green: 0.31, blue: 0.02)
     }
-    return Color(red: 1.0, green: 0.48, blue: 0.50)
+    return colorScheme == .dark
+        ? Color(red: 1.0, green: 0.48, blue: 0.50)
+        : Color(red: 0.68, green: 0.10, blue: 0.16)
 }
 
 func copyToPasteboard(_ value: String) {

--- a/Sources/Toki/Views/AIInstructionsEditor.swift
+++ b/Sources/Toki/Views/AIInstructionsEditor.swift
@@ -69,7 +69,11 @@ struct AIInstructionsEditor: View {
                 Button {
                     persist(text)
                 } label: {
-                    Label(saved ? "Saved" : "Save", systemImage: saved ? "checkmark" : "checkmark.circle.fill")
+                    ZStack {
+                        Label("Saved", systemImage: "checkmark")
+                            .hidden()
+                        Label(saved ? "Saved" : "Save", systemImage: saved ? "checkmark" : "checkmark.circle.fill")
+                    }
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.small)

--- a/Sources/Toki/Views/AccountCard.swift
+++ b/Sources/Toki/Views/AccountCard.swift
@@ -98,7 +98,7 @@ struct AccountCard: View {
                         if let secondaryIdentifier {
                             Text(secondaryIdentifier)
                                 .font(.system(size: 9, weight: .regular))
-                                .foregroundStyle(.tertiary)
+                                .foregroundStyle(.secondary)
                                 .lineLimit(1)
                                 // Error text reads better cut from the end (keeps the
                                 // meaningful lead-in); emails/org names keep .middle so the
@@ -216,12 +216,14 @@ struct AccountCard: View {
                             // limited credit, so redeeming always asks first.
                             confirmingReset = true
                         } label: {
-                            if isResetting {
-                                ProgressView()
-                                    .controlSize(.small)
-                                    .accessibilityLabel("Resetting Codex rate limit")
-                            } else {
+                            ZStack {
                                 Label(resetButtonTitle, systemImage: "arrow.counterclockwise")
+                                    .opacity(isResetting ? 0 : 1)
+                                if isResetting {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                        .accessibilityLabel("Resetting Codex rate limit")
+                                }
                             }
                         }
                         .buttonStyle(.bordered)

--- a/Sources/Toki/Views/ChangelogView.swift
+++ b/Sources/Toki/Views/ChangelogView.swift
@@ -176,10 +176,6 @@ struct ChangelogPage: View {
         }
         .padding(8)
         .frame(maxWidth: .infinity, alignment: .topLeading)
-        .background(Color.primary.opacity(0.03), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(Color.primary.opacity(0.06), lineWidth: 1)
-        )
+        .contentSurface()
     }
 }

--- a/Sources/Toki/Views/Components.swift
+++ b/Sources/Toki/Views/Components.swift
@@ -40,11 +40,14 @@ struct UpdateAvailableBanner: View {
                 Button {
                     updateChecker.installUpdate()
                 } label: {
-                    if updateChecker.isInstalling {
-                        ProgressView()
-                            .controlSize(.small)
-                    } else {
+                    ZStack {
                         Text("Update")
+                            .opacity(updateChecker.isInstalling ? 0 : 1)
+                        if updateChecker.isInstalling {
+                            ProgressView()
+                                .controlSize(.small)
+                                .accessibilityLabel("Installing update")
+                        }
                     }
                 }
                 .buttonStyle(.borderedProminent)
@@ -187,37 +190,44 @@ struct AIInsightCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: expanded ? 6 : 0) {
-            HStack(alignment: .top, spacing: 6) {
+            HStack(alignment: .center, spacing: 6) {
                 Button {
                     if canExpand { expanded.toggle() }
                 } label: {
-                    HStack(alignment: .top, spacing: 6) {
-                        if isUpdating {
-                            ProgressView()
-                                .controlSize(.mini)
-                                .frame(width: 11, height: 11)
-                        } else {
-                            Image(systemName: isAI ? "sparkles" : "lightbulb")
-                                .font(.system(size: 11, weight: .semibold))
-                                .foregroundStyle(isAI ? .purple : .secondary)
+                    HStack(alignment: .center, spacing: 6) {
+                        Group {
+                            if isUpdating {
+                                ProgressView()
+                                    .controlSize(.mini)
+                            } else {
+                                Image(systemName: isAI ? "sparkles" : "lightbulb")
+                                    .font(.system(size: 11, weight: .semibold))
+                                    .foregroundStyle(isAI ? .purple : .secondary)
+                            }
                         }
-                        Text(summary)
-                            .font(.system(size: 11))
-                            .foregroundStyle(.primary)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .multilineTextAlignment(.leading)
-                        if canExpand {
-                            Image(systemName: expanded ? "chevron.up" : "chevron.down")
-                                .font(.system(size: 9, weight: .semibold))
-                                .foregroundStyle(.tertiary)
-                                .padding(.top, 3)
+                        .frame(width: 11, height: 11)
+                        Group {
+                            if canExpand {
+                                Text(summary)
+                                    .font(.system(size: 11))
+                                    .foregroundColor(.primary)
+                                + Text(" ")
+                                + Text(Image(systemName: expanded ? "chevron.up" : "chevron.down"))
+                                    .font(.system(size: 9, weight: .semibold))
+                                    .foregroundColor(Color(nsColor: .tertiaryLabelColor))
+                            } else {
+                                Text(summary)
+                                    .font(.system(size: 11))
+                                    .foregroundStyle(.primary)
+                            }
                         }
+                        .fixedSize(horizontal: false, vertical: true)
+                        .multilineTextAlignment(.leading)
                     }
                 }
                 .buttonStyle(.plain)
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .pointerOnHover()
-
-                Spacer(minLength: 4)
 
                 if let switchAction {
                     Button(action: switchAction.perform) {
@@ -385,6 +395,7 @@ struct MetricRow: View {
 // MARK: - QuotaSummaryLine
 
 struct QuotaSummaryLine: View {
+    @Environment(\.colorScheme) private var colorScheme
     var label: String
     var value: String
     var resetHint: String?
@@ -416,7 +427,7 @@ struct QuotaSummaryLine: View {
             HStack(spacing: 3) {
                 Text("\(availability)%")
                     .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(availabilityColor(for: availability))
+                    .foregroundStyle(availabilityColor(for: availability, colorScheme: colorScheme))
                 Text("left")
                     .font(.system(size: 11, weight: .regular))
                     .foregroundStyle(.secondary)

--- a/Sources/Toki/Views/ContentSurface.swift
+++ b/Sources/Toki/Views/ContentSurface.swift
@@ -12,13 +12,21 @@ extension View {
     }
 
     @ViewBuilder
-    func functionalGlass(cornerRadius: CGFloat = 14) -> some View {
-        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+    func functionalGlass<S: Shape>(in shape: S, interactive: Bool = false) -> some View {
         if #available(macOS 26, *) {
-            glassEffect(.regular, in: shape)
+            glassEffect(interactive ? .regular.interactive() : .regular, in: shape)
         } else {
             background(.regularMaterial, in: shape)
-                .overlay(shape.strokeBorder(Color.primary.opacity(0.08), lineWidth: 1))
+                .overlay(shape.stroke(Color.primary.opacity(0.08), lineWidth: 1))
         }
+    }
+
+    @ViewBuilder
+    func functionalControlStyle() -> some View {
+        let shape = RoundedRectangle(cornerRadius: 8, style: .continuous)
+        buttonStyle(.plain)
+            .frame(width: 28, height: 28)
+            .contentShape(shape)
+            .functionalGlass(in: shape, interactive: true)
     }
 }

--- a/Sources/Toki/Views/EventPanel.swift
+++ b/Sources/Toki/Views/EventPanel.swift
@@ -9,7 +9,11 @@ struct EventPanel: View {
                 Button {
                     store.setDND(!store.preferences.dndEnabled)
                 } label: {
-                    Label(store.preferences.dndEnabled ? "DND On" : "DND Off", systemImage: store.preferences.dndEnabled ? "moon.zzz.fill" : "bell")
+                    ZStack {
+                        Label("DND Off", systemImage: "moon.zzz.fill")
+                            .hidden()
+                        Label(store.preferences.dndEnabled ? "DND On" : "DND Off", systemImage: store.preferences.dndEnabled ? "moon.zzz.fill" : "bell")
+                    }
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)

--- a/Sources/Toki/Views/MenuContentView.swift
+++ b/Sources/Toki/Views/MenuContentView.swift
@@ -47,7 +47,7 @@ struct MenuContentView: View {
             contentBody
                 .safeAreaBar(edge: .top, spacing: 0) {
                     functionalBar
-                        .padding(.horizontal, 12)
+                        .padding(.horizontal, 10)
                         .padding(.top, 10)
                         .padding(.bottom, 6)
                 }
@@ -55,7 +55,7 @@ struct MenuContentView: View {
         } else {
             VStack(spacing: 0) {
                 functionalBar
-                    .padding(.horizontal, 12)
+                    .padding(.horizontal, 10)
                     .padding(.top, 10)
                     .padding(.bottom, 6)
                 contentBody
@@ -88,20 +88,40 @@ struct MenuContentView: View {
                 debugPanel
             }
         }
-        .padding(.horizontal, 12)
+        .padding(.horizontal, 10)
         .padding(.bottom, 12)
         .padding(.top, 4)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
 
+    @ViewBuilder
     private var functionalBar: some View {
+        if #available(macOS 26, *) {
+            GlassEffectContainer(spacing: 0) {
+                functionalBarContents
+            }
+        } else {
+            functionalBarContents
+        }
+    }
+
+    private var functionalBarContents: some View {
         HStack(alignment: .center, spacing: 7) {
-            TokiLogoMark(size: 22)
+            TokiLogoMark(size: 28)
+                .accessibilityHidden(true)
 
             Text("/toki")
                 .font(.system(size: 14, weight: .semibold, design: .monospaced))
                 .lineLimit(1)
                 .fixedSize()
+
+            Text("v\(appVersion)")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 7)
+                .padding(.vertical, 4)
+                .functionalGlass(in: Capsule(), interactive: true)
+                .accessibilityLabel("Toki version \(appVersion)")
                 .onTapGesture(count: 5) {
                     store.toggleDebug()
                 }
@@ -109,101 +129,94 @@ struct MenuContentView: View {
             Spacer(minLength: 0)
             headerControls
         }
-        .padding(6)
-        .functionalGlass()
+        .frame(height: 28)
     }
 
     private var headerControls: some View {
-        HStack(spacing: 5) {
-            // Same reasoning as the Agents panel's refresh: without a visible busy state the
-            // button looks identical before, during and after a refresh, so a press that is
-            // already running reads as one that did nothing and invites another - and the
-            // store drops overlapping refreshes, so those presses go nowhere.
-            Button {
-                store.refresh(minimumRefreshInterval: 60)
-            } label: {
-                Group {
-                    if store.isRefreshing {
-                        ProgressView()
-                            .controlSize(.small)
-                            .scaleEffect(0.7)
-                    } else if !store.isNetworkAvailable {
-                        Image(systemName: "wifi.slash")
-                    } else {
-                        Image(systemName: "arrow.clockwise")
+        HStack(spacing: 8) {
+            HStack(spacing: 5) {
+                Button {
+                    store.refresh(minimumRefreshInterval: 60)
+                } label: {
+                    Group {
+                        if store.isRefreshing {
+                            ProgressView()
+                                .controlSize(.small)
+                                .scaleEffect(0.7)
+                        } else if !store.isNetworkAvailable {
+                            Image(systemName: "wifi.slash")
+                        } else {
+                            Image(systemName: "arrow.clockwise")
+                        }
                     }
+                    .frame(width: 13, height: 13)
+                    .contentShape(Rectangle())
                 }
-                .frame(width: 24, height: 24)
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.borderless)
-            .disabled(store.isRefreshing || !store.isNetworkAvailable)
-            .help(
-                store.isRefreshing
-                    ? "Refreshing…"
-                    : (store.isNetworkAvailable
-                        ? "Refresh"
-                        : "Offline — usage refreshes automatically when the connection returns")
-            )
-            .pointerOnHover()
-
-            Button {
-                store.hidesSensitiveInfo.toggle()
-            } label: {
-                Image(systemName: store.hidesSensitiveInfo ? "eye.slash" : "eye")
-                    .frame(width: 24, height: 24)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.borderless)
-            .foregroundStyle(store.hidesSensitiveInfo ? Color.blue : Color.primary)
-            .help(store.hidesSensitiveInfo ? "Showing masked emails and org info - click to reveal" : "Hide emails and org info for screenshots")
-            .accessibilityLabel(store.hidesSensitiveInfo ? "Reveal sensitive info" : "Hide sensitive info")
-            .pointerOnHover()
-
-            Button {
-                showConfig = true
-            } label: {
-                Image(systemName: "gearshape")
-                    .frame(width: 24, height: 24)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.borderless)
-            .help("Settings")
-            .pointerOnHover()
-
-            Menu {
-                Button("Version \(appVersion)") {}
-                    .disabled(true)
-
-                Divider()
+                .functionalControlStyle()
+                .disabled(store.isRefreshing || !store.isNetworkAvailable)
+                .help(
+                    store.isRefreshing
+                        ? "Refreshing…"
+                        : (store.isNetworkAvailable
+                            ? "Refresh"
+                            : "Offline — usage refreshes automatically when the connection returns")
+                )
+                .pointerOnHover()
 
                 Button {
-                    showChangelog = true
+                    store.hidesSensitiveInfo.toggle()
                 } label: {
-                    Label("What's New", systemImage: "doc.text")
+                    Image(systemName: store.hidesSensitiveInfo ? "eye.slash" : "eye")
+                        .frame(width: 13, height: 13)
+                        .contentShape(Rectangle())
                 }
-
-                Divider()
-
-                Button(role: .destructive) {
-                    NSApp.terminate(nil)
-                } label: {
-                    Label("Quit Toki", systemImage: "power")
-                }
-            } label: {
-                Image(systemName: "ellipsis")
-                    .frame(width: 24, height: 24)
-                    .contentShape(Rectangle())
+                .functionalControlStyle()
+                .foregroundStyle(store.hidesSensitiveInfo ? Color.blue : Color.primary)
+                .help(store.hidesSensitiveInfo ? "Showing masked emails and org info - click to reveal" : "Hide emails and org info for screenshots")
+                .accessibilityLabel(store.hidesSensitiveInfo ? "Reveal sensitive info" : "Hide sensitive info")
+                .pointerOnHover()
             }
-            .menuStyle(.borderlessButton)
-            .menuIndicator(.hidden)
-            .fixedSize()
-            .help("More")
-            .accessibilityLabel("More actions")
-            .pointerOnHover()
+
+            HStack(spacing: 5) {
+                Button {
+                    showConfig = true
+                } label: {
+                    Image(systemName: "gearshape")
+                        .frame(width: 13, height: 13)
+                        .contentShape(Rectangle())
+                }
+                .functionalControlStyle()
+                .help("Settings")
+                .pointerOnHover()
+
+                Menu {
+                    Button {
+                        showChangelog = true
+                    } label: {
+                        Label("What's New", systemImage: "doc.text")
+                    }
+
+                    Divider()
+
+                    Button(role: .destructive) {
+                        NSApp.terminate(nil)
+                    } label: {
+                        Label("Quit Toki", systemImage: "power")
+                    }
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .frame(width: 13, height: 13)
+                        .contentShape(Rectangle())
+                }
+                .functionalControlStyle()
+                .menuIndicator(.hidden)
+                .fixedSize()
+                .help("More")
+                .accessibilityLabel("More actions")
+                .pointerOnHover()
+            }
         }
         .font(.system(size: 13, weight: .semibold))
-        .controlSize(.small)
     }
 
     private var overview: some View {
@@ -265,9 +278,9 @@ struct MenuContentView: View {
                     .contentShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
                 }
                 .buttonStyle(.plain)
-                .foregroundStyle(selectedTab == tab ? Color.white : Color.secondary)
+                .foregroundStyle(selectedTab == tab ? Color.primary : Color.secondary)
                 .background(
-                    selectedTab == tab ? Color.accentColor : Color.clear,
+                    selectedTab == tab ? Color.accentColor.opacity(0.16) : Color.clear,
                     in: RoundedRectangle(cornerRadius: 6, style: .continuous)
                 )
                 .help(tab.rawValue)
@@ -278,7 +291,7 @@ struct MenuContentView: View {
         }
         .padding(3)
         .frame(maxWidth: .infinity)
-        .background(Color.primary.opacity(0.06), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .background(.fill.quaternary, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
         .accessibilityLabel("Toki section")
     }
 
@@ -286,7 +299,7 @@ struct MenuContentView: View {
         Group {
             switch selectedTab {
             case .accounts:
-                accountList
+                accountsContent
             case .agents:
                 ActiveAgentsPanel(store: store)
             case .analytics:
@@ -314,21 +327,28 @@ struct MenuContentView: View {
         return 0
     }
 
+    private var accountsContent: some View {
+        VStack(spacing: 0) {
+            if showsQuotaRings {
+                QuotaRingsPanel(snapshots: store.snapshots) {
+                    var next = store.preferences
+                    next.quotaRingsEnabled = false
+                    store.updatePreferences(next)
+                }
+
+                Divider()
+                    .padding(.leading, 44)
+                    .padding(.vertical, 2)
+            }
+
+            accountList
+        }
+    }
+
     private var accountList: some View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 0) {
-                    if showsQuotaRings {
-                        QuotaRingsPanel(snapshots: store.snapshots) {
-                            var next = store.preferences
-                            next.quotaRingsEnabled = false
-                            store.updatePreferences(next)
-                        }
-
-                        Divider()
-                            .padding(.leading, 44)
-                    }
-
                     ForEach(Array(sortedSnapshots.enumerated()), id: \.element.id) { index, snapshot in
                         AccountCard(snapshot: snapshot, store: store) { id in
                             DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
@@ -338,16 +358,15 @@ struct MenuContentView: View {
                             }
                         }
                         .id(snapshot.id)
-                        .transition(.move(edge: .top).combined(with: .opacity))
 
                         if index < sortedSnapshots.count - 1 {
                             Divider()
                                 .padding(.leading, 44)
+                                .padding(.vertical, 2)
                         }
                     }
                 }
                 .padding(.horizontal, 2)
-                .animation(.spring(response: 0.32, dampingFraction: 0.86), value: store.snapshots.map(\.id))
             }
             .frame(maxHeight: .infinity)
         }
@@ -399,10 +418,6 @@ struct MenuContentView: View {
             }
         }
         .padding(8)
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(Color.orange.opacity(0.3), lineWidth: 1)
-        )
+        .contentSurface(stroke: .orange)
     }
 }

--- a/Sources/Toki/Views/MenuContentView.swift
+++ b/Sources/Toki/Views/MenuContentView.swift
@@ -337,7 +337,7 @@ struct MenuContentView: View {
                 }
 
                 Divider()
-                    .padding(.leading, 44)
+                    .padding(.horizontal, 10)
                     .padding(.vertical, 2)
             }
 
@@ -361,12 +361,11 @@ struct MenuContentView: View {
 
                         if index < sortedSnapshots.count - 1 {
                             Divider()
-                                .padding(.leading, 44)
+                                .padding(.horizontal, 10)
                                 .padding(.vertical, 2)
                         }
                     }
                 }
-                .padding(.horizontal, 2)
             }
             .frame(maxHeight: .infinity)
         }

--- a/Sources/Toki/Views/OnboardingView.swift
+++ b/Sources/Toki/Views/OnboardingView.swift
@@ -61,7 +61,7 @@ struct OnboardingView: View {
             if let configError = store.configError {
                 Text(configError)
                     .font(.system(size: 9))
-                    .foregroundStyle(.tertiary)
+                    .foregroundStyle(.red)
             }
 
             Button {
@@ -139,11 +139,10 @@ private struct ProviderConnectRow: View {
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 6)
                     .padding(.vertical, 3)
-                    .background(Color.primary.opacity(0.06), in: Capsule())
+                    .background(.fill.quaternary, in: Capsule())
             }
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 6)
-        .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 7, style: .continuous))
     }
 }

--- a/Sources/Toki/Views/ProviderLogo.swift
+++ b/Sources/Toki/Views/ProviderLogo.swift
@@ -159,15 +159,27 @@ struct TokiLogoMark: View {
     var size: CGFloat
 
     var body: some View {
-        SVGLogoMark(asset: "toki-logo", size: size) {
-            ZStack {
-                RoundedRectangle(cornerRadius: size * 0.22, style: .continuous)
-                    .fill(Color.primary.opacity(0.08))
-                Image(systemName: "wallet.pass")
-                    .font(.system(size: size * 0.48, weight: .semibold))
-                    .foregroundStyle(.primary)
+        ZStack {
+            SVGLogoMark(asset: "toki-router-mark", size: size, template: true) {
+                Image(systemName: "point.3.connected.trianglepath.dotted")
+                    .font(.system(size: size * 0.52, weight: .semibold))
             }
+            .foregroundStyle(.primary)
+
+            Circle()
+                .fill(Color(red: 0.56, green: 0.66, blue: 0.61))
+                .frame(width: size * 0.076, height: size * 0.076)
+                .offset(x: size * 0.229, y: size * -0.219)
+
+            Circle()
+                .fill(Color(red: 0.79, green: 0.60, blue: 0.32))
+                .frame(width: size * 0.076, height: size * 0.076)
+                .offset(x: size * 0.227, y: size * 0.197)
         }
+        .frame(width: size, height: size)
+        .functionalGlass(
+            in: RoundedRectangle(cornerRadius: size * 0.286, style: .continuous)
+        )
         .accessibilityLabel("/toki")
     }
 }

--- a/Sources/Toki/Views/QuotaRingsPanel.swift
+++ b/Sources/Toki/Views/QuotaRingsPanel.swift
@@ -2,10 +2,10 @@ import AppKit
 import SwiftUI
 
 struct QuotaRingsPanel: View {
+    @Environment(\.colorScheme) private var colorScheme
     let snapshots: [AccountSnapshot]
     var onHide: () -> Void = {}
     @State private var hoveredSnapshotID: String?
-    @State private var cardsHeight: CGFloat = 84
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -27,18 +27,11 @@ struct QuotaRingsPanel: View {
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(
-                    GeometryReader { proxy in
-                        Color.clear
-                            .onAppear { cardsHeight = proxy.size.height }
-                            .onChange(of: proxy.size.height) { _, newValue in cardsHeight = newValue }
-                    }
-                )
 
                 QuotaRingsView(
                     snapshots: ringSnapshots,
                     colors: ringColors,
-                    size: min(88, max(68, cardsHeight - 8)),
+                    size: 88,
                     hoveredSnapshotID: $hoveredSnapshotID
                 )
                 .padding(.trailing, 4)
@@ -85,7 +78,7 @@ struct QuotaRingsPanel: View {
                 if let resetHint = snapshot.primaryWindow?.resetHint {
                     Text(resetHint)
                         .font(.system(size: 8, weight: .medium))
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(.secondary)
                         .lineLimit(1)
                         .truncationMode(.tail)
                 }
@@ -152,7 +145,7 @@ struct QuotaRingsPanel: View {
     private func shaded(_ base: Color, index: Int, count: Int) -> Color {
         let ns = NSColor(base).usingColorSpace(.sRGB) ?? NSColor(base)
         let t = count > 1 ? Double(index) / Double(count - 1) : 0.5
-        let factor = 0.68 + t * 0.64
+        let factor = colorScheme == .dark ? 1 + t * 0.32 : 0.72 + t * 0.28
         return Color(
             red: min(1, Double(ns.redComponent) * factor),
             green: min(1, Double(ns.greenComponent) * factor),
@@ -196,7 +189,7 @@ private struct QuotaRingsView: View {
             if let centerProvider {
                 ProviderLogo(provider: centerProvider, size: centerBadgeSize * 0.6)
                     .frame(width: centerBadgeSize, height: centerBadgeSize)
-                    .background(.regularMaterial, in: Circle())
+                    .background(.fill.tertiary, in: Circle())
                     .overlay(Circle().stroke(Color.primary.opacity(0.10), lineWidth: 1))
                     .allowsHitTesting(false)
                     .transition(.opacity)

--- a/Sources/Toki/Views/SettingsPanel.swift
+++ b/Sources/Toki/Views/SettingsPanel.swift
@@ -288,11 +288,14 @@ struct SettingsPanel: View {
                     Button {
                         updateChecker.checkNow()
                     } label: {
-                        if updateChecker.isChecking {
-                            ProgressView()
-                                .controlSize(.small)
-                        } else {
+                        ZStack {
                             Text("Check now")
+                                .opacity(updateChecker.isChecking ? 0 : 1)
+                            if updateChecker.isChecking {
+                                ProgressView()
+                                    .controlSize(.small)
+                                    .accessibilityLabel("Checking for updates")
+                            }
                         }
                     }
                     .buttonStyle(.bordered)

--- a/Sources/Toki/Views/SpendAnalyticsPanel.swift
+++ b/Sources/Toki/Views/SpendAnalyticsPanel.swift
@@ -5,6 +5,7 @@ struct SpendAnalyticsPanel: View {
     @ObservedObject var store: UsageStore
     @State private var piTotals: PiUsageClient.Totals?
     @State private var openCodeTotals: OpenCodeUsageClient.Totals?
+    @State private var isLoadingLocalTotals = true
     @State private var selectedRange: TimeRange = .day
     @State private var selectedAgentID: Int32?
 
@@ -102,7 +103,15 @@ struct SpendAnalyticsPanel: View {
             let week = (piTotals?.weekCost ?? 0) + (openCodeTotals?.weekCost ?? 0)
             let month = (piTotals?.monthCost ?? 0) + (openCodeTotals?.monthCost ?? 0)
             let allTime = (piTotals?.allTimeCost ?? 0) + (openCodeTotals?.allTimeCost ?? 0)
-            if piTotals != nil || openCodeTotals != nil {
+            if isLoadingLocalTotals && hasLocalCostProvider {
+                HStack(spacing: 4) {
+                    spendBlock(label: "Today", cost: 0)
+                    spendBlock(label: "Week", cost: 0)
+                    spendBlock(label: "Month", cost: 0)
+                    spendBlock(label: "All Time", cost: 0)
+                }
+                .redacted(reason: .placeholder)
+            } else if piTotals != nil || openCodeTotals != nil {
                 HStack(spacing: 4) {
                     spendBlock(label: "Today", cost: today)
                     spendBlock(label: "Week", cost: week)
@@ -164,32 +173,33 @@ struct SpendAnalyticsPanel: View {
                 }
 
                 // Hover detail / total line
-                if let selID = selectedAgentID,
-                   let agent = costAgents.first(where: { $0.id == selID }),
-                   let cost = agent.sessionUsage?.cost {
-                    HStack(spacing: 6) {
-                        ProviderLogo(provider: agent.provider, size: 14)
-                        Text(agent.title)
-                            .font(.system(size: 10, weight: .medium))
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                        Spacer()
-                        Text(cost, format: .currency(code: "USD").precision(.fractionLength(2)))
-                            .font(.system(size: 11, weight: .bold, design: .monospaced))
+                Group {
+                    if let selID = selectedAgentID,
+                       let agent = costAgents.first(where: { $0.id == selID }),
+                       let cost = agent.sessionUsage?.cost {
+                        HStack(spacing: 6) {
+                            ProviderLogo(provider: agent.provider, size: 14)
+                            Text(agent.title)
+                                .font(.system(size: 10, weight: .medium))
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                            Spacer()
+                            Text(cost, format: .currency(code: "USD").precision(.fractionLength(2)))
+                                .font(.system(size: 11, weight: .bold, design: .monospaced))
+                        }
+                    } else {
+                        HStack {
+                            Text("Total")
+                                .font(.system(size: 10))
+                                .foregroundStyle(.tertiary)
+                            Spacer()
+                            Text(totalCost, format: .currency(code: "USD").precision(.fractionLength(2)))
+                                .font(.system(size: 11, weight: .bold, design: .monospaced))
+                        }
                     }
-                    .padding(.horizontal, 4)
-                    .transition(.opacity)
-                } else {
-                    HStack {
-                        Text("Total")
-                            .font(.system(size: 10))
-                            .foregroundStyle(.tertiary)
-                        Spacer()
-                        Text(totalCost, format: .currency(code: "USD").precision(.fractionLength(2)))
-                            .font(.system(size: 11, weight: .bold, design: .monospaced))
-                    }
-                    .padding(.horizontal, 4)
                 }
+                .frame(height: 14)
+                .padding(.horizontal, 4)
 
                 ForEach(costAgents) { agent in
                     HStack(spacing: 8) {
@@ -216,7 +226,7 @@ struct SpendAnalyticsPanel: View {
                 }
             }
 
-            if costProviders.isEmpty && piTotals == nil && openCodeTotals == nil && costAgents.isEmpty {
+            if !isLoadingLocalTotals && costProviders.isEmpty && piTotals == nil && openCodeTotals == nil && costAgents.isEmpty {
                 emptyState(icon: "dollarsign.circle", text: "No spend data yet")
             }
         }
@@ -444,12 +454,17 @@ struct SpendAnalyticsPanel: View {
     }
 
     private func loadPiTotals() async {
+        defer { isLoadingLocalTotals = false }
         if store.snapshots.contains(where: { $0.provider == .pi }) {
             piTotals = try? PiUsageClient.aggregate()
         }
         if store.snapshots.contains(where: { $0.provider == .openCode }) {
             openCodeTotals = try? OpenCodeUsageClient.aggregate()
         }
+    }
+
+    private var hasLocalCostProvider: Bool {
+        store.snapshots.contains { $0.provider == .pi || $0.provider == .openCode }
     }
 }
 

--- a/Sources/Toki/Views/UsageHeatmap.swift
+++ b/Sources/Toki/Views/UsageHeatmap.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct UsageHeatmap: View {
     @ObservedObject var store: UsageStore
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
     @State private var provider: Provider?
     @State private var isPulsing = false
     @State private var hoveredDay: HeatmapDay?
@@ -92,10 +93,16 @@ struct UsageHeatmap: View {
                     }
                 }
             }
+
+            Color.clear
+                .frame(height: 26)
         }
-        .opacity(isPulsing ? 0.55 : 1)
-        .animation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true), value: isPulsing)
-        .onAppear { isPulsing = true }
+        .opacity(accessibilityReduceMotion ? 1 : (isPulsing ? 0.55 : 1))
+        .animation(
+            accessibilityReduceMotion ? nil : .easeInOut(duration: 0.9).repeatForever(autoreverses: true),
+            value: isPulsing
+        )
+        .onAppear { isPulsing = !accessibilityReduceMotion }
         .accessibilityLabel("Loading daily usage")
     }
 

--- a/Sources/TokiWidgets/TokiWidgets.swift
+++ b/Sources/TokiWidgets/TokiWidgets.swift
@@ -247,11 +247,12 @@ private func disambiguatedTitles(_ entries: [WidgetEntry]) -> [String: String] {
 }
 
 private struct QuotaRings: View {
+    @Environment(\.colorScheme) private var colorScheme
     let entries: [WidgetEntry]
     let size: CGFloat
 
     var body: some View {
-        let colors = resolvedRingColors(ringEntries)
+        let colors = resolvedRingColors(ringEntries, colorScheme: colorScheme)
         return ZStack {
             ForEach(Array(ringEntries.enumerated()), id: \.element.id) { index, item in
                 let diameter = size - CGFloat(index) * ringSpacing * 2
@@ -319,6 +320,7 @@ private func providerColor(_ provider: String) -> Color {
 
 private struct TokiQuotaRingsEntryView: View {
     @Environment(\.widgetFamily) private var family
+    @Environment(\.colorScheme) private var colorScheme
     let entry: TokiTimelineEntry
 
     var body: some View {
@@ -349,7 +351,7 @@ private struct TokiQuotaRingsEntryView: View {
 
             if family == .systemMedium {
                 let rings = ringEntries(data)
-                let colors = resolvedRingColors(rings)
+                let colors = resolvedRingColors(rings, colorScheme: colorScheme)
                 HStack(spacing: 22) {
                     QuotaRings(entries: data.entries, size: 104)
                     VStack(alignment: .leading, spacing: 10) {
@@ -402,7 +404,7 @@ private func distinctByID(_ entries: [WidgetEntry]) -> [WidgetEntry] {
     return entries.filter { seen.insert($0.id).inserted }
 }
 
-private func resolvedRingColors(_ entries: [WidgetEntry]) -> [String: Color] {
+private func resolvedRingColors(_ entries: [WidgetEntry], colorScheme: ColorScheme) -> [String: Color] {
     var result: [String: Color] = [:]
     let groups = Dictionary(grouping: entries, by: { $0.provider })
     for (_, group) in groups {
@@ -412,17 +414,22 @@ private func resolvedRingColors(_ entries: [WidgetEntry]) -> [String: Color] {
             } else if group.count == 1 {
                 result[entry.id] = providerColor(entry.provider)
             } else {
-                result[entry.id] = shadedColor(providerColor(entry.provider), index: index, count: group.count)
+                result[entry.id] = shadedColor(
+                    providerColor(entry.provider),
+                    index: index,
+                    count: group.count,
+                    colorScheme: colorScheme
+                )
             }
         }
     }
     return result
 }
 
-private func shadedColor(_ base: Color, index: Int, count: Int) -> Color {
+private func shadedColor(_ base: Color, index: Int, count: Int, colorScheme: ColorScheme) -> Color {
     let ns = NSColor(base).usingColorSpace(.sRGB) ?? NSColor(base)
     let t = count > 1 ? Double(index) / Double(count - 1) : 0.5
-    let factor = 0.68 + t * 0.64
+    let factor = colorScheme == .dark ? 1 + t * 0.32 : 0.72 + t * 0.28
     return Color(
         red: min(1, Double(ns.redComponent) * factor),
         green: min(1, Double(ns.greenComponent) * factor),
@@ -437,7 +444,7 @@ private struct ProviderGlyph: View {
     var body: some View {
         Group {
             if let assetName {
-                WidgetSVGLogo(asset: assetName, size: size)
+                WidgetSVGLogo(asset: assetName, size: size, template: item.provider == "grok")
             } else if let leadingText = item.leadingText, !leadingText.isEmpty {
                 Text(leadingText)
             } else {
@@ -485,13 +492,15 @@ private struct ProviderGlyph: View {
 private enum WidgetSVGAsset {
     @MainActor private static var cache: [String: NSImage] = [:]
 
-    @MainActor static func image(named name: String) -> NSImage? {
-        if let cached = cache[name] { return cached }
+    @MainActor static func image(named name: String, template: Bool = false) -> NSImage? {
+        let cacheKey = "\(name):\(template)"
+        if let cached = cache[cacheKey] { return cached }
         guard let url = Bundle.main.url(forResource: name, withExtension: "svg"),
               let image = NSImage(contentsOf: url) else {
             return nil
         }
-        cache[name] = image
+        image.isTemplate = template
+        cache[cacheKey] = image
         return image
     }
 }
@@ -499,13 +508,15 @@ private enum WidgetSVGAsset {
 private struct WidgetSVGLogo: View {
     let asset: String
     let size: CGFloat
+    var template = false
 
     var body: some View {
         Group {
-            if let image = WidgetSVGAsset.image(named: asset) {
+            if let image = WidgetSVGAsset.image(named: asset, template: template) {
                 Image(nsImage: image)
                     .resizable()
                     .scaledToFit()
+                    .foregroundStyle(.primary)
             } else {
                 Image(systemName: "app.fill")
                     .resizable()


### PR DESCRIPTION
Prep for **v2.5.1-beta.2**'s successor, **v2.5.1-beta.3**, continuing on `release/v2.5.1` after beta.2.

## Changes since beta.2

- Fix Liquid Glass layout regressions (#48, by @thepushkarp), including restoring the pinned quota layout.

Further beta.3 tweaks will land directly on `release/v2.5.1` and accumulate here.

Build + 186 tests green on the branch.