### PR TITLE
Harden VS Code multi-display window focus (beta 2)

### DIFF
--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -407,8 +407,7 @@ enum ActiveAgentNavigator {
         var value: CFTypeRef?
         guard AXUIElementCopyAttributeValue(window, kAXDocumentAttribute as CFString, &value) == .success,
               let document = value as? String else { return nil }
-        if let url = URL(string: document), url.isFileURL { return url.path }
-        return document
+        return WorkspaceWindowMatcher.documentPath(fromRawValue: document)
     }
 
     nonisolated private static func isSafeTTY(_ value: String) -> Bool {
@@ -511,6 +510,12 @@ enum WorkspaceWindowMatcher {
                 return index
             }
         }
+        return nil
+    }
+
+    static func documentPath(fromRawValue raw: String) -> String? {
+        if let url = URL(string: raw), url.isFileURL { return url.path }
+        if raw.hasPrefix("/") { return raw }
         return nil
     }
 

--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -379,33 +379,22 @@ enum ActiveAgentNavigator {
     }
 
     private static func raiseWorkspaceWindow(pid: pid_t, bundleID: String?, directory: String?) {
-        guard let bundleID, workspaceWindowBundleIDs.contains(bundleID), let directory else { return }
-        let candidates = workspaceNameCandidates(for: directory)
-        guard !candidates.isEmpty, hasAccessibilityAccess() else { return }
+        guard let bundleID, workspaceWindowBundleIDs.contains(bundleID), let directory,
+              !WorkspaceWindowMatcher.nameCandidates(for: directory).isEmpty,
+              hasAccessibilityAccess() else { return }
 
         let app = AXUIElementCreateApplication(pid)
         var windowsValue: CFTypeRef?
         guard AXUIElementCopyAttributeValue(app, kAXWindowsAttribute as CFString, &windowsValue) == .success,
               let windows = windowsValue as? [AXUIElement] else { return }
 
-        for candidate in candidates {
-            let matches = windows.filter { window in
-                guard let title = windowTitle(window) else { return false }
-                return title == candidate || title.hasSuffix(" \(candidate)")
-            }
-            guard !matches.isEmpty else { continue }
-            let target = bestMatch(matches, directory: directory, candidate: candidate)
-            AXUIElementSetAttributeValue(target, kAXMainAttribute as CFString, kCFBooleanTrue)
-            AXUIElementPerformAction(target, kAXRaiseAction as CFString)
-            return
+        let infos = windows.map {
+            WorkspaceWindowMatcher.WindowInfo(title: windowTitle($0) ?? "", documentPath: windowDocumentPath($0))
         }
-    }
-
-    private static func bestMatch(_ windows: [AXUIElement], directory: String, candidate: String) -> AXUIElement {
-        guard windows.count > 1, let root = workspaceRoot(of: directory, named: candidate) else { return windows[0] }
-        return windows.first { window in
-            windowDocumentPath(window).map { $0.hasPrefix(root) } ?? false
-        } ?? windows[0]
+        guard let index = WorkspaceWindowMatcher.pick(directory: directory, windows: infos) else { return }
+        let target = windows[index]
+        AXUIElementSetAttributeValue(target, kAXMainAttribute as CFString, kCFBooleanTrue)
+        AXUIElementPerformAction(target, kAXRaiseAction as CFString)
     }
 
     private static func windowTitle(_ window: AXUIElement) -> String? {
@@ -420,31 +409,6 @@ enum ActiveAgentNavigator {
               let document = value as? String else { return nil }
         if let url = URL(string: document), url.isFileURL { return url.path }
         return document
-    }
-
-    private static func workspaceNameCandidates(for directory: String) -> [String] {
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        var names: [String] = []
-        var path = (directory as NSString).standardizingPath
-        while !path.isEmpty, path != "/", path != home {
-            let name = (path as NSString).lastPathComponent
-            if !name.isEmpty, name != "/" { names.append(name) }
-            let parent = (path as NSString).deletingLastPathComponent
-            if parent == path { break }
-            path = parent
-        }
-        return names
-    }
-
-    private static func workspaceRoot(of directory: String, named candidate: String) -> String? {
-        var path = (directory as NSString).standardizingPath
-        while !path.isEmpty, path != "/" {
-            if (path as NSString).lastPathComponent == candidate { return path }
-            let parent = (path as NSString).deletingLastPathComponent
-            if parent == path { break }
-            path = parent
-        }
-        return nil
     }
 
     nonisolated private static func isSafeTTY(_ value: String) -> Bool {
@@ -518,5 +482,68 @@ enum ActiveAgentNavigator {
         end if
         error "TTY not found"
         """
+    }
+}
+
+enum WorkspaceWindowMatcher {
+    struct WindowInfo: Equatable {
+        let title: String
+        let documentPath: String?
+    }
+
+    static func pick(directory: String, windows: [WindowInfo]) -> Int? {
+        let candidates = nameCandidates(for: directory)
+        guard !candidates.isEmpty else { return nil }
+
+        for candidate in candidates {
+            guard let root = root(of: directory, named: candidate) else { continue }
+            if let index = windows.firstIndex(where: { window in
+                titleMatches(window.title, name: candidate)
+                    && (window.documentPath.map { isPath($0, under: root) } ?? false)
+            }) {
+                return index
+            }
+        }
+        for candidate in candidates {
+            if let index = windows.firstIndex(where: { window in
+                titleMatches(window.title, name: candidate) && window.documentPath == nil
+            }) {
+                return index
+            }
+        }
+        return nil
+    }
+
+    static func titleMatches(_ title: String, name: String) -> Bool {
+        title == name || title.hasSuffix(" \(name)")
+    }
+
+    static func isPath(_ path: String, under root: String) -> Bool {
+        path == root || path.hasPrefix(root + "/")
+    }
+
+    static func nameCandidates(for directory: String) -> [String] {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        var names: [String] = []
+        var path = (directory as NSString).standardizingPath
+        while !path.isEmpty, path != "/", path != home {
+            let name = (path as NSString).lastPathComponent
+            if !name.isEmpty, name != "/" { names.append(name) }
+            let parent = (path as NSString).deletingLastPathComponent
+            if parent == path { break }
+            path = parent
+        }
+        return names
+    }
+
+    static func root(of directory: String, named candidate: String) -> String? {
+        var path = (directory as NSString).standardizingPath
+        while !path.isEmpty, path != "/" {
+            if (path as NSString).lastPathComponent == candidate { return path }
+            let parent = (path as NSString).deletingLastPathComponent
+            if parent == path { break }
+            path = parent
+        }
+        return nil
     }
 }

--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -495,21 +495,21 @@ enum WorkspaceWindowMatcher {
         guard !candidates.isEmpty else { return nil }
 
         for candidate in candidates {
-            guard let rootPath = root(of: directory, named: candidate) else { continue }
+            guard let rootPath = root(of: directory, named: candidate).map(resolved) else { continue }
             if let index = windows.firstIndex(where: { window in
                 titleMatches(window.title, name: candidate)
-                    && (window.documentPath.map { isPath($0, under: rootPath) } ?? false)
+                    && (window.documentPath.map { isPath(resolved($0), under: rootPath) } ?? false)
             }) {
                 return index
             }
         }
         for candidate in candidates {
-            guard let rootPath = root(of: directory, named: candidate) else { continue }
+            guard let rootPath = root(of: directory, named: candidate).map(resolved) else { continue }
             let matches = windows.indices.filter { index in
                 let window = windows[index]
                 guard titleMatches(window.title, name: candidate) else { return false }
                 if let document = window.documentPath,
-                   let otherRoot = root(of: document, named: candidate),
+                   let otherRoot = root(of: document, named: candidate).map(resolved),
                    otherRoot != rootPath {
                     return false
                 }
@@ -518,6 +518,10 @@ enum WorkspaceWindowMatcher {
             if matches.count == 1 { return matches[0] }
         }
         return nil
+    }
+
+    static func resolved(_ path: String) -> String {
+        (path as NSString).resolvingSymlinksInPath
     }
 
     static func documentPath(fromRawValue raw: String) -> String? {

--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -367,25 +367,84 @@ enum ActiveAgentNavigator {
         "com.vscodium",
     ]
 
+    private static var didPromptAccessibility = false
+
+    private static func hasAccessibilityAccess() -> Bool {
+        if AXIsProcessTrusted() { return true }
+        if !didPromptAccessibility {
+            didPromptAccessibility = true
+            _ = AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": true] as CFDictionary)
+        }
+        return false
+    }
+
     private static func raiseWorkspaceWindow(pid: pid_t, bundleID: String?, directory: String?) {
         guard let bundleID, workspaceWindowBundleIDs.contains(bundleID), let directory else { return }
-        let folder = (directory as NSString).lastPathComponent
-        guard !folder.isEmpty, folder != "/" else { return }
+        let candidates = workspaceNameCandidates(for: directory)
+        guard !candidates.isEmpty, hasAccessibilityAccess() else { return }
 
         let app = AXUIElementCreateApplication(pid)
         var windowsValue: CFTypeRef?
         guard AXUIElementCopyAttributeValue(app, kAXWindowsAttribute as CFString, &windowsValue) == .success,
               let windows = windowsValue as? [AXUIElement] else { return }
 
-        for window in windows {
-            var titleValue: CFTypeRef?
-            guard AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleValue) == .success,
-                  let title = titleValue as? String,
-                  title == folder || title.hasSuffix(" \(folder)") else { continue }
-            AXUIElementSetAttributeValue(window, kAXMainAttribute as CFString, kCFBooleanTrue)
-            AXUIElementPerformAction(window, kAXRaiseAction as CFString)
+        for candidate in candidates {
+            let matches = windows.filter { window in
+                guard let title = windowTitle(window) else { return false }
+                return title == candidate || title.hasSuffix(" \(candidate)")
+            }
+            guard !matches.isEmpty else { continue }
+            let target = bestMatch(matches, directory: directory, candidate: candidate)
+            AXUIElementSetAttributeValue(target, kAXMainAttribute as CFString, kCFBooleanTrue)
+            AXUIElementPerformAction(target, kAXRaiseAction as CFString)
             return
         }
+    }
+
+    private static func bestMatch(_ windows: [AXUIElement], directory: String, candidate: String) -> AXUIElement {
+        guard windows.count > 1, let root = workspaceRoot(of: directory, named: candidate) else { return windows[0] }
+        return windows.first { window in
+            windowDocumentPath(window).map { $0.hasPrefix(root) } ?? false
+        } ?? windows[0]
+    }
+
+    private static func windowTitle(_ window: AXUIElement) -> String? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &value) == .success else { return nil }
+        return value as? String
+    }
+
+    private static func windowDocumentPath(_ window: AXUIElement) -> String? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(window, kAXDocumentAttribute as CFString, &value) == .success,
+              let document = value as? String else { return nil }
+        if let url = URL(string: document), url.isFileURL { return url.path }
+        return document
+    }
+
+    private static func workspaceNameCandidates(for directory: String) -> [String] {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        var names: [String] = []
+        var path = (directory as NSString).standardizingPath
+        while !path.isEmpty, path != "/", path != home {
+            let name = (path as NSString).lastPathComponent
+            if !name.isEmpty, name != "/" { names.append(name) }
+            let parent = (path as NSString).deletingLastPathComponent
+            if parent == path { break }
+            path = parent
+        }
+        return names
+    }
+
+    private static func workspaceRoot(of directory: String, named candidate: String) -> String? {
+        var path = (directory as NSString).standardizingPath
+        while !path.isEmpty, path != "/" {
+            if (path as NSString).lastPathComponent == candidate { return path }
+            let parent = (path as NSString).deletingLastPathComponent
+            if parent == path { break }
+            path = parent
+        }
+        return nil
     }
 
     nonisolated private static func isSafeTTY(_ value: String) -> Bool {

--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -495,20 +495,27 @@ enum WorkspaceWindowMatcher {
         guard !candidates.isEmpty else { return nil }
 
         for candidate in candidates {
-            guard let root = root(of: directory, named: candidate) else { continue }
+            guard let rootPath = root(of: directory, named: candidate) else { continue }
             if let index = windows.firstIndex(where: { window in
                 titleMatches(window.title, name: candidate)
-                    && (window.documentPath.map { isPath($0, under: root) } ?? false)
+                    && (window.documentPath.map { isPath($0, under: rootPath) } ?? false)
             }) {
                 return index
             }
         }
         for candidate in candidates {
-            if let index = windows.firstIndex(where: { window in
-                titleMatches(window.title, name: candidate) && window.documentPath == nil
-            }) {
-                return index
+            guard let rootPath = root(of: directory, named: candidate) else { continue }
+            let matches = windows.indices.filter { index in
+                let window = windows[index]
+                guard titleMatches(window.title, name: candidate) else { return false }
+                if let document = window.documentPath,
+                   let otherRoot = root(of: document, named: candidate),
+                   otherRoot != rootPath {
+                    return false
+                }
+                return true
             }
+            if matches.count == 1 { return matches[0] }
         }
         return nil
     }

--- a/Tests/TokiTests/WorkspaceWindowMatcherTests.swift
+++ b/Tests/TokiTests/WorkspaceWindowMatcherTests.swift
@@ -38,6 +38,20 @@ final class WorkspaceWindowMatcherTests: XCTestCase {
         XCTAssertEqual(WorkspaceWindowMatcher.pick(directory: "/work/project/src", windows: windows), 1)
     }
 
+    func testSymlinkedWorkspaceRootResolvesToCanonicalDocument() throws {
+        let fm = FileManager.default
+        let base = fm.temporaryDirectory.appendingPathComponent("wm-\(UUID().uuidString)")
+        let realProject = base.appendingPathComponent("real/project")
+        try fm.createDirectory(at: realProject, withIntermediateDirectories: true)
+        try fm.createSymbolicLink(at: base.appendingPathComponent("link"), withDestinationURL: base.appendingPathComponent("real"))
+        defer { try? fm.removeItem(at: base) }
+
+        let cwd = base.appendingPathComponent("link/project").path
+        let document = realProject.appendingPathComponent("main.swift").path
+        let windows = [Window(title: "project", documentPath: document)]
+        XCTAssertEqual(WorkspaceWindowMatcher.pick(directory: cwd, windows: windows), 0)
+    }
+
     func testNoMatchReturnsNil() {
         let windows = [Window(title: "unrelated", documentPath: "/x/y.swift")]
         XCTAssertNil(WorkspaceWindowMatcher.pick(directory: "/work/project", windows: windows))

--- a/Tests/TokiTests/WorkspaceWindowMatcherTests.swift
+++ b/Tests/TokiTests/WorkspaceWindowMatcherTests.swift
@@ -49,6 +49,19 @@ final class WorkspaceWindowMatcherTests: XCTestCase {
         XCTAssertFalse(WorkspaceWindowMatcher.isPath("/work/project-old/a.swift", under: "/work/project"))
     }
 
+    func testWindowWithExternalDocumentStillRaisedWhenTitleUnambiguous() {
+        let windows = [Window(title: "project", documentPath: "/somewhere/else/notes.txt")]
+        XCTAssertEqual(WorkspaceWindowMatcher.pick(directory: "/work/project/src", windows: windows), 0)
+    }
+
+    func testAmbiguousSameNameWithoutConfirmingDocumentIsNotGuessed() {
+        let windows = [
+            Window(title: "project", documentPath: nil),
+            Window(title: "project", documentPath: nil),
+        ]
+        XCTAssertNil(WorkspaceWindowMatcher.pick(directory: "/work/project/src", windows: windows))
+    }
+
     func testDocumentPathAcceptsFileURLsAndPosixPathsOnly() {
         XCTAssertEqual(WorkspaceWindowMatcher.documentPath(fromRawValue: "file:///work/project/a.swift"), "/work/project/a.swift")
         XCTAssertEqual(WorkspaceWindowMatcher.documentPath(fromRawValue: "/work/project/a.swift"), "/work/project/a.swift")

--- a/Tests/TokiTests/WorkspaceWindowMatcherTests.swift
+++ b/Tests/TokiTests/WorkspaceWindowMatcherTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import Toki
+
+final class WorkspaceWindowMatcherTests: XCTestCase {
+    private typealias Window = WorkspaceWindowMatcher.WindowInfo
+
+    func testExactWorkspaceRootWithDocument() {
+        let windows = [Window(title: "project", documentPath: "/work/project/main.swift")]
+        XCTAssertEqual(WorkspaceWindowMatcher.pick(directory: "/work/project", windows: windows), 0)
+    }
+
+    func testSubdirectoryMatchesAncestorWorkspace() {
+        let windows = [Window(title: "main.swift - project", documentPath: "/work/project/src/main.swift")]
+        XCTAssertEqual(WorkspaceWindowMatcher.pick(directory: "/work/project/src", windows: windows), 0)
+    }
+
+    func testUnrelatedDeeperNameIsNotPreferredOverRealAncestor() {
+        let windows = [
+            Window(title: "src", documentPath: "/other/src/x.swift"),
+            Window(title: "project", documentPath: "/work/project/y.swift"),
+        ]
+        XCTAssertEqual(WorkspaceWindowMatcher.pick(directory: "/work/project/src", windows: windows), 1)
+    }
+
+    func testDocumentedUnrelatedWindowIsSkippedForNoDocumentFallback() {
+        let windows = [
+            Window(title: "src", documentPath: "/other/src/x.swift"),
+            Window(title: "project", documentPath: nil),
+        ]
+        XCTAssertEqual(WorkspaceWindowMatcher.pick(directory: "/work/project/src", windows: windows), 1)
+    }
+
+    func testSameTitleDisambiguatedByDocumentPathOnComponentBoundary() {
+        let windows = [
+            Window(title: "project", documentPath: "/work/project-old/a.swift"),
+            Window(title: "project", documentPath: "/work/project/b.swift"),
+        ]
+        XCTAssertEqual(WorkspaceWindowMatcher.pick(directory: "/work/project/src", windows: windows), 1)
+    }
+
+    func testNoMatchReturnsNil() {
+        let windows = [Window(title: "unrelated", documentPath: "/x/y.swift")]
+        XCTAssertNil(WorkspaceWindowMatcher.pick(directory: "/work/project", windows: windows))
+    }
+
+    func testIsPathRespectsComponentBoundaries() {
+        XCTAssertTrue(WorkspaceWindowMatcher.isPath("/work/project", under: "/work/project"))
+        XCTAssertTrue(WorkspaceWindowMatcher.isPath("/work/project/sub/f.swift", under: "/work/project"))
+        XCTAssertFalse(WorkspaceWindowMatcher.isPath("/work/project-old/a.swift", under: "/work/project"))
+    }
+
+    func testTitleMatchesOnlyOnFullTrailingComponent() {
+        XCTAssertTrue(WorkspaceWindowMatcher.titleMatches("project", name: "project"))
+        XCTAssertTrue(WorkspaceWindowMatcher.titleMatches("file - project", name: "project"))
+        XCTAssertFalse(WorkspaceWindowMatcher.titleMatches("notproject", name: "project"))
+    }
+}

--- a/Tests/TokiTests/WorkspaceWindowMatcherTests.swift
+++ b/Tests/TokiTests/WorkspaceWindowMatcherTests.swift
@@ -49,6 +49,18 @@ final class WorkspaceWindowMatcherTests: XCTestCase {
         XCTAssertFalse(WorkspaceWindowMatcher.isPath("/work/project-old/a.swift", under: "/work/project"))
     }
 
+    func testDocumentPathAcceptsFileURLsAndPosixPathsOnly() {
+        XCTAssertEqual(WorkspaceWindowMatcher.documentPath(fromRawValue: "file:///work/project/a.swift"), "/work/project/a.swift")
+        XCTAssertEqual(WorkspaceWindowMatcher.documentPath(fromRawValue: "/work/project/a.swift"), "/work/project/a.swift")
+        XCTAssertNil(WorkspaceWindowMatcher.documentPath(fromRawValue: "untitled:Untitled-1"))
+        XCTAssertNil(WorkspaceWindowMatcher.documentPath(fromRawValue: "vscode-userdata:/foo"))
+    }
+
+    func testUntitledEditorWindowStillFallsBackToTitleMatch() {
+        let windows = [Window(title: "project", documentPath: WorkspaceWindowMatcher.documentPath(fromRawValue: "untitled:Untitled-1"))]
+        XCTAssertEqual(WorkspaceWindowMatcher.pick(directory: "/work/project", windows: windows), 0)
+    }
+
     func testTitleMatchesOnlyOnFullTrailingComponent() {
         XCTAssertTrue(WorkspaceWindowMatcher.titleMatches("project", name: "project"))
         XCTAssertTrue(WorkspaceWindowMatcher.titleMatches("file - project", name: "project"))


### PR DESCRIPTION
Closes #60. Targets 2.5.3 beta 2.

Hardens the best-effort VS Code window-raise shipped in `v2.5.3-beta.1`. Reviewed with Codex across several rounds; findings addressed and locked with unit tests.

## What it does
- **Accessibility prompt (P1):** checks `AXIsProcessTrusted()` and triggers the system Accessibility prompt once per launch when access is missing, so the window-raise actually works on default installs. Whole-app activation remains the fallback while access is not granted.
- **Workspace-root matching (P2):** walks the agent cwd's ancestors (up to home) and matches the VS Code window whose title carries a workspace folder name, deepest first, so an agent launched from a subdirectory still finds its window.
- **Document-confirmed disambiguation (P2):** when a window's open document is under the resolved workspace root, it is chosen directly; this disambiguates workspaces that share a folder name.

## Codex findings addressed
- Reject a title match only when the window's document proves it belongs to a different same-named workspace; otherwise raise the unambiguous title match (covers workspaces with an external/multi-root document open).
- Path containment checks respect component boundaries (`/work/project-old` is not under `/work/project`).
- Non-file `AXDocument` values (for example `untitled:` editors) are treated as no document, so the title fallback still applies.
- Workspace roots are compared by resolved filesystem path, so a symlinked cwd matches a canonical document path.

The matching logic is factored into a pure `WorkspaceWindowMatcher` and covered by `WorkspaceWindowMatcherTests`.

## Verification
- `swift build` passes.
- `swift test` - 206 tests, 0 failures (13 in the matcher suite, encoding each scenario above).
- AX raising not exercised live here; still worth an on-device multi-display check, including granting the new Accessibility prompt.

Tag `v2.5.3-beta.2` after merge (hyphenated tag -> prerelease, Homebrew skipped).