### PR TITLE
Release v2.5.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,11 @@ jobs:
           echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
 
       - name: Build and package
-        run: bash scripts/package-release.sh
+        env:
+          TOKI_RELEASE_VERSION: ${{ github.ref_name }}
+        run: |
+          export TOKI_RELEASE_VERSION="${TOKI_RELEASE_VERSION#v}"
+          bash scripts/package-release.sh
 
       - name: Notarize DMG
         # notarytool rejects ad-hoc signed binaries outright, so if notarization creds are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Quota rings now draw one ring per account instead of collapsing accounts that share a provider, so two Claude (or two Codex) accounts each get their own ring and side card. Each is given a distinct color (the account's label color, or a shaded provider color), and multiple accounts of a provider show their alias to tell them apart. The same fix applies to the quota-rings widget and the usage widget.
 - The quota rings now scale to the available height so they read clearly next to the account cards.
 - With multiple Claude Code accounts, a running session was shown on every Claude card. It is now attributed to the active account only (the one `claude-swap` has switched to), so inactive accounts no longer double-count it.
+- Beta builds now carry their full release version (e.g. `2.5.1-beta.3`), so the in-app updater on the beta channel correctly offers the next beta and graduates to the stable release. Previously every build of a version reported the same base version, so betas never saw each other.
 
 ## 2.5.0 - 2026-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.5.1 - Unreleased
+## 2.5.1 - 2026-07-27
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version 2.5.0" src="https://img.shields.io/badge/version-2.5.0-2f80ed">
+  <img alt="Version 2.5.1" src="https://img.shields.io/badge/version-2.5.1-2f80ed">
   <img alt="Downloads" src="https://img.shields.io/github/downloads/aashutoshrathi/toki/total">
   <img alt="Stars" src="https://img.shields.io/github/stars/aashutoshrathi/toki">
   <img alt="macOS 14+" src="https://img.shields.io/badge/macOS-14%2B-111111">

