### PR TITLE
v2.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- On multiple displays, the popover now stays below the menu bar item that was clicked instead of rejecting the display change and falling back to stale coordinates from another screen.
+
 ## 2.5.2 - 2026-07-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## 2.5.3 - 2026-07-27
+## 2.5.3 - 2026-07-28
 
 ### Fixed
 
 - On multiple displays, the popover now stays below the menu bar item that was clicked instead of rejecting the display change and falling back to stale coordinates from another screen.
+- Clicking an agent running in a VS Code integrated terminal now raises the specific workspace window that hosts it, so on a multi-display setup you land on the right window and screen instead of whichever one macOS happened to focus.
 
 ## 2.5.2 - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed
 
 - On multiple displays, the popover now stays below the menu bar item that was clicked instead of rejecting the display change and falling back to stale coordinates from another screen.
-- Clicking an agent running in a VS Code integrated terminal now raises the specific workspace window that hosts it, so on a multi-display setup you land on the right window and screen instead of whichever one macOS happened to focus.
+- When Toki has Accessibility access, clicking an agent running in a VS Code integrated terminal now tries to raise the specific workspace window that hosts it, so on a multi-display setup you are more likely to land on the right window and screen. Without that permission it falls back to bringing VS Code forward as before.
 
 ## 2.5.2 - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.5.3 - 2026-07-27
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 2.5.3 - 2026-07-28
 
+### Changed
+
+- On macOS 26, the usage and quota-rings widgets now render on the system's Liquid Glass material, bringing them in line with the app's redesigned popover. Older macOS keeps the existing look.
+
 ### Fixed
 
 - On multiple displays, the popover now stays below the menu bar item that was clicked instead of rejecting the display change and falling back to stale coordinates from another screen.

