### PR TITLE
Fix multi-display popover anchoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- On multiple displays, the popover now stays below the menu bar item that was clicked instead of rejecting the display change and falling back to stale coordinates from another screen.
+
 ## 2.5.2 - 2026-07-27
 
 ### Fixed

--- a/Sources/Toki/App/AppDelegate.swift
+++ b/Sources/Toki/App/AppDelegate.swift
@@ -7,6 +7,53 @@ final class PassthroughHostingView<Content: View>: NSHostingView<Content> {
     }
 }
 
+func popoverStatusFrameIsUsable(
+    _ candidate: NSRect,
+    screenFrames: [NSRect],
+    activationPoint: NSPoint?,
+    lastKnownFrame: NSRect?
+) -> Bool {
+    guard candidate.width > 0, candidate.height > 0,
+          let candidateScreen = screenFrames.first(where: { $0.intersects(candidate) }) else {
+        return false
+    }
+
+    if let activationPoint {
+        guard candidateScreen.contains(activationPoint) else { return false }
+        // The action came from this button, so its settled horizontal bounds must remain under
+        // the click. During an auto-hide reveal AppKit can briefly report a far-left frame on the
+        // correct display; checking the display alone cannot distinguish that transient frame.
+        return activationPoint.x >= candidate.minX - 12 && activationPoint.x <= candidate.maxX + 12
+    }
+
+    // Non-pointer activation has no click to validate against. Retain the old jump guard only
+    // within one display; moving the active menu bar to another display is a legitimate jump.
+    if let lastKnownFrame,
+       let lastScreen = screenFrames.first(where: { $0.intersects(lastKnownFrame) }),
+       lastScreen == candidateScreen,
+       abs(candidate.midX - lastKnownFrame.midX) > 200 {
+        return false
+    }
+    return true
+}
+
+func popoverFallbackAnchorX(
+    on screenFrame: NSRect,
+    activationPoint: NSPoint?,
+    lastKnownFrame: NSRect?
+) -> CGFloat {
+    let x: CGFloat
+    if let activationPoint, screenFrame.contains(activationPoint) {
+        x = activationPoint.x
+    } else if let lastKnownFrame,
+              screenFrame.contains(NSPoint(x: lastKnownFrame.midX, y: lastKnownFrame.midY)) {
+        x = lastKnownFrame.midX
+    } else {
+        x = screenFrame.midX
+    }
+    return min(max(x, screenFrame.minX + 1), screenFrame.maxX - 1)
+}
+
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var statusItem: NSStatusItem!
@@ -160,16 +207,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         } else {
             // Anchoring immediately can race the status bar's layout pass, and NSPopover then
             // falls back to the screen corner. Defer and retry until the button has a position.
-            presentPopover(retriesRemaining: 6)
+            presentPopover(retriesRemaining: 6, activationPoint: currentPointerActivationPoint())
             store.refresh(keepsExistingSnapshots: true, minimumRefreshInterval: 60)
             store.refreshActiveAgents()
             store.rescanProviders()
         }
     }
 
+    private func currentPointerActivationPoint() -> NSPoint? {
+        guard let event = NSApp.currentEvent else { return nil }
+        switch event.type {
+        case .leftMouseDown, .leftMouseUp, .rightMouseDown, .rightMouseUp,
+             .otherMouseDown, .otherMouseUp:
+            return NSEvent.mouseLocation
+        default:
+            return nil
+        }
+    }
+
     // Waits for the button to report a real on-screen position; falls back to a transient
     // anchor window if it never does (hidden behind the notch, or in the overflow menu).
-    private func presentPopover(retriesRemaining: Int) {
+    private func presentPopover(retriesRemaining: Int, activationPoint: NSPoint?) {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             // In notch mode the status item is hidden, so the panel is the anchor.
@@ -181,7 +239,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 return
             }
             guard let button = self.statusItem.button else { return }
-            if self.hasValidScreenPosition(button) {
+            if self.hasValidScreenPosition(button, activationPoint: activationPoint) {
                 self.popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
                 self.configurePopoverBackdrop()
                 self.popover.contentViewController?.view.window?.makeKey()
@@ -189,10 +247,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 // 40ms is long enough to let a menu-bar reveal animation advance without the
                 // click feeling laggy across the handful of retries.
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.04) { [weak self] in
-                    self?.presentPopover(retriesRemaining: retriesRemaining - 1)
+                    self?.presentPopover(
+                        retriesRemaining: retriesRemaining - 1,
+                        activationPoint: activationPoint
+                    )
                 }
             } else {
-                self.showFallbackPopover()
+                self.showFallbackPopover(activationPoint: activationPoint)
             }
         }
     }
@@ -202,18 +263,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var lastKnownStatusFrame: NSRect?
 
     // `bounds` stays non-empty even off-screen, so convert and require a real display.
-    private func hasValidScreenPosition(_ button: NSStatusBarButton) -> Bool {
+    private func hasValidScreenPosition(_ button: NSStatusBarButton, activationPoint: NSPoint?) -> Bool {
         guard !button.bounds.isEmpty, let window = button.window else { return false }
         let screenRect = window.convertToScreen(button.convert(button.bounds, to: nil))
-        guard screenRect.width > 0, screenRect.height > 0 else { return false }
-        guard NSScreen.screens.contains(where: { $0.frame.intersects(screenRect) }) else { return false }
-        // While an auto-hidden menu bar is revealing, the item can briefly report a far-left
-        // origin; anchoring there drops the popover in the top-left corner. A status item doesn't
-        // jump horizontally between clicks, so if this is far from where we last saw it, treat it
-        // as not-yet-settled and let the retry (then fallback) place it near the icon instead.
-        if let last = lastKnownStatusFrame, abs(screenRect.midX - last.midX) > 200 {
-            return false
-        }
+        guard popoverStatusFrameIsUsable(
+            screenRect,
+            screenFrames: NSScreen.screens.map(\.frame),
+            activationPoint: activationPoint,
+            lastKnownFrame: lastKnownStatusFrame
+        ) else { return false }
         lastKnownStatusFrame = screenRect
         return true
     }
@@ -235,15 +293,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         return window
     }()
 
