### PR TITLE
Focus the right VS Code window when navigating to an agent

### DIFF
--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -1,4 +1,5 @@
 import AppKit
+import ApplicationServices
 import Foundation
 
 struct AgentSessionUsage: Hashable, Sendable {
@@ -330,6 +331,7 @@ enum ActiveAgentNavigator {
            let running = NSRunningApplication(processIdentifier: pid_t(hostProcessID)),
            running.activationPolicy == .regular {
             running.activate(options: [.activateAllWindows])
+            raiseWorkspaceWindow(pid: running.processIdentifier, directory: agent.directory)
             return
         }
 
@@ -337,23 +339,45 @@ enum ActiveAgentNavigator {
         // The host's own bundle id is matched first and exactly, so with both VS Code and VS
         // Code Insiders running the click lands on the variant that actually holds the agent
         // rather than whichever the system happens to list first.
-        if let host = agent.hostApp, activate(bundleID: host.bundleID) {
+        if let host = agent.hostApp, activate(bundleID: host.bundleID, directory: agent.directory) {
             return
         }
         // Only when the ancestry walk named no host: raise any known terminal that's running.
-        for bundleID in ["com.googlecode.iterm2", "com.apple.Terminal", "com.microsoft.VSCode"] where activate(bundleID: bundleID) {
+        for bundleID in ["com.googlecode.iterm2", "com.apple.Terminal", "com.microsoft.VSCode"]
+        where activate(bundleID: bundleID, directory: agent.directory) {
             return
         }
         DiagnosticLogger.shared.record(.warning, component: "agents", code: "navigation_unavailable")
     }
 
     @discardableResult
-    private static func activate(bundleID: String) -> Bool {
+    private static func activate(bundleID: String, directory: String?) -> Bool {
         guard let application = NSWorkspace.shared.runningApplications.first(where: {
             $0.activationPolicy == .regular && $0.bundleIdentifier == bundleID
         }) else { return false }
         application.activate(options: [.activateAllWindows])
+        raiseWorkspaceWindow(pid: application.processIdentifier, directory: directory)
         return true
+    }
+
+    private static func raiseWorkspaceWindow(pid: pid_t, directory: String?) {
+        guard let directory else { return }
+        let folder = (directory as NSString).lastPathComponent
+        guard !folder.isEmpty, folder != "/" else { return }
+
+        let app = AXUIElementCreateApplication(pid)
+        var windowsValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(app, kAXWindowsAttribute as CFString, &windowsValue) == .success,
+              let windows = windowsValue as? [AXUIElement] else { return }
+
+        for window in windows {
+            var titleValue: CFTypeRef?
+            guard AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleValue) == .success,
+                  let title = titleValue as? String, title.contains(folder) else { continue }
+            AXUIElementSetAttributeValue(window, kAXMainAttribute as CFString, kCFBooleanTrue)
+            AXUIElementPerformAction(window, kAXRaiseAction as CFString)
+            return
+        }
     }
 
     nonisolated private static func isSafeTTY(_ value: String) -> Bool {

--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -331,7 +331,7 @@ enum ActiveAgentNavigator {
            let running = NSRunningApplication(processIdentifier: pid_t(hostProcessID)),
            running.activationPolicy == .regular {
             running.activate(options: [.activateAllWindows])
-            raiseWorkspaceWindow(pid: running.processIdentifier, directory: agent.directory)
+            raiseWorkspaceWindow(pid: running.processIdentifier, bundleID: running.bundleIdentifier, directory: agent.directory)
             return
         }
 
@@ -356,12 +356,19 @@ enum ActiveAgentNavigator {
             $0.activationPolicy == .regular && $0.bundleIdentifier == bundleID
         }) else { return false }
         application.activate(options: [.activateAllWindows])
-        raiseWorkspaceWindow(pid: application.processIdentifier, directory: directory)
+        raiseWorkspaceWindow(pid: application.processIdentifier, bundleID: bundleID, directory: directory)
         return true
     }
 
-    private static func raiseWorkspaceWindow(pid: pid_t, directory: String?) {
-        guard let directory else { return }
+    private static let workspaceWindowBundleIDs: Set<String> = [
+        "com.microsoft.VSCode",
+        "com.microsoft.VSCodeInsiders",
+        "com.visualstudio.code.oss",
+        "com.vscodium",
+    ]
+
+    private static func raiseWorkspaceWindow(pid: pid_t, bundleID: String?, directory: String?) {
+        guard let bundleID, workspaceWindowBundleIDs.contains(bundleID), let directory else { return }
         let folder = (directory as NSString).lastPathComponent
         guard !folder.isEmpty, folder != "/" else { return }
 

--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -373,7 +373,8 @@ enum ActiveAgentNavigator {
         for window in windows {
             var titleValue: CFTypeRef?
             guard AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleValue) == .success,
-                  let title = titleValue as? String, title.contains(folder) else { continue }
+                  let title = titleValue as? String,
+                  title == folder || title.hasSuffix(" \(folder)") else { continue }
             AXUIElementSetAttributeValue(window, kAXMainAttribute as CFString, kCFBooleanTrue)
             AXUIElementPerformAction(window, kAXRaiseAction as CFString)
             return


### PR DESCRIPTION
Prototype for #57.

## Problem
Clicking a VS Code-hosted agent whose window is on another display brings VS Code forward but focuses whatever window macOS picks (usually on the active display), not the workspace window holding the agent. Terminals don't have this issue because navigation selects the exact tab by tty; VS Code only got a blanket whole-app activation.

## Approach
After activating VS Code, use the Accessibility API to raise the window whose title contains the agent's workspace folder (`ActiveAgent.directory`'s last path component, which VS Code puts in its window titles). Applied in both navigation paths (`activate(bundleID:directory:)` and the regular-policy PID branch).

Falls through gracefully: if the Accessibility permission isn't granted, or no window title matches, the existing whole-app activation stands as the fallback, so behavior is never worse than today.

## Notes / open questions
- Title matching is `contains(folder)`, so two workspaces sharing a folder name, or an open file named like the folder in another window, could match the wrong window. A tighter match (VS Code appends ` — <folder>` at the end) would be more precise if we want it.
- Needs the Accessibility permission (Privacy > Accessibility) to actually raise the window; the app doesn't currently request it. Worth deciding whether to prompt for it or keep it best-effort.
- Verified it builds; not yet exercised live across displays.