--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ApplicationServices
 import Foundation
 
 struct AgentSessionUsage: Hashable, Sendable {
@@ -330,6 +331,7 @@ enum ActiveAgentNavigator {
            let running = NSRunningApplication(processIdentifier: pid_t(hostProcessID)),
            running.activationPolicy == .regular {
             running.activate(options: [.activateAllWindows])
+            raiseWorkspaceWindow(pid: running.processIdentifier, directory: agent.directory)
             return
         }
 
@@ -337,23 +339,45 @@ enum ActiveAgentNavigator {
         // The host's own bundle id is matched first and exactly, so with both VS Code and VS
         // Code Insiders running the click lands on the variant that actually holds the agent
         // rather than whichever the system happens to list first.
-        if let host = agent.hostApp, activate(bundleID: host.bundleID) {
+        if let host = agent.hostApp, activate(bundleID: host.bundleID, directory: agent.directory) {
             return
         }
         // Only when the ancestry walk named no host: raise any known terminal that's running.
-        for bundleID in ["com.googlecode.iterm2", "com.apple.Terminal", "com.microsoft.VSCode"] where activate(bundleID: bundleID) {
+        for bundleID in ["com.googlecode.iterm2", "com.apple.Terminal", "com.microsoft.VSCode"]
+        where activate(bundleID: bundleID, directory: agent.directory) {
             return
         }
         DiagnosticLogger.shared.record(.warning, component: "agents", code: "navigation_unavailable")
     }
 
     @discardableResult
-    private static func activate(bundleID: String) -> Bool {
+    private static func activate(bundleID: String, directory: String?) -> Bool {
         guard let application = NSWorkspace.shared.runningApplications.first(where: {
             $0.activationPolicy == .regular && $0.bundleIdentifier == bundleID
         }) else { return false }
         application.activate(options: [.activateAllWindows])
+        raiseWorkspaceWindow(pid: application.processIdentifier, directory: directory)
         return true
+    }
+
+    private static func raiseWorkspaceWindow(pid: pid_t, directory: String?) {
+        guard let directory else { return }
+        let folder = (directory as NSString).lastPathComponent
+        guard !folder.isEmpty, folder != "/" else { return }
+
+        let app = AXUIElementCreateApplication(pid)
+        var windowsValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(app, kAXWindowsAttribute as CFString, &windowsValue) == .success,
+              let windows = windowsValue as? [AXUIElement] else { return }
+
+        for window in windows {
+            var titleValue: CFTypeRef?
+            guard AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleValue) == .success,
+                  let title = titleValue as? String, title.contains(folder) else { continue }
+            AXUIElementSetAttributeValue(window, kAXMainAttribute as CFString, kCFBooleanTrue)
+            AXUIElementPerformAction(window, kAXRaiseAction as CFString)
+            return
+        }
     }
 
     nonisolated private static func isSafeTTY(_ value: String) -> Bool {

--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -331,7 +331,7 @@ enum ActiveAgentNavigator {
            let running = NSRunningApplication(processIdentifier: pid_t(hostProcessID)),
            running.activationPolicy == .regular {
             running.activate(options: [.activateAllWindows])
-            raiseWorkspaceWindow(pid: running.processIdentifier, directory: agent.directory)
+            raiseWorkspaceWindow(pid: running.processIdentifier, bundleID: running.bundleIdentifier, directory: agent.directory)
             return
         }
 
@@ -356,12 +356,19 @@ enum ActiveAgentNavigator {
             $0.activationPolicy == .regular && $0.bundleIdentifier == bundleID
         }) else { return false }
         application.activate(options: [.activateAllWindows])
-        raiseWorkspaceWindow(pid: application.processIdentifier, directory: directory)
+        raiseWorkspaceWindow(pid: application.processIdentifier, bundleID: bundleID, directory: directory)
         return true
     }
 
-    private static func raiseWorkspaceWindow(pid: pid_t, directory: String?) {
-        guard let directory else { return }
+    private static let workspaceWindowBundleIDs: Set<String> = [
+        "com.microsoft.VSCode",
+        "com.microsoft.VSCodeInsiders",
+        "com.visualstudio.code.oss",
+        "com.vscodium",
+    ]
+
+    private static func raiseWorkspaceWindow(pid: pid_t, bundleID: String?, directory: String?) {
+        guard let bundleID, workspaceWindowBundleIDs.contains(bundleID), let directory else { return }
         let folder = (directory as NSString).lastPathComponent
         guard !folder.isEmpty, folder != "/" else { return }
 

--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -373,7 +373,8 @@ enum ActiveAgentNavigator {
         for window in windows {
             var titleValue: CFTypeRef?
             guard AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleValue) == .success,
-                  let title = titleValue as? String, title.contains(folder) else { continue }
+                  let title = titleValue as? String,
+                  title == folder || title.hasSuffix(" \(folder)") else { continue }
             AXUIElementSetAttributeValue(window, kAXMainAttribute as CFString, kCFBooleanTrue)
             AXUIElementPerformAction(window, kAXRaiseAction as CFString)
             return

--- a/Sources/Toki/App/AppDelegate.swift
+++ b/Sources/Toki/App/AppDelegate.swift
@@ -7,6 +7,53 @@ final class PassthroughHostingView<Content: View>: NSHostingView<Content> {
     }
 }
 
+func popoverStatusFrameIsUsable(
+    _ candidate: NSRect,
+    screenFrames: [NSRect],
+    activationPoint: NSPoint?,
+    lastKnownFrame: NSRect?
+) -> Bool {
+    guard candidate.width > 0, candidate.height > 0,
+          let candidateScreen = screenFrames.first(where: { $0.intersects(candidate) }) else {
+        return false
+    }
+
+    if let activationPoint {
+        guard candidateScreen.contains(activationPoint) else { return false }
+        // The action came from this button, so its settled horizontal bounds must remain under
+        // the click. During an auto-hide reveal AppKit can briefly report a far-left frame on the
+        // correct display; checking the display alone cannot distinguish that transient frame.
+        return activationPoint.x >= candidate.minX - 12 && activationPoint.x <= candidate.maxX + 12
+    }
+
+    // Non-pointer activation has no click to validate against. Retain the old jump guard only
+    // within one display; moving the active menu bar to another display is a legitimate jump.
+    if let lastKnownFrame,
+       let lastScreen = screenFrames.first(where: { $0.intersects(lastKnownFrame) }),
+       lastScreen == candidateScreen,
+       abs(candidate.midX - lastKnownFrame.midX) > 200 {
+        return false
+    }
+    return true
+}
+
+func popoverFallbackAnchorX(
+    on screenFrame: NSRect,
+    activationPoint: NSPoint?,
+    lastKnownFrame: NSRect?
+) -> CGFloat {
+    let x: CGFloat
+    if let activationPoint, screenFrame.contains(activationPoint) {
+        x = activationPoint.x
+    } else if let lastKnownFrame,
+              screenFrame.contains(NSPoint(x: lastKnownFrame.midX, y: lastKnownFrame.midY)) {
+        x = lastKnownFrame.midX
+    } else {
+        x = screenFrame.midX
+    }
+    return min(max(x, screenFrame.minX + 1), screenFrame.maxX - 1)
+}
+
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var statusItem: NSStatusItem!
@@ -160,16 +207,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         } else {
             // Anchoring immediately can race the status bar's layout pass, and NSPopover then
             // falls back to the screen corner. Defer and retry until the button has a position.
-            presentPopover(retriesRemaining: 6)
+            presentPopover(retriesRemaining: 6, activationPoint: currentPointerActivationPoint())
             store.refresh(keepsExistingSnapshots: true, minimumRefreshInterval: 60)
             store.refreshActiveAgents()
             store.rescanProviders()
         }
     }
 
+    private func currentPointerActivationPoint() -> NSPoint? {
+        guard let event = NSApp.currentEvent else { return nil }
+        switch event.type {
+        case .leftMouseDown, .leftMouseUp, .rightMouseDown, .rightMouseUp,
+             .otherMouseDown, .otherMouseUp:
+            return NSEvent.mouseLocation
+        default:
+            return nil
+        }
+    }
+
     // Waits for the button to report a real on-screen position; falls back to a transient
     // anchor window if it never does (hidden behind the notch, or in the overflow menu).
-    private func presentPopover(retriesRemaining: Int) {
+    private func presentPopover(retriesRemaining: Int, activationPoint: NSPoint?) {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             // In notch mode the status item is hidden, so the panel is the anchor.
@@ -181,7 +239,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 return
             }
             guard let button = self.statusItem.button else { return }
-            if self.hasValidScreenPosition(button) {
+            if self.hasValidScreenPosition(button, activationPoint: activationPoint) {
                 self.popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
                 self.configurePopoverBackdrop()
                 self.popover.contentViewController?.view.window?.makeKey()
@@ -189,10 +247,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
                 // 40ms is long enough to let a menu-bar reveal animation advance without the
                 // click feeling laggy across the handful of retries.
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.04) { [weak self] in
-                    self?.presentPopover(retriesRemaining: retriesRemaining - 1)
+                    self?.presentPopover(
+                        retriesRemaining: retriesRemaining - 1,
+                        activationPoint: activationPoint
+                    )
                 }
             } else {
-                self.showFallbackPopover()
+                self.showFallbackPopover(activationPoint: activationPoint)
             }
         }
     }
@@ -202,18 +263,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
     private var lastKnownStatusFrame: NSRect?
 
     // `bounds` stays non-empty even off-screen, so convert and require a real display.
-    private func hasValidScreenPosition(_ button: NSStatusBarButton) -> Bool {
+    private func hasValidScreenPosition(_ button: NSStatusBarButton, activationPoint: NSPoint?) -> Bool {
         guard !button.bounds.isEmpty, let window = button.window else { return false }
         let screenRect = window.convertToScreen(button.convert(button.bounds, to: nil))
-        guard screenRect.width > 0, screenRect.height > 0 else { return false }
-        guard NSScreen.screens.contains(where: { $0.frame.intersects(screenRect) }) else { return false }
-        // While an auto-hidden menu bar is revealing, the item can briefly report a far-left
-        // origin; anchoring there drops the popover in the top-left corner. A status item doesn't
-        // jump horizontally between clicks, so if this is far from where we last saw it, treat it
-        // as not-yet-settled and let the retry (then fallback) place it near the icon instead.
-        if let last = lastKnownStatusFrame, abs(screenRect.midX - last.midX) > 200 {
-            return false
-        }
+        guard popoverStatusFrameIsUsable(
+            screenRect,
+            screenFrames: NSScreen.screens.map(\.frame),
+            activationPoint: activationPoint,
+            lastKnownFrame: lastKnownStatusFrame
+        ) else { return false }
         lastKnownStatusFrame = screenRect
         return true
     }
@@ -235,15 +293,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         return window
     }()
 
-    private func showFallbackPopover() {
-        // Prefer the screen under the pointer, so multi-display anchors correctly.
-        let mouse = NSEvent.mouseLocation
-        let screen = NSScreen.screens.first { $0.frame.contains(mouse) } ?? NSScreen.main ?? NSScreen.screens.first
+    private func showFallbackPopover(activationPoint: NSPoint?) {
+        // Use the original click even if the pointer moved while the status bar was settling.
+        let referencePoint = activationPoint ?? NSEvent.mouseLocation
+        let screen = NSScreen.screens.first { $0.frame.contains(referencePoint) } ?? NSScreen.main ?? NSScreen.screens.first
         guard let screen, let anchorView = fallbackAnchorWindow.contentView else { return }
 
-        // Anchor under the icon's last-known x when we have one, so a menu-bar reveal that never
-        // settles still drops the popover near the status item rather than at the screen centre.
-        let anchorX = lastKnownStatusFrame.map { min(max($0.midX, screen.frame.minX + 1), screen.frame.maxX - 1) } ?? screen.frame.midX
+        // A last-known frame from another display is stale for this click. Clamping its global x
+        // into this screen would pin the popover to an unrelated edge.
+        let anchorX = popoverFallbackAnchorX(
+            on: screen.frame,
+            activationPoint: activationPoint,
+            lastKnownFrame: lastKnownStatusFrame
+        )
         let origin = NSPoint(x: anchorX, y: screen.visibleFrame.maxY - 1)
         fallbackAnchorWindow.setFrame(NSRect(origin: origin, size: NSSize(width: 1, height: 1)), display: false)
         fallbackAnchorWindow.orderFrontRegardless()

--- a/Sources/Toki/Config/Constants.swift
+++ b/Sources/Toki/Config/Constants.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-let appVersion = "2.5.2"
+let appVersion = "2.5.3"
 let appUserAgent = "Toki/\(appVersion)"
 let defaultConfigPath = "~/.toki/config.json"
 let defaultStatePath = "~/.toki/usage-state.json"

--- a/Sources/TokiWidgets/TokiWidgets.swift
+++ b/Sources/TokiWidgets/TokiWidgets.swift
@@ -93,7 +93,7 @@ private struct TokiWidgetEntryView: View {
                 emptyState
             }
         }
-        .containerBackground(.fill.tertiary, for: .widget)
+        .widgetContainerBackground()
     }
 
     @ViewBuilder
@@ -333,7 +333,7 @@ private struct TokiQuotaRingsEntryView: View {
                 emptyState
             }
         }
-        .containerBackground(.fill.tertiary, for: .widget)
+        .widgetContainerBackground()
     }
 
     private func content(_ data: WidgetDataSnapshot) -> some View {
@@ -553,6 +553,17 @@ private extension Color {
             green: Double((value >> 8) & 0xff) / 255,
             blue: Double(value & 0xff) / 255
         )
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func widgetContainerBackground() -> some View {
+        if #available(macOS 26, *) {
+            containerBackground(.regularMaterial, for: .widget)
+        } else {
+            containerBackground(.fill.tertiary, for: .widget)
+        }
     }
 }
 