--- a/Sources/Toki/Updates/UpdateChecker.swift
+++ b/Sources/Toki/Updates/UpdateChecker.swift
@@ -71,9 +71,20 @@ final class UpdateChecker: ObservableObject {
     private let mockVersion: String?
     private var checkTimer: Timer?
 
+    // The full release identity of this build, including any prerelease suffix, so a beta can see
+    // the next beta and the eventual stable. Release DMGs carry it in Info.plist; local/dev builds
+    // fall back to the marketing version.
+    nonisolated static var installedVersion: String {
+        guard let value = Bundle.main.object(forInfoDictionaryKey: "TokiReleaseVersion") as? String,
+              !value.isEmpty else {
+            return appVersion
+        }
+        return value
+    }
+
     init(
         session: URLSession = .shared,
-        currentVersion: String = appVersion,
+        currentVersion: String = UpdateChecker.installedVersion,
         apiBaseURL: URL = URL(string: "https://api.github.com/repos/aashutoshrathi/toki")!,
         defaults: UserDefaults = .standard,
         mockVersion: String? = ProcessInfo.processInfo.environment["TOKI_MOCK_UPDATE_VERSION"]

--- a/Tests/TokiTests/UpdateChannelTests.swift
+++ b/Tests/TokiTests/UpdateChannelTests.swift
@@ -40,6 +40,18 @@ final class UpdateChannelTests: XCTestCase {
         XCTAssertFalse(UpdateChecker.isNewerVersion("2.5.0-beta.1", than: "2.5.0-beta.1"))
     }
 
+    // Only works when the build reports its full beta identity, which is why release builds carry
+    // TokiReleaseVersion rather than the dotted-numeric CFBundleShortVersionString.
+    func testBetaSeesNextBetaAndGraduatesToStable() {
+        XCTAssertTrue(UpdateChecker.isNewerVersion("2.5.1-beta.3", than: "2.5.1-beta.2"))
+        XCTAssertTrue(UpdateChecker.isNewerVersion("2.5.1", than: "2.5.1-beta.2"))
+        XCTAssertFalse(UpdateChecker.isNewerVersion("2.5.1-beta.2", than: "2.5.1"))
+    }
+
+    func testInstalledVersionFallsBackToMarketingVersionWithoutTheKey() {
+        XCTAssertEqual(UpdateChecker.installedVersion, appVersion)
+    }
+
     func testPrereleaseIdentifierRules() {
         // Fewer identifiers sort first: -beta < -beta.1 (semver spec rule 11).
         XCTAssertTrue(UpdateChecker.isNewerVersion("2.5.0-beta.1", than: "2.5.0-beta"))

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -6,6 +6,10 @@ cd "$ROOT_DIR"
 
 APP_NAME="Toki"
 VERSION=$(grep '^let appVersion' Sources/Toki/Config/Constants.swift | sed 's/.*"\(.*\)"/\1/')
+# The full release identity, including any prerelease suffix (e.g. 2.5.1-beta.3). CFBundleShort-
+# VersionString must stay dotted-numeric, so the updater compares against this instead, letting a
+# beta see the next beta and the eventual stable. Falls back to the marketing version locally.
+RELEASE_VERSION="${TOKI_RELEASE_VERSION:-$VERSION}"
 BUILD_NUMBER="${TOKI_BUILD_NUMBER:-10}"
 if [[ -n "${APPLE_SIGNING_IDENTITY:-}" ]]; then
   WIDGET_DATA_MODE="app-group"
@@ -75,6 +79,8 @@ cat > "$INFO_PLIST" <<PLIST
   <string>$VERSION</string>
   <key>CFBundleVersion</key>
   <string>$BUILD_NUMBER</string>
+  <key>TokiReleaseVersion</key>
+  <string>$RELEASE_VERSION</string>
   <key>TokiWidgetDataMode</key>
   <string>$WIDGET_DATA_MODE</string>
   <key>LSMinimumSystemVersion</key>
@@ -110,6 +116,8 @@ cat > "$WIDGET_DIR/Contents/Info.plist" <<PLIST
   <string>$VERSION</string>
   <key>CFBundleVersion</key>
   <string>$BUILD_NUMBER</string>
+  <key>TokiReleaseVersion</key>
+  <string>$RELEASE_VERSION</string>
   <key>TokiWidgetDataMode</key>
   <string>$WIDGET_DATA_MODE</string>
   <key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
Promote **v2.5.1** to stable (the stable of beta.1/2/3, already on main), plus a real fix for beta-channel updates.

## Release prep

- Set the 2.5.1 changelog date to **2026-07-27**.
- Bump the README version badge to 2.5.1.

## Fix: beta-channel updates never fired

Every build of a version reported the same base `CFBundleShortVersionString` (`2.5.1`). A `2.5.1-beta.N` app therefore considered itself **newer** than `2.5.1-beta.M` and than stable `2.5.1` (a prerelease sorts below its release in semver), so the updater always said "up to date." That is why beta.2 never saw beta.3.

Release builds now write the full tag version (e.g. `2.5.1-beta.3`) into a `TokiReleaseVersion` Info.plist key (via `package-release.sh` + `release.yml`), and `UpdateChecker` compares against that, falling back to the marketing version for local/dev builds. Tests cover the beta -> next-beta -> stable ordering and the fallback.

Note: this only helps builds that carry the key, so already-installed 2.5.1-beta.1/2/3 DMGs (which lack it) still cannot auto-update within 2.5.1; they graduate once on 2.5.2, or via a one-time manual install of stable 2.5.1.

## What's in 2.5.1

Liquid Glass redesign (#34, #47, #48, #50), Cursor support (#33), and the multi-account quota-rings and Claude-attribution fixes.

## After merge

Tag `v2.5.1` on the merge commit to cut stable (updates the Homebrew cask); I will set the GitHub release notes then.