### PR TITLE
Fix 2.5.4 release packaging (webui dir + CHANGELOG symlink)

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -51,7 +51,9 @@ strip "$APP_DIR/Contents/MacOS/Toki"
 strip "$APP_DIR/Contents/PlugIns/TokiWidgets.appex/Contents/MacOS/TokiWidgets"
 
 echo "==> Copying resources"
-cp "$ROOT_DIR/Sources/Toki/Resources/"* "$APP_DIR/Contents/Resources/"
+# -R recurses into subdirectories such as webui/; -L follows the CHANGELOG.md
+# symlink so the bundle gets a real file the in-app What's New can read.
+cp -RL "$ROOT_DIR/Sources/Toki/Resources/"* "$APP_DIR/Contents/Resources/"
 cp "$ROOT_DIR/Sources/Toki/Resources/"*-logo.svg \
   "$APP_DIR/Contents/PlugIns/TokiWidgets.appex/Contents/Resources/"
 cp "$ROOT_DIR/Sources/Toki/Resources/"toki-router-glyph-*.svg \


### PR DESCRIPTION
The v2.5.4-beta.1 release build failed in `package-release.sh`: a plain `cp` of `Resources/*` could not copy the new `webui/` directory (`cp: ... is a directory`).

Fix: use `cp -RL` so subdirectories (webui) are recursed and the `CHANGELOG.md` symlink is followed into a real file the in-app What's New reads. Validated locally that webui copies recursively and CHANGELOG.md lands as a real 40KB file.

After merge: re-tag `v2.5.4-beta.1` on main so the release workflow rebuilds.