--- a/Tests/TokiTests/PopoverPositioningTests.swift
+++ b/Tests/TokiTests/PopoverPositioningTests.swift
@@ -1,0 +1,69 @@
+import AppKit
+import XCTest
+@testable import Toki
+
+final class PopoverPositioningTests: XCTestCase {
+    private let primary = NSRect(x: 0, y: 0, width: 1512, height: 982)
+    private let secondary = NSRect(x: 1512, y: 120, width: 1920, height: 1080)
+
+    func testCrossDisplayMoveMatchingClickIsAccepted() {
+        let previous = NSRect(x: 1300, y: 956, width: 100, height: 24)
+        let candidate = NSRect(x: 3200, y: 1174, width: 100, height: 24)
+
+        XCTAssertTrue(popoverStatusFrameIsUsable(
+            candidate,
+            screenFrames: [primary, secondary],
+            activationPoint: NSPoint(x: 3250, y: 1185),
+            lastKnownFrame: previous
+        ))
+    }
+
+    func testFarLeftRevealFrameIsRejectedOnClickedDisplay() {
+        let candidate = NSRect(x: 1512, y: 1174, width: 100, height: 24)
+
+        XCTAssertFalse(popoverStatusFrameIsUsable(
+            candidate,
+            screenFrames: [primary, secondary],
+            activationPoint: NSPoint(x: 3250, y: 1185),
+            lastKnownFrame: nil
+        ))
+    }
+
+    func testNegativeDisplayCoordinatesAreAccepted() {
+        let leftDisplay = NSRect(x: -1920, y: -160, width: 1920, height: 1080)
+        let candidate = NSRect(x: -220, y: 894, width: 100, height: 24)
+
+        XCTAssertTrue(popoverStatusFrameIsUsable(
+            candidate,
+            screenFrames: [leftDisplay, primary],
+            activationPoint: NSPoint(x: -170, y: 905),
+            lastKnownFrame: nil
+        ))
+    }
+
+    func testFallbackPrefersClickOverFrameFromAnotherDisplay() {
+        let previous = NSRect(x: 1300, y: 956, width: 100, height: 24)
+
+        XCTAssertEqual(
+            popoverFallbackAnchorX(
+                on: secondary,
+                activationPoint: NSPoint(x: 3250, y: 1185),
+                lastKnownFrame: previous
+            ),
+            3250
+        )
+    }
+
+    func testFallbackRetainsLastKnownXOnSameDisplayWithoutClick() {
+        let previous = NSRect(x: 3200, y: 1174, width: 100, height: 24)
+
+        XCTAssertEqual(
+            popoverFallbackAnchorX(
+                on: secondary,
+                activationPoint: nil,
+                lastKnownFrame: previous
+            ),
+            previous.midX
+        )
+    }
+}


