### PR TITLE
v2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.5.2 - Unreleased
+## 2.5.2 - 2026-07-27
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.5.2 - Unreleased
+
+### Fixed
+
+- The reset-credit badge (redeem a banked Codex reset) is clickable again on the collapsed account card. The card's tap-to-expand gesture was swallowing taps meant for the buttons inside it.
+
 ## 2.5.1 - 2026-07-27
 
 ### Added

--- a/Sources/Toki/Config/Constants.swift
+++ b/Sources/Toki/Config/Constants.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-let appVersion = "2.5.1"
+let appVersion = "2.5.2"
 let appUserAgent = "Toki/\(appVersion)"
 let defaultConfigPath = "~/.toki/config.json"
 let defaultStatePath = "~/.toki/usage-state.json"

--- a/Sources/Toki/Views/AccountCard.swift
+++ b/Sources/Toki/Views/AccountCard.swift
@@ -304,7 +304,7 @@ struct AccountCard: View {
                 guard !isEditingAlias else { return }
                 toggleExpanded()
             },
-            including: .gesture
+            including: .all
         )
         .onHover { isHovered = $0 }
         .animation(.easeOut(duration: 0.12), value: isHovered)


### PR DESCRIPTION
Patch release for **2.5.2**.

## Fixed

- The reset-credit badge (redeem a banked Codex reset) is clickable again on the collapsed account card. The Liquid Glass redesign's card tap-to-expand gesture used `including: .gesture`, which disables every gesture in the card's subviews, so the button inside never received taps. Switched to `.all` so background taps still expand the card while inline controls (reset, Switch) work.

Version bumped to 2.5.2. Build + 188 tests green.

Cut a beta (`v2.5.2-beta.1`) or go straight to stable (`v2.5.2`) from the merge commit, your call.