### PR TITLE
Release 2.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- The header controls (refresh, privacy, Settings, and More) now respond to a click anywhere on the button, not just on the icon. The glass square was larger than its tappable area, so clicks near the edges did nothing.
 - On multiple displays, the popover now stays below the menu bar item that was clicked instead of rejecting the display change and falling back to stale coordinates from another screen.
 - When Toki has Accessibility access, clicking an agent running in a VS Code integrated terminal now tries to raise the specific workspace window that hosts it, so on a multi-display setup you are more likely to land on the right window and screen. Without that permission it falls back to bringing VS Code forward as before.
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ scripts/install-app.sh        # build a bundle and install to ~/Applications
 | [Providers](docs/providers.md) | Claude Code, Codex, Pi, OpenCode, and the detection-only ones |
 | [Features](docs/features.md) | Agents, heatmap, widgets, quota rings, notch mode, insights, notifications, updates |
 | [Development](docs/development.md) | Building, concurrency checking, conventions, troubleshooting |
+| [Release signing](docs/release-signing.md) | Apple secrets for signing and notarizing release builds |
 
 ## Privacy
 

--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -407,8 +407,7 @@ enum ActiveAgentNavigator {
         var value: CFTypeRef?
         guard AXUIElementCopyAttributeValue(window, kAXDocumentAttribute as CFString, &value) == .success,
               let document = value as? String else { return nil }
-        if let url = URL(string: document), url.isFileURL { return url.path }
-        return document
+        return WorkspaceWindowMatcher.documentPath(fromRawValue: document)
     }
 
     nonisolated private static func isSafeTTY(_ value: String) -> Bool {
@@ -511,6 +510,12 @@ enum WorkspaceWindowMatcher {
                 return index
             }
         }
+        return nil
+    }
+
+    static func documentPath(fromRawValue raw: String) -> String? {
+        if let url = URL(string: raw), url.isFileURL { return url.path }
+        if raw.hasPrefix("/") { return raw }
         return nil
     }
 