### PR DESCRIPTION
Release **v2.5.3** (`release/v2.5.3` → `main`).

## Changed
- On macOS 26, the usage and quota-rings widgets render on the system's Liquid Glass material, matching the app's redesigned popover. Older macOS keeps the existing `.fill.tertiary` look, so nothing regresses below 26 (#59).

## Fixed
- On multiple displays, the popover stays below the menu bar item that was clicked instead of rejecting the display change and falling back to stale coordinates from another screen (#54, by @thepushkarp).
- When Toki has Accessibility access, clicking an agent in a VS Code integrated terminal tries to raise the specific workspace window hosting it, so on a multi-display setup you are more likely to land on the right window (#58). Scoped to VS Code variants and matched by window-title suffix.

## Known limitation (shipping best-effort)
Codex review flagged that the VS Code window-raise is a no-op unless Toki already has Accessibility permission (the app does not yet prompt for it), and that the title match uses the agent cwd basename, so a subdirectory cwd or two same-named workspaces can miss or mis-target. Shipping as best-effort for 2.5.3 (falls back to the prior whole-app activation); hardening tracked in #60.

## Release paperwork
- `appVersion` bumped to `2.5.3` (`Sources/Toki/Config/Constants.swift`).
- CHANGELOG `## 2.5.3 - 2026-07-28` section written.

## Ship
Merge to `main`, then tag `v2.5.3` to trigger the release build + Homebrew cask update.