-    private func showFallbackPopover() {
-        // Prefer the screen under the pointer, so multi-display anchors correctly.
-        let mouse = NSEvent.mouseLocation
-        let screen = NSScreen.screens.first { $0.frame.contains(mouse) } ?? NSScreen.main ?? NSScreen.screens.first
+    private func showFallbackPopover(activationPoint: NSPoint?) {
+        // Use the original click even if the pointer moved while the status bar was settling.
+        let referencePoint = activationPoint ?? NSEvent.mouseLocation
+        let screen = NSScreen.screens.first { $0.frame.contains(referencePoint) } ?? NSScreen.main ?? NSScreen.screens.first
         guard let screen, let anchorView = fallbackAnchorWindow.contentView else { return }
 
-        // Anchor under the icon's last-known x when we have one, so a menu-bar reveal that never
-        // settles still drops the popover near the status item rather than at the screen centre.
-        let anchorX = lastKnownStatusFrame.map { min(max($0.midX, screen.frame.minX + 1), screen.frame.maxX - 1) } ?? screen.frame.midX
+        // A last-known frame from another display is stale for this click. Clamping its global x
+        // into this screen would pin the popover to an unrelated edge.
+        let anchorX = popoverFallbackAnchorX(
+            on: screen.frame,
+            activationPoint: activationPoint,
+            lastKnownFrame: lastKnownStatusFrame
+        )
         let origin = NSPoint(x: anchorX, y: screen.visibleFrame.maxY - 1)
         fallbackAnchorWindow.setFrame(NSRect(origin: origin, size: NSSize(width: 1, height: 1)), display: false)
         fallbackAnchorWindow.orderFrontRegardless()

--- a/Tests/TokiTests/PopoverPositioningTests.swift
+++ b/Tests/TokiTests/PopoverPositioningTests.swift
@@ -1,0 +1,69 @@
+import AppKit
+import XCTest
+@testable import Toki
+
+final class PopoverPositioningTests: XCTestCase {
+    private let primary = NSRect(x: 0, y: 0, width: 1512, height: 982)
+    private let secondary = NSRect(x: 1512, y: 120, width: 1920, height: 1080)
+
+    func testCrossDisplayMoveMatchingClickIsAccepted() {
+        let previous = NSRect(x: 1300, y: 956, width: 100, height: 24)
+        let candidate = NSRect(x: 3200, y: 1174, width: 100, height: 24)
+
+        XCTAssertTrue(popoverStatusFrameIsUsable(
+            candidate,
+            screenFrames: [primary, secondary],
+            activationPoint: NSPoint(x: 3250, y: 1185),
+            lastKnownFrame: previous
+        ))
+    }
+
+    func testFarLeftRevealFrameIsRejectedOnClickedDisplay() {
+        let candidate = NSRect(x: 1512, y: 1174, width: 100, height: 24)
+
+        XCTAssertFalse(popoverStatusFrameIsUsable(
+            candidate,
+            screenFrames: [primary, secondary],
+            activationPoint: NSPoint(x: 3250, y: 1185),
+            lastKnownFrame: nil
+        ))
+    }
+
+    func testNegativeDisplayCoordinatesAreAccepted() {
+        let leftDisplay = NSRect(x: -1920, y: -160, width: 1920, height: 1080)
+        let candidate = NSRect(x: -220, y: 894, width: 100, height: 24)
+
+        XCTAssertTrue(popoverStatusFrameIsUsable(
+            candidate,
+            screenFrames: [leftDisplay, primary],
+            activationPoint: NSPoint(x: -170, y: 905),
+            lastKnownFrame: nil
+        ))
+    }
+
+    func testFallbackPrefersClickOverFrameFromAnotherDisplay() {
+        let previous = NSRect(x: 1300, y: 956, width: 100, height: 24)
+
+        XCTAssertEqual(
+            popoverFallbackAnchorX(
+                on: secondary,
+                activationPoint: NSPoint(x: 3250, y: 1185),
+                lastKnownFrame: previous
+            ),
+            3250
+        )
+    }
+
+    func testFallbackRetainsLastKnownXOnSameDisplayWithoutClick() {
+        let previous = NSRect(x: 3200, y: 1174, width: 100, height: 24)
+
+        XCTAssertEqual(
+            popoverFallbackAnchorX(
+                on: secondary,
+                activationPoint: nil,
+                lastKnownFrame: previous
+            ),
+            previous.midX
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- keep the popover below the menu bar item that initiated the click when moving between displays
- preserve the existing auto-hidden menu bar retry and fallback behavior
- prevent fallback from reusing stale coordinates from another display
- add focused coverage for cross-display, auto-hide, negative-coordinate, and fallback positioning

## Root cause

The auto-hide workaround treated any horizontal status-item movement over 200 points as an invalid transient position. macOS legitimately moves the status item much farther when the active menu bar changes displays, so Toki rejected the correct frame and eventually anchored using an x-coordinate remembered from the previous screen.

## Validation

- `swift test` — 193 tests passed
- `scripts/build-app.sh`
- `codesign --verify --deep --strict .build/Toki.app`
- `plutil -lint .build/Toki.app/Contents/Info.plist`
- `git diff --check`
- manually verified across multiple displays