--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -379,33 +379,22 @@ enum ActiveAgentNavigator {
     }
 
     private static func raiseWorkspaceWindow(pid: pid_t, bundleID: String?, directory: String?) {
-        guard let bundleID, workspaceWindowBundleIDs.contains(bundleID), let directory else { return }
-        let candidates = workspaceNameCandidates(for: directory)
-        guard !candidates.isEmpty, hasAccessibilityAccess() else { return }
+        guard let bundleID, workspaceWindowBundleIDs.contains(bundleID), let directory,
+              !WorkspaceWindowMatcher.nameCandidates(for: directory).isEmpty,
+              hasAccessibilityAccess() else { return }
 
         let app = AXUIElementCreateApplication(pid)
         var windowsValue: CFTypeRef?
         guard AXUIElementCopyAttributeValue(app, kAXWindowsAttribute as CFString, &windowsValue) == .success,
               let windows = windowsValue as? [AXUIElement] else { return }
 
-        for candidate in candidates {
-            let matches = windows.filter { window in
-                guard let title = windowTitle(window) else { return false }
-                return title == candidate || title.hasSuffix(" \(candidate)")
-            }
-            guard !matches.isEmpty else { continue }
-            let target = bestMatch(matches, directory: directory, candidate: candidate)
-            AXUIElementSetAttributeValue(target, kAXMainAttribute as CFString, kCFBooleanTrue)
-            AXUIElementPerformAction(target, kAXRaiseAction as CFString)
-            return
+        let infos = windows.map {
+            WorkspaceWindowMatcher.WindowInfo(title: windowTitle($0) ?? "", documentPath: windowDocumentPath($0))
         }
-    }
-
-    private static func bestMatch(_ windows: [AXUIElement], directory: String, candidate: String) -> AXUIElement {
-        guard windows.count > 1, let root = workspaceRoot(of: directory, named: candidate) else { return windows[0] }
-        return windows.first { window in
-            windowDocumentPath(window).map { $0.hasPrefix(root) } ?? false
-        } ?? windows[0]
+        guard let index = WorkspaceWindowMatcher.pick(directory: directory, windows: infos) else { return }
+        let target = windows[index]
+        AXUIElementSetAttributeValue(target, kAXMainAttribute as CFString, kCFBooleanTrue)
+        AXUIElementPerformAction(target, kAXRaiseAction as CFString)
     }
 
     private static func windowTitle(_ window: AXUIElement) -> String? {
@@ -420,31 +409,6 @@ enum ActiveAgentNavigator {
               let document = value as? String else { return nil }
         if let url = URL(string: document), url.isFileURL { return url.path }
         return document
-    }
-
-    private static func workspaceNameCandidates(for directory: String) -> [String] {
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        var names: [String] = []
-        var path = (directory as NSString).standardizingPath
-        while !path.isEmpty, path != "/", path != home {
-            let name = (path as NSString).lastPathComponent
-            if !name.isEmpty, name != "/" { names.append(name) }
-            let parent = (path as NSString).deletingLastPathComponent
-            if parent == path { break }
-            path = parent
-        }
-        return names
-    }
-
-    private static func workspaceRoot(of directory: String, named candidate: String) -> String? {
-        var path = (directory as NSString).standardizingPath
-        while !path.isEmpty, path != "/" {
-            if (path as NSString).lastPathComponent == candidate { return path }
-            let parent = (path as NSString).deletingLastPathComponent
-            if parent == path { break }
-            path = parent
-        }
-        return nil
     }
 
     nonisolated private static func isSafeTTY(_ value: String) -> Bool {
@@ -518,5 +482,68 @@ enum ActiveAgentNavigator {
         end if
         error "TTY not found"
         """
+    }
+}
+
+enum WorkspaceWindowMatcher {
+    struct WindowInfo: Equatable {
+        let title: String
+        let documentPath: String?
+    }
+
+    static func pick(directory: String, windows: [WindowInfo]) -> Int? {
+        let candidates = nameCandidates(for: directory)
+        guard !candidates.isEmpty else { return nil }
+
+        for candidate in candidates {
+            guard let root = root(of: directory, named: candidate) else { continue }
+            if let index = windows.firstIndex(where: { window in
+                titleMatches(window.title, name: candidate)
+                    && (window.documentPath.map { isPath($0, under: root) } ?? false)
+            }) {
+                return index
+            }
+        }
+        for candidate in candidates {
+            if let index = windows.firstIndex(where: { window in
+                titleMatches(window.title, name: candidate) && window.documentPath == nil
+            }) {
+                return index
+            }
+        }
+        return nil
+    }
+
+    static func titleMatches(_ title: String, name: String) -> Bool {
+        title == name || title.hasSuffix(" \(name)")
+    }
+
+    static func isPath(_ path: String, under root: String) -> Bool {
+        path == root || path.hasPrefix(root + "/")
+    }
+
+    static func nameCandidates(for directory: String) -> [String] {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        var names: [String] = []
+        var path = (directory as NSString).standardizingPath
+        while !path.isEmpty, path != "/", path != home {
+            let name = (path as NSString).lastPathComponent
+            if !name.isEmpty, name != "/" { names.append(name) }
+            let parent = (path as NSString).deletingLastPathComponent
+            if parent == path { break }
+            path = parent
+        }
+        return names
+    }
+
+    static func root(of directory: String, named candidate: String) -> String? {
+        var path = (directory as NSString).standardizingPath
+        while !path.isEmpty, path != "/" {
+            if (path as NSString).lastPathComponent == candidate { return path }
+            let parent = (path as NSString).deletingLastPathComponent
+            if parent == path { break }
+            path = parent
+        }
+        return nil
     }
 }

--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -495,21 +495,21 @@ enum WorkspaceWindowMatcher {
         guard !candidates.isEmpty else { return nil }
 
         for candidate in candidates {
-            guard let rootPath = root(of: directory, named: candidate) else { continue }
+            guard let rootPath = root(of: directory, named: candidate).map(resolved) else { continue }
             if let index = windows.firstIndex(where: { window in
                 titleMatches(window.title, name: candidate)
-                    && (window.documentPath.map { isPath($0, under: rootPath) } ?? false)
+                    && (window.documentPath.map { isPath(resolved($0), under: rootPath) } ?? false)
             }) {
                 return index
             }
         }
         for candidate in candidates {
-            guard let rootPath = root(of: directory, named: candidate) else { continue }
+            guard let rootPath = root(of: directory, named: candidate).map(resolved) else { continue }
             let matches = windows.indices.filter { index in
                 let window = windows[index]
                 guard titleMatches(window.title, name: candidate) else { return false }
                 if let document = window.documentPath,
-                   let otherRoot = root(of: document, named: candidate),
+                   let otherRoot = root(of: document, named: candidate).map(resolved),
                    otherRoot != rootPath {
                     return false
                 }
@@ -518,6 +518,10 @@ enum WorkspaceWindowMatcher {
             if matches.count == 1 { return matches[0] }
         }
         return nil
+    }
+
+    static func resolved(_ path: String) -> String {
+        (path as NSString).resolvingSymlinksInPath
     }
 
     static func documentPath(fromRawValue raw: String) -> String? {

--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -367,25 +367,84 @@ enum ActiveAgentNavigator {
         "com.vscodium",
     ]
 
+    private static var didPromptAccessibility = false
+
+    private static func hasAccessibilityAccess() -> Bool {
+        if AXIsProcessTrusted() { return true }
+        if !didPromptAccessibility {
+            didPromptAccessibility = true
+            _ = AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": true] as CFDictionary)
+        }
+        return false
+    }
+
     private static func raiseWorkspaceWindow(pid: pid_t, bundleID: String?, directory: String?) {
         guard let bundleID, workspaceWindowBundleIDs.contains(bundleID), let directory else { return }
-        let folder = (directory as NSString).lastPathComponent
-        guard !folder.isEmpty, folder != "/" else { return }
+        let candidates = workspaceNameCandidates(for: directory)
+        guard !candidates.isEmpty, hasAccessibilityAccess() else { return }
 
         let app = AXUIElementCreateApplication(pid)
         var windowsValue: CFTypeRef?
         guard AXUIElementCopyAttributeValue(app, kAXWindowsAttribute as CFString, &windowsValue) == .success,
               let windows = windowsValue as? [AXUIElement] else { return }
 
-        for window in windows {
-            var titleValue: CFTypeRef?
-            guard AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleValue) == .success,
-                  let title = titleValue as? String,
-                  title == folder || title.hasSuffix(" \(folder)") else { continue }
-            AXUIElementSetAttributeValue(window, kAXMainAttribute as CFString, kCFBooleanTrue)
-            AXUIElementPerformAction(window, kAXRaiseAction as CFString)
+        for candidate in candidates {
+            let matches = windows.filter { window in
+                guard let title = windowTitle(window) else { return false }
+                return title == candidate || title.hasSuffix(" \(candidate)")
+            }
+            guard !matches.isEmpty else { continue }
+            let target = bestMatch(matches, directory: directory, candidate: candidate)
+            AXUIElementSetAttributeValue(target, kAXMainAttribute as CFString, kCFBooleanTrue)
+            AXUIElementPerformAction(target, kAXRaiseAction as CFString)
             return
         }
+    }
+
+    private static func bestMatch(_ windows: [AXUIElement], directory: String, candidate: String) -> AXUIElement {
+        guard windows.count > 1, let root = workspaceRoot(of: directory, named: candidate) else { return windows[0] }
+        return windows.first { window in
+            windowDocumentPath(window).map { $0.hasPrefix(root) } ?? false
+        } ?? windows[0]
+    }
+
+    private static func windowTitle(_ window: AXUIElement) -> String? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &value) == .success else { return nil }
+        return value as? String
+    }
+
+    private static func windowDocumentPath(_ window: AXUIElement) -> String? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(window, kAXDocumentAttribute as CFString, &value) == .success,
+              let document = value as? String else { return nil }
+        if let url = URL(string: document), url.isFileURL { return url.path }
+        return document
+    }
+
+    private static func workspaceNameCandidates(for directory: String) -> [String] {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        var names: [String] = []
+        var path = (directory as NSString).standardizingPath
+        while !path.isEmpty, path != "/", path != home {
+            let name = (path as NSString).lastPathComponent
+            if !name.isEmpty, name != "/" { names.append(name) }
+            let parent = (path as NSString).deletingLastPathComponent
+            if parent == path { break }
+            path = parent
+        }
+        return names
+    }
+
+    private static func workspaceRoot(of directory: String, named candidate: String) -> String? {
+        var path = (directory as NSString).standardizingPath
+        while !path.isEmpty, path != "/" {
+            if (path as NSString).lastPathComponent == candidate { return path }
+            let parent = (path as NSString).deletingLastPathComponent
+            if parent == path { break }
+            path = parent
+        }
+        return nil
     }
 
     nonisolated private static func isSafeTTY(_ value: String) -> Bool {

--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -495,20 +495,27 @@ enum WorkspaceWindowMatcher {
         guard !candidates.isEmpty else { return nil }
 
         for candidate in candidates {
-            guard let root = root(of: directory, named: candidate) else { continue }
+            guard let rootPath = root(of: directory, named: candidate) else { continue }
             if let index = windows.firstIndex(where: { window in
                 titleMatches(window.title, name: candidate)
-                    && (window.documentPath.map { isPath($0, under: root) } ?? false)
+                    && (window.documentPath.map { isPath($0, under: rootPath) } ?? false)
             }) {
                 return index
             }
         }
         for candidate in candidates {
-            if let index = windows.firstIndex(where: { window in
-                titleMatches(window.title, name: candidate) && window.documentPath == nil
-            }) {
-                return index
+            guard let rootPath = root(of: directory, named: candidate) else { continue }
+            let matches = windows.indices.filter { index in
+                let window = windows[index]
+                guard titleMatches(window.title, name: candidate) else { return false }
+                if let document = window.documentPath,
+                   let otherRoot = root(of: document, named: candidate),
+                   otherRoot != rootPath {
+                    return false
+                }
+                return true
             }
+            if matches.count == 1 { return matches[0] }
         }
         return nil
     }

--- a/Sources/Toki/Views/MenuContentView.swift
+++ b/Sources/Toki/Views/MenuContentView.swift
@@ -149,7 +149,7 @@ struct MenuContentView: View {
                             Image(systemName: "arrow.clockwise")
                         }
                     }
-                    .frame(width: 13, height: 13)
+                    .frame(width: 28, height: 28)
                     .contentShape(Rectangle())
                 }
                 .functionalControlStyle()
@@ -167,7 +167,7 @@ struct MenuContentView: View {
                     store.hidesSensitiveInfo.toggle()
                 } label: {
                     Image(systemName: store.hidesSensitiveInfo ? "eye.slash" : "eye")
-                        .frame(width: 13, height: 13)
+                        .frame(width: 28, height: 28)
                         .contentShape(Rectangle())
                 }
                 .functionalControlStyle()
@@ -182,7 +182,7 @@ struct MenuContentView: View {
                     showConfig = true
                 } label: {
                     Image(systemName: "gearshape")
-                        .frame(width: 13, height: 13)
+                        .frame(width: 28, height: 28)
                         .contentShape(Rectangle())
                 }
                 .functionalControlStyle()
@@ -205,7 +205,7 @@ struct MenuContentView: View {
                     }
                 } label: {
                     Image(systemName: "ellipsis")
-                        .frame(width: 13, height: 13)
+                        .frame(width: 28, height: 28)
                         .contentShape(Rectangle())
                 }
                 .functionalControlStyle()

--- a/Tests/TokiTests/WorkspaceWindowMatcherTests.swift
+++ b/Tests/TokiTests/WorkspaceWindowMatcherTests.swift
@@ -38,6 +38,20 @@ final class WorkspaceWindowMatcherTests: XCTestCase {
         XCTAssertEqual(WorkspaceWindowMatcher.pick(directory: "/work/project/src", windows: windows), 1)
     }
 
+    func testSymlinkedWorkspaceRootResolvesToCanonicalDocument() throws {
+        let fm = FileManager.default
+        let base = fm.temporaryDirectory.appendingPathComponent("wm-\(UUID().uuidString)")
+        let realProject = base.appendingPathComponent("real/project")
+        try fm.createDirectory(at: realProject, withIntermediateDirectories: true)
+        try fm.createSymbolicLink(at: base.appendingPathComponent("link"), withDestinationURL: base.appendingPathComponent("real"))
+        defer { try? fm.removeItem(at: base) }
+
+        let cwd = base.appendingPathComponent("link/project").path
+        let document = realProject.appendingPathComponent("main.swift").path
+        let windows = [Window(title: "project", documentPath: document)]
+        XCTAssertEqual(WorkspaceWindowMatcher.pick(directory: cwd, windows: windows), 0)
+    }
+
     func testNoMatchReturnsNil() {
         let windows = [Window(title: "unrelated", documentPath: "/x/y.swift")]
         XCTAssertNil(WorkspaceWindowMatcher.pick(directory: "/work/project", windows: windows))

--- a/Tests/TokiTests/WorkspaceWindowMatcherTests.swift
+++ b/Tests/TokiTests/WorkspaceWindowMatcherTests.swift
@@ -49,6 +49,19 @@ final class WorkspaceWindowMatcherTests: XCTestCase {
         XCTAssertFalse(WorkspaceWindowMatcher.isPath("/work/project-old/a.swift", under: "/work/project"))
     }
 
+    func testWindowWithExternalDocumentStillRaisedWhenTitleUnambiguous() {
+        let windows = [Window(title: "project", documentPath: "/somewhere/else/notes.txt")]
+        XCTAssertEqual(WorkspaceWindowMatcher.pick(directory: "/work/project/src", windows: windows), 0)
+    }
+
+    func testAmbiguousSameNameWithoutConfirmingDocumentIsNotGuessed() {
+        let windows = [
+            Window(title: "project", documentPath: nil),
+            Window(title: "project", documentPath: nil),
+        ]
+        XCTAssertNil(WorkspaceWindowMatcher.pick(directory: "/work/project/src", windows: windows))
+    }
+
     func testDocumentPathAcceptsFileURLsAndPosixPathsOnly() {
         XCTAssertEqual(WorkspaceWindowMatcher.documentPath(fromRawValue: "file:///work/project/a.swift"), "/work/project/a.swift")
         XCTAssertEqual(WorkspaceWindowMatcher.documentPath(fromRawValue: "/work/project/a.swift"), "/work/project/a.swift")

--- a/Tests/TokiTests/WorkspaceWindowMatcherTests.swift
+++ b/Tests/TokiTests/WorkspaceWindowMatcherTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import Toki
+
+final class WorkspaceWindowMatcherTests: XCTestCase {
+    private typealias Window = WorkspaceWindowMatcher.WindowInfo
+
+    func testExactWorkspaceRootWithDocument() {
+        let windows = [Window(title: "project", documentPath: "/work/project/main.swift")]
+        XCTAssertEqual(WorkspaceWindowMatcher.pick(directory: "/work/project", windows: windows), 0)
+    }
+
+    func testSubdirectoryMatchesAncestorWorkspace() {
+        let windows = [Window(title: "main.swift - project", documentPath: "/work/project/src/main.swift")]
+        XCTAssertEqual(WorkspaceWindowMatcher.pick(directory: "/work/project/src", windows: windows), 0)
+    }
+
+    func testUnrelatedDeeperNameIsNotPreferredOverRealAncestor() {
+        let windows = [
+            Window(title: "src", documentPath: "/other/src/x.swift"),
+            Window(title: "project", documentPath: "/work/project/y.swift"),
+        ]
+        XCTAssertEqual(WorkspaceWindowMatcher.pick(directory: "/work/project/src", windows: windows), 1)
+    }
+
+    func testDocumentedUnrelatedWindowIsSkippedForNoDocumentFallback() {
+        let windows = [
+            Window(title: "src", documentPath: "/other/src/x.swift"),
+            Window(title: "project", documentPath: nil),
+        ]
+        XCTAssertEqual(WorkspaceWindowMatcher.pick(directory: "/work/project/src", windows: windows), 1)
+    }
+
+    func testSameTitleDisambiguatedByDocumentPathOnComponentBoundary() {
+        let windows = [
+            Window(title: "project", documentPath: "/work/project-old/a.swift"),
+            Window(title: "project", documentPath: "/work/project/b.swift"),
+        ]
+        XCTAssertEqual(WorkspaceWindowMatcher.pick(directory: "/work/project/src", windows: windows), 1)
+    }
+
+    func testNoMatchReturnsNil() {
+        let windows = [Window(title: "unrelated", documentPath: "/x/y.swift")]
+        XCTAssertNil(WorkspaceWindowMatcher.pick(directory: "/work/project", windows: windows))
+    }
+
+    func testIsPathRespectsComponentBoundaries() {
+        XCTAssertTrue(WorkspaceWindowMatcher.isPath("/work/project", under: "/work/project"))
+        XCTAssertTrue(WorkspaceWindowMatcher.isPath("/work/project/sub/f.swift", under: "/work/project"))
+        XCTAssertFalse(WorkspaceWindowMatcher.isPath("/work/project-old/a.swift", under: "/work/project"))
+    }
+
+    func testTitleMatchesOnlyOnFullTrailingComponent() {
+        XCTAssertTrue(WorkspaceWindowMatcher.titleMatches("project", name: "project"))
+        XCTAssertTrue(WorkspaceWindowMatcher.titleMatches("file - project", name: "project"))
+        XCTAssertFalse(WorkspaceWindowMatcher.titleMatches("notproject", name: "project"))
+    }
+}

--- a/Tests/TokiTests/WorkspaceWindowMatcherTests.swift
+++ b/Tests/TokiTests/WorkspaceWindowMatcherTests.swift
@@ -49,6 +49,18 @@ final class WorkspaceWindowMatcherTests: XCTestCase {
         XCTAssertFalse(WorkspaceWindowMatcher.isPath("/work/project-old/a.swift", under: "/work/project"))
     }
 
+    func testDocumentPathAcceptsFileURLsAndPosixPathsOnly() {
+        XCTAssertEqual(WorkspaceWindowMatcher.documentPath(fromRawValue: "file:///work/project/a.swift"), "/work/project/a.swift")
+        XCTAssertEqual(WorkspaceWindowMatcher.documentPath(fromRawValue: "/work/project/a.swift"), "/work/project/a.swift")
+        XCTAssertNil(WorkspaceWindowMatcher.documentPath(fromRawValue: "untitled:Untitled-1"))
+        XCTAssertNil(WorkspaceWindowMatcher.documentPath(fromRawValue: "vscode-userdata:/foo"))
+    }
+
+    func testUntitledEditorWindowStillFallsBackToTitleMatch() {
+        let windows = [Window(title: "project", documentPath: WorkspaceWindowMatcher.documentPath(fromRawValue: "untitled:Untitled-1"))]
+        XCTAssertEqual(WorkspaceWindowMatcher.pick(directory: "/work/project", windows: windows), 0)
+    }
+
     func testTitleMatchesOnlyOnFullTrailingComponent() {
         XCTAssertTrue(WorkspaceWindowMatcher.titleMatches("project", name: "project"))
         XCTAssertTrue(WorkspaceWindowMatcher.titleMatches("file - project", name: "project"))

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -1,0 +1,100 @@
+# Release signing and notarization
+
+The release workflow (`.github/workflows/release.yml`) signs and notarizes the app when the
+Apple secrets below are present, and otherwise falls back to ad-hoc signing (unsigned, not
+notarizable) so releases still build. This page lists exactly what to collect and where each
+value comes from.
+
+Everything here comes from an Apple Developer Program account (99 USD per year). If you are
+using someone else's developer identity, note that the app ships under their name and team, and
+the `.p12` contains their private key, so treat these as sensitive credentials: store them only
+as encrypted GitHub Actions secrets, never in the repository.
+
+## What you need
+
+Two things are required: a signing certificate and a notarization credential. The certificate
+and the notarization credential must belong to the same Apple team.
+
+### 1. Signing: Developer ID certificate (all three required)
+
+| Secret | What it is |
+| --- | --- |
+| `APPLE_CERTIFICATE_P12` | base64 of a **Developer ID Application** certificate exported as `.p12` (certificate plus private key) |
+| `APPLE_CERTIFICATE_PASSWORD` | the password set when exporting the `.p12` |
+| `APPLE_SIGNING_IDENTITY` | the identity string, for example `Developer ID Application: Jane Doe (AB12CD34EF)` |
+
+The certificate must be of type **Developer ID Application** (for distribution outside the App
+Store). "Apple Development" and "Mac App Distribution" certificates will not work, and an ad-hoc
+signed build cannot be notarized.
+
+To create and export it:
+
+1. In Xcode, go to Settings > Accounts > Manage Certificates, then add a **Developer ID
+   Application** certificate. (Or create one at developer.apple.com > Certificates.)
+2. In Keychain Access, right-click the `Developer ID Application: ...` certificate and choose
+   Export, saving a `.p12` and setting a password. That password is `APPLE_CERTIFICATE_PASSWORD`.
+3. Find the identity string for `APPLE_SIGNING_IDENTITY` with:
+
+   ```bash
+   security find-identity -v -p codesigning
+   ```
+
+### 2. Notarization: pick one style
+
+**Style A, App Store Connect API key (recommended, does not expire, independently revocable):**
+
+| Secret | What it is |
+| --- | --- |
+| `APPLE_API_KEY_P8` | base64 of the `.p8` key file |
+| `APPLE_API_KEY_ID` | the Key ID |
+| `APPLE_API_ISSUER` | the Issuer ID (a UUID) |
+
+Generate the key in App Store Connect > Users and Access > Integrations (Keys). The `.p8` file
+can only be downloaded once. The Key ID is shown next to the key, and the Issuer ID is at the top
+of the Keys page.
+
+**Style B, Apple ID and app-specific password:**
+
+| Secret | What it is |
+| --- | --- |
+| `APPLE_ID` | the Apple ID email |
+| `APPLE_APP_SPECIFIC_PASSWORD` | an app-specific password from appleid.apple.com > Sign-In and Security |
+| `APPLE_TEAM_ID` | the 10-character team ID (from developer.apple.com membership, or the parentheses in the signing identity) |
+
+`notarize.sh` uses the API key style if it is set, otherwise the Apple ID style.
+
+### Not required for betas
+
+`HOMEBREW_TAP_TOKEN` is a GitHub token for the `homebrew-tap` repository. It is only used on
+stable tags (no hyphen) to update the Homebrew cask. Beta tags such as `v2.5.3-beta.2` skip it.
+
+## Setting the secrets
+
+Prepare the base64 values:
+
+```bash
+base64 -i DeveloperID.p12 | pbcopy   # APPLE_CERTIFICATE_P12
+base64 -i AuthKey_XXXX.p8 | pbcopy   # APPLE_API_KEY_P8
+```
+
+Then set each secret, either in the repository UI (Settings > Secrets and variables > Actions) or
+with the GitHub CLI:
+
+```bash
+gh secret set APPLE_CERTIFICATE_P12 < <(base64 -i DeveloperID.p12)
+gh secret set APPLE_CERTIFICATE_PASSWORD --body '...'
+gh secret set APPLE_SIGNING_IDENTITY --body 'Developer ID Application: Jane Doe (AB12CD34EF)'
+gh secret set APPLE_API_KEY_P8 < <(base64 -i AuthKey_XXXX.p8)
+gh secret set APPLE_API_KEY_ID --body '...'
+gh secret set APPLE_API_ISSUER --body '...'
+```
+
+Confirm what is already configured with `gh secret list`.
+
+## Minimum set for signed, notarized builds
+
+- Signing: `APPLE_CERTIFICATE_P12`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`
+- Notarization: one style from section 2
+
+With those in place, a tag push produces a signed and notarized DMG. Without them, the workflow
+still builds and publishes an ad-hoc signed DMG.


### PR DESCRIPTION
Stable **v2.5.3**.

## Fixed
- **Header controls hit area:** refresh, privacy, Settings, and More now respond to a click anywhere on the glass square, not just the icon. Each button's label filled only 13x13 while the glass and frame were 28x28, and a SwiftUI button only hit-tests its label, so edge clicks did nothing. The label now fills the control.
- **VS Code multi-display focus (closes #60):** reviewed with Codex across several rounds (each finding fixed and covered by tests):
  - Prompts for Accessibility access when missing, so the raise works on default installs instead of silently no-op'ing.
  - Matches the workspace root by walking the agent cwd's ancestors (handles subdirectory launches).
  - Confirms the window by its open document path, with component-boundary checks, non-file `AXDocument` handling, external/multi-root tolerance, and symlink-resolved comparison.
  - Factored into a pure `WorkspaceWindowMatcher` with `WorkspaceWindowMatcherTests`.

## Changed
- On macOS 26, the usage and quota-rings widgets render on the system's Liquid Glass material, matching the app's redesigned popover. Older macOS keeps the existing look.

## Docs
- Adds `docs/release-signing.md`: the Apple secrets needed to sign and notarize release builds.

## Verification
- `swift build` passes; `swift test` - 206 tests, 0 failures.

## Ship
Merge to `main`, then tag `v2.5.3` (clean tag -> normal release + Homebrew cask update; beta testers graduate automatically).