### PR TITLE
Widgets: adopt Liquid Glass on macOS 26

### DIFF
--- a/Sources/TokiWidgets/TokiWidgets.swift
+++ b/Sources/TokiWidgets/TokiWidgets.swift
@@ -93,7 +93,7 @@ private struct TokiWidgetEntryView: View {
                 emptyState
             }
         }
-        .containerBackground(.fill.tertiary, for: .widget)
+        .widgetContainerBackground()
     }
 
     @ViewBuilder
@@ -333,7 +333,7 @@ private struct TokiQuotaRingsEntryView: View {
                 emptyState
             }
         }
-        .containerBackground(.fill.tertiary, for: .widget)
+        .widgetContainerBackground()
     }
 
     private func content(_ data: WidgetDataSnapshot) -> some View {
@@ -553,6 +553,17 @@ private extension Color {
             green: Double((value >> 8) & 0xff) / 255,
             blue: Double(value & 0xff) / 255
         )
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func widgetContainerBackground() -> some View {
+        if #available(macOS 26, *) {
+            containerBackground(.regularMaterial, for: .widget)
+        } else {
+            containerBackground(.fill.tertiary, for: .widget)
+        }
     }
 }
 


### PR DESCRIPTION
Brings the widgets onto the same Liquid Glass footing as the redesigned app popover, targeting `release/v2.5.3`.

## What changed
Both widget entry views (`TokiWidget` usage, `TokiQuotaRingsWidget`) now render their container with the Liquid Glass material on macOS 26, via a `widgetContainerBackground()` helper:

- macOS 26: `containerBackground(.regularMaterial, for: .widget)` so the system renders the widget's surface as Liquid Glass, mirroring the app's `glassEffect(.regular)`.
- Older macOS: keeps the existing `.fill.tertiary`, so nothing regresses below 26.

The gate mirrors exactly how the app applies glass in `ContentSurface.functionalGlass` (`#available(macOS 26, *)` glass, material fallback).

## Why it is a container-level change, not glassEffect everywhere
WidgetKit renders widgets as static archived snapshots. `glassEffect` is a live, interactive material meant for the running app, and it has no desktop backdrop to refract inside a widget snapshot. The supported way to get Liquid Glass in a widget is to let the system render the `containerBackground` material, which macOS 26 draws as Liquid Glass. So this adopts the app's look through the API WidgetKit actually honors, rather than forcing `glassEffect` onto subviews where it would not render.

## Scope and follow-ups
- Inner tiles (the medium usage widget's per-provider columns) still use the subtle `.fill.tertiary` content fill, layered on the glass container rather than glass-on-glass. Can flatten them to borderless rows to match the app's content-first hierarchy if we want to go further.

## Verification
- `swift build --target TokiWidgets` passes.
- Not yet verified visually on a macOS 26 device: WidgetKit's material rendering differs from the live popover, so the widget should be eyeballed in the gallery on 26. If `.regularMaterial` reads flat there, reverting the container to `.fill.tertiary` is a one-line change.

No changelog entry added yet; can add a 2.5.3 line once the look is confirmed on-device.