### PR TITLE
v2.5.4 Beta 2 — Remote Control ease-of-use improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - **Remote Control (#64): follow and reply to your agents from your phone.** Toki can run a local Remote Control server and pair a browser over Tailscale (recommended), your local network, or this Mac, using a six-digit code that rotates every two minutes and a scoped session you can limit from 1 hour up to 2 days. The web app lists the same active agents as the menu bar, streams their transcripts with GitHub-style Markdown tables, and lets you reply, send terminal keys, and approve or reject prompts; non-terminal sessions such as Codex desktop are clearly read-only. It installs as a phone app (PWA) with an offline-capable shell and Add to Home Screen, and you can start a session by scanning the Connect QR or entering a host and token by hand. Agent data stays between your browser and your Mac; the hosted interface only serves the UI. A teal status icon in the header opens the Remote Control settings while the server is running.
+- Remote Control settings include a built-in Tailscale setup guide. An info button next to the Host picker walks through the one-time steps to connect from anywhere (MagicDNS, HTTPS certificates, and `tailscale serve`), with the links and a copyable command you need.
 
 ## 2.5.3 - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - **Remote Control (#64): follow and reply to your agents from your phone.** Toki can run a local Remote Control server and pair a browser over Tailscale (recommended), your local network, or this Mac, using a six-digit code that rotates every two minutes and a scoped session you can limit from 1 hour up to 2 days. The web app lists the same active agents as the menu bar, streams their transcripts with GitHub-style Markdown tables, and lets you reply, send terminal keys, and approve or reject prompts; non-terminal sessions such as Codex desktop are clearly read-only. It installs as a phone app (PWA) with an offline-capable shell and Add to Home Screen, and you can start a session by scanning the Connect QR or entering a host and token by hand. Agent data stays between your browser and your Mac; the hosted interface only serves the UI. A teal status icon in the header opens the Remote Control settings while the server is running.
 - Remote Control settings include a built-in Tailscale setup guide. An info button next to the Host picker walks through the one-time steps to connect from anywhere (MagicDNS, HTTPS certificates, and `tailscale serve`), with the links and a copyable command you need.
+- Remote Control shows a live reachability indicator for the connect-from-anywhere path: it tells you when your phone can actually reach this Mac, or that `tailscale serve` still needs to start, instead of handing you a QR that silently fails.
+- One-click HTTPS setup: when `tailscale serve` isn't running, an "Enable HTTPS access" button starts it for you and re-checks reachability.
+- New **Cloudflare Tunnel** host option (when `cloudflared` is installed) gives you a public HTTPS address with no Tailscale, account, or DNS setup.
+- The companion app can notify you when an agent needs your input or approval, with a one-tap prompt to turn alerts on. (Notifications fire while the app is open or backgrounded.)
+- Remote Control settings lead with a single **Reach** choice, "On my network" or "From anywhere", with the detailed host and app options tucked under Advanced.
 
 ## 2.5.3 - 2026-07-28
 

--- a/Sources/Toki/Resources/webui/app.js
+++ b/Sources/Toki/Resources/webui/app.js
@@ -52,6 +52,7 @@ function pollAgents(){if(TOKEN)refreshAgents().then(()=>setConnected(true),()=>s
 function pollLog(){if(TOKEN)refreshLog().then(()=>setConnected(true),()=>setConnected(false))}
 function startApp(){
   document.body.classList.remove("locked");
+  updateAlertsButton();
   if(started)return;started=true;
   pollAgents();pollLog();
   setInterval(pollAgents,4000);setInterval(pollLog,2500);
@@ -113,8 +114,41 @@ function updateComposer(agent){
   document.querySelectorAll("footer button,footer input,footer textarea").forEach(el=>el.disabled=!enabled);
   $("#msg").placeholder=writable?"Reply to the agent\u2026":(agent?"Read-only session":"No active session");
 }
+let notifiedAttention={},notifySeeded=false;
+function attentionKey(a){
+  if(!a.attention)return"";
+  const q=a.attention.questions&&a.attention.questions.length
+    ?a.attention.questions.map(x=>x.question).join("|"):(a.attention.prompt||"");
+  return a.attention.kind+":"+q;
+}
+function notifyAttention(list){
+  if(!("Notification"in window)||Notification.permission!="granted"){notifiedAttention={};return}
+  const seen={};
+  for(const a of list){
+    const key=attentionKey(a);if(!key)continue;
+    seen[a.pid]=key;
+    if(notifySeeded&&notifiedAttention[a.pid]!=key)showAttentionNotification(a);
+  }
+  notifiedAttention=seen;notifySeeded=true;
+}
+function showAttentionNotification(a){
+  const kind=a.attention.kind=="permission"?"needs approval":"needs your input";
+  const q=(a.attention.questions&&a.attention.questions[0]&&a.attention.questions[0].question)
+    ||a.attention.prompt||"";
+  const opts={body:q.replace(/[#*`>]/g,"").trim().slice(0,140),tag:"toki-"+a.pid,
+    renotify:true,data:{pid:a.pid}};
+  const title=a.title+" "+kind;
+  if(navigator.serviceWorker&&navigator.serviceWorker.ready)
+    navigator.serviceWorker.ready.then(r=>r.showNotification(title,opts))
+      .catch(()=>{try{new Notification(title,opts)}catch(e){}});
+  else try{new Notification(title,opts)}catch(e){}
+}
+function updateAlertsButton(){
+  $("#enablealerts").hidden=!("Notification"in window)||Notification.permission!="default"||!TOKEN;
+}
 async function refreshAgents(){
   agents=await api("/api/agents");const prev=current;
+  notifyAttention(agents);
   if(agents.length&&!agents.some(a=>a.pid==prev)){current=agents[0].pid;offset=0;$("#log").innerHTML=""}
   renderAgents();
   const a=agents.find(x=>x.pid==current), al=$("#alert");
@@ -191,6 +225,10 @@ $("#ddbtn").addEventListener("click",e=>{e.stopPropagation();document.getElement
 document.addEventListener("click",()=>document.getElementById("dd").classList.remove("open"));
 $("#tolatest").addEventListener("click",scrollToLatest);
 window.addEventListener("scroll",()=>{if(nearBottom())$("#tolatest").hidden=true},{passive:true});
+$("#enablealerts").addEventListener("click",async()=>{
+  try{await Notification.requestPermission()}catch(e){}
+  updateAlertsButton();
+});
 
 // Enter a fresh link from another device: scan Toki's Connect QR, or type its host and token.
 // Both reload with the params in the fragment so the normal verify flow takes over.

--- a/Sources/Toki/Resources/webui/index.html
+++ b/Sources/Toki/Resources/webui/index.html
@@ -42,6 +42,7 @@
 </div>
 <header><h1><svg width="24" height="24" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Toki"><rect width="1024" height="1024" rx="232" fill="#181a1f"/><g transform="translate(0 6)"><path d="M268 245H704L682 282L704 319H268C248 319 232 303 232 282C232 261 248 245 268 245Z" fill="#f4f1ea"/><path d="M520 600L636 484" fill="none" stroke="#f4f1ea" stroke-width="74" stroke-linecap="round" stroke-linejoin="round"/><path d="M465 354H539V626C539 664 558 671 600 671H704L684 708L704 745H566C502 745 465 708 465 636Z" fill="#f4f1ea"/><circle cx="502" cy="282" r="96" fill="#f4f1ea"/><circle cx="502" cy="282" r="48" fill="#181a1f"/><circle cx="746" cy="282" r="39" fill="#9bb5a7"/><circle cx="636" cy="484" r="39" fill="#f4f1ea"/><circle cx="744" cy="708" r="38" fill="#d3a45c"/></g></svg>Remote Control</h1><div id="dd"><button id="ddbtn" type="button"></button><div id="ddlist"></div></div></header>
 <div id="conn" role="status" hidden><span class="conn-dot"></span>Reconnecting to Toki on your Mac&#8230;</div>
+<button id="enablealerts" type="button" hidden>&#128276; Turn on alerts when an agent needs you</button>
 <div id="alert"></div><div id="readonly" role="status">Read-only session — this agent is not running in a terminal, so you can follow its progress but cannot send replies.</div><div id="log"></div>
 <button id="tolatest" type="button" hidden aria-label="Jump to latest">&#8595; New messages</button>
 <footer>

--- a/Sources/Toki/Resources/webui/styles.css
+++ b/Sources/Toki/Resources/webui/styles.css
@@ -8,7 +8,7 @@ button{font:inherit;touch-action:manipulation;-webkit-tap-highlight-color:transp
 button:not(:disabled):active{transform:scale(.96);filter:brightness(1.16)}
 button:focus-visible,input:focus-visible,textarea:focus-visible{outline:3px solid #72a7e8;outline-offset:2px}
 .locked>header,.locked>#alert,.locked>#log,.locked>footer,
-.locked>#conn,.locked>#tolatest{display:none}
+.locked>#conn,.locked>#tolatest,.locked>#enablealerts{display:none}
 #pairing{display:none;min-height:100vh;align-items:center;justify-content:center;
          padding:calc(24px + env(safe-area-inset-top)) 24px calc(24px + env(safe-area-inset-bottom))}
 .locked #pairing{display:flex}
@@ -63,6 +63,10 @@ header{position:sticky;top:0;background:#111c;backdrop-filter:blur(10px);
           background:#294f78;color:#fff;border:1px solid #6596c7;box-shadow:0 3px 12px #0007;
           font-size:13px;font-weight:600}
 #tolatest[hidden]{display:none}
+#enablealerts{display:block;width:calc(100% - 28px);margin:10px 14px;padding:10px 12px;
+              border-radius:10px;background:#1f3a5c;border:1px solid #37a;color:#cfe2f7;
+              font-size:13px;font-weight:600;text-align:left}
+#enablealerts[hidden]{display:none}
 h1{font-size:16px;display:flex;align-items:center;gap:8px}
 #dd{position:relative;margin-top:8px}
 #ddbtn{width:100%;display:flex;align-items:center;gap:8px;padding:8px;border-radius:8px;

--- a/Sources/Toki/Resources/webui/sw.js
+++ b/Sources/Toki/Resources/webui/sw.js
@@ -27,6 +27,18 @@ self.addEventListener("activate", event => {
   );
 });
 
+self.addEventListener("notificationclick", event => {
+  event.notification.close();
+  event.waitUntil(
+    self.clients.matchAll({ type: "window", includeUncontrolled: true }).then(list => {
+      for (const client of list) {
+        if ("focus" in client) return client.focus();
+      }
+      if (self.clients.openWindow) return self.clients.openWindow("./");
+    })
+  );
+});
+
 self.addEventListener("fetch", event => {
   const request = event.request;
   if (request.method !== "GET") return;

--- a/Sources/Toki/Server/RemoteControlServer.swift
+++ b/Sources/Toki/Server/RemoteControlServer.swift
@@ -12,6 +12,7 @@ final class RemoteControlServer: ObservableObject {
 
     enum HostMode: String, CaseIterable, Identifiable {
         case tailscale
+        case tunnel
         case localNetwork
         case localhost
         case custom
@@ -23,6 +24,7 @@ final class RemoteControlServer: ObservableObject {
             case .localhost: return "Localhost"
             case .localNetwork: return "Local network"
             case .tailscale: return "Tailscale (Recommended)"
+            case .tunnel: return "Cloudflare Tunnel"
             case .custom: return "Custom"
             }
         }
@@ -74,11 +76,22 @@ final class RemoteControlServer: ObservableObject {
     @Published private(set) var tailscaleServeReady: Bool?
     @Published private(set) var isEnablingServe = false
     @Published private(set) var serveSetupError: String?
+    // Public HTTPS address from a Cloudflare quick tunnel, when Host is Cloudflare Tunnel.
+    @Published private(set) var tunnelHost: String?
+    @Published private(set) var isStartingTunnel = false
+    @Published private(set) var tunnelError: String?
 
     @Published var hostMode: HostMode = .localhost {
         didSet {
+            guard hostMode != oldValue else { return }
             if hostMode == .tailscale {
                 refreshTailscaleStatus()
+            }
+            if oldValue == .tunnel {
+                stopTunnel()
+            }
+            if hostMode == .tunnel, isRunning {
+                startTunnel()
             }
         }
     }
@@ -92,6 +105,7 @@ final class RemoteControlServer: ObservableObject {
     private var inputPipe: Pipe?
     private var outputBuffer = ""
     private var activeAgents: [ActiveAgent] = []
+    private var tunnelProcess: Process?
 
     private init() {
         hostMode = Self.preferredHostMode(
@@ -109,6 +123,8 @@ final class RemoteControlServer: ObservableObject {
             return Self.localNetworkIP()
         case .tailscale:
             return tailscaleDNSName
+        case .tunnel:
+            return tunnelHost
         case .custom:
             let trimmed = customHost.trimmingCharacters(in: .whitespacesAndNewlines)
             return trimmed.isEmpty ? nil : trimmed
@@ -117,12 +133,17 @@ final class RemoteControlServer: ObservableObject {
 
     var availableHostModes: [HostMode] {
         Self.orderedHostModes(
-            tailscaleAvailable: Self.tailscaleIP() != nil || tailscaleDNSName != nil
+            tailscaleAvailable: Self.tailscaleIP() != nil || tailscaleDNSName != nil,
+            cloudflaredAvailable: Self.cloudflaredExecutable() != nil
         )
     }
 
-    static func orderedHostModes(tailscaleAvailable: Bool) -> [HostMode] {
+    static func orderedHostModes(
+        tailscaleAvailable: Bool,
+        cloudflaredAvailable: Bool = false
+    ) -> [HostMode] {
         var modes: [HostMode] = [.localNetwork, .localhost, .custom]
+        if cloudflaredAvailable { modes.insert(.tunnel, at: 0) }
         if tailscaleAvailable { modes.insert(.tailscale, at: 0) }
         return modes
     }
@@ -159,10 +180,11 @@ final class RemoteControlServer: ObservableObject {
         switch companionAppMode {
         case .sameHost:
             guard let host else { return nil }
+            let isHTTPSHost = hostMode == .tailscale || hostMode == .tunnel
             return directConnectURL(
                 host: host,
-                scheme: hostMode == .tailscale ? "https" : "http",
-                port: hostMode == .tailscale ? nil : port,
+                scheme: isHTTPSHost ? "https" : "http",
+                port: isHTTPSHost ? nil : port,
                 token: token
             )
         case .localhost:
@@ -255,10 +277,12 @@ final class RemoteControlServer: ObservableObject {
         inputPipe = input
         isRunning = true
         refreshTailscaleStatus()
+        if hostMode == .tunnel { startTunnel() }
         sendActiveAgentSnapshot()
     }
 
     func stop() {
+        stopTunnel()
         guard let task = process else { return }
         task.terminationHandler = nil
         (task.standardOutput as? Pipe)?.fileHandleForReading.readabilityHandler = nil
@@ -474,6 +498,83 @@ final class RemoteControlServer: ObservableObject {
             return message
         }
         return "tailscale serve did not start. Try running it in Terminal (see the guide)."
+    }
+
+    // A Cloudflare quick tunnel gives this Mac a public HTTPS address with no account or DNS setup;
+    // the tunnel proxies to the same server, so the phone hits one origin (no mixed content, no CORS).
+    static func cloudflaredExecutable() -> URL? {
+        let candidates = ["/opt/homebrew/bin/cloudflared", "/usr/local/bin/cloudflared"]
+        if let path = candidates.first(where: FileManager.default.isExecutableFile(atPath:)) {
+            return URL(fileURLWithPath: path)
+        }
+        return nil
+    }
+
+    nonisolated static func parseTunnelHost(from text: String) -> String? {
+        guard let range = text.range(
+            of: #"https://[a-z0-9-]+\.trycloudflare\.com"#,
+            options: .regularExpression
+        ) else {
+            return nil
+        }
+        return URL(string: String(text[range]))?.host
+    }
+
+    func startTunnel() {
+        guard tunnelProcess == nil else { return }
+        guard let executable = Self.cloudflaredExecutable() else {
+            tunnelError = "cloudflared isn't installed. Install it with `brew install cloudflared`, then reopen this menu."
+            return
+        }
+        tunnelError = nil
+        tunnelHost = nil
+        isStartingTunnel = true
+
+        let task = Process()
+        task.executableURL = executable
+        task.arguments = ["tunnel", "--url", "http://127.0.0.1:\(port)"]
+        let output = Pipe()
+        task.standardOutput = output
+        task.standardError = output
+        output.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            guard !data.isEmpty, let text = String(data: data, encoding: .utf8),
+                  let host = Self.parseTunnelHost(from: text) else { return }
+            Task { @MainActor in
+                guard RemoteControlServer.shared.tunnelHost == nil else { return }
+                RemoteControlServer.shared.tunnelHost = host
+                RemoteControlServer.shared.isStartingTunnel = false
+            }
+        }
+        task.terminationHandler = { _ in
+            Task { @MainActor in
+                let server = RemoteControlServer.shared
+                server.tunnelProcess = nil
+                if server.tunnelHost == nil, server.hostMode == .tunnel, server.tunnelError == nil {
+                    server.tunnelError = "The Cloudflare tunnel stopped before it was ready."
+                }
+                server.tunnelHost = nil
+                server.isStartingTunnel = false
+            }
+        }
+        do {
+            try task.run()
+        } catch {
+            isStartingTunnel = false
+            tunnelError = "Couldn't launch cloudflared."
+            return
+        }
+        tunnelProcess = task
+    }
+
+    func stopTunnel() {
+        isStartingTunnel = false
+        tunnelHost = nil
+        guard let task = tunnelProcess else { return }
+        task.terminationHandler = nil
+        (task.standardOutput as? Pipe)?.fileHandleForReading.readabilityHandler = nil
+        task.terminate()
+        tunnelProcess = nil
     }
 
     // `tailscale serve status --json` reports a Web handler map keyed by "<host>:<port>", each with

--- a/Sources/Toki/Server/RemoteControlServer.swift
+++ b/Sources/Toki/Server/RemoteControlServer.swift
@@ -481,18 +481,38 @@ final class RemoteControlServer: ObservableObject {
         task.executableURL = executable
         task.arguments = executable.lastPathComponent == "env" ? ["tailscale"] + arguments : arguments
 
-        let errorPipe = Pipe()
-        task.standardError = errorPipe
+        // Capture stderr to a temp file, not a Pipe. `serve --bg` can leave a descriptor open,
+        // and a blocking pipe read would then never reach EOF (hangs the caller forever).
+        let logURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("toki-serve-\(UUID().uuidString).log")
+        FileManager.default.createFile(atPath: logURL.path, contents: nil)
+        let logHandle = try? FileHandle(forWritingTo: logURL)
+        defer {
+            try? logHandle?.close()
+            try? FileManager.default.removeItem(at: logURL)
+        }
+        task.standardError = logHandle ?? FileHandle.nullDevice
         task.standardOutput = FileHandle.nullDevice
+
         do {
             try task.run()
         } catch {
             return "Couldn't run tailscale. Make sure Tailscale is installed."
         }
-        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
-        task.waitUntilExit()
+
+        // Never block the UI indefinitely: `tailscale serve` can stall while provisioning a cert.
+        let deadline = Date().addingTimeInterval(25)
+        while task.isRunning, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.2)
+        }
+        if task.isRunning {
+            task.terminate()
+            return "Enabling HTTPS timed out. Make sure Tailscale is running and HTTPS Certificates are enabled, or run the command in Terminal (see the guide)."
+        }
+
+        try? logHandle?.close()
         if task.terminationStatus == 0 { return nil }
-        let message = String(data: errorData, encoding: .utf8)?
+        let message = (try? String(contentsOf: logURL, encoding: .utf8))?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         if let message, !message.isEmpty {
             return message

--- a/Sources/Toki/Server/RemoteControlServer.swift
+++ b/Sources/Toki/Server/RemoteControlServer.swift
@@ -69,6 +69,9 @@ final class RemoteControlServer: ObservableObject {
     @Published private(set) var pairingCode: String?
     @Published private(set) var lastError: String?
     @Published private(set) var tailscaleDNSName: String?
+    // nil until the first check completes; true when `tailscale serve` fronts our port on 443,
+    // so the hosted Toki RC UI can actually reach this Mac from a phone.
+    @Published private(set) var tailscaleServeReady: Bool?
 
     @Published var hostMode: HostMode = .localhost {
         didSet {
@@ -249,6 +252,7 @@ final class RemoteControlServer: ObservableObject {
         process = task
         inputPipe = input
         isRunning = true
+        refreshTailscaleStatus()
         sendActiveAgentSnapshot()
     }
 
@@ -370,31 +374,34 @@ final class RemoteControlServer: ObservableObject {
         !host.isEmpty && host.lowercased().hasSuffix(".ts.net")
     }
 
-    private func refreshTailscaleStatus() {
+    func refreshTailscaleStatus() {
+        let checkPort = port
         Task {
-            let name = await Task.detached(priority: .utility) {
-                Self.readTailscaleDNSName()
+            let result = await Task.detached(priority: .utility) {
+                (name: Self.readTailscaleDNSName(), serve: Self.readTailscaleServeReady(port: checkPort))
             }.value
-            tailscaleDNSName = name
+            tailscaleDNSName = result.name
+            tailscaleServeReady = result.serve
         }
     }
 
-    private nonisolated static func readTailscaleDNSName() -> String? {
+    private nonisolated static func tailscaleExecutable() -> URL {
         let candidates = [
             "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
             "/opt/homebrew/bin/tailscale",
             "/usr/local/bin/tailscale"
         ]
-        let executable = candidates.first(where: FileManager.default.isExecutableFile(atPath:))
-
-        let task = Process()
-        if let executable {
-            task.executableURL = URL(fileURLWithPath: executable)
-            task.arguments = ["status", "--json"]
-        } else {
-            task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            task.arguments = ["tailscale", "status", "--json"]
+        if let path = candidates.first(where: FileManager.default.isExecutableFile(atPath:)) {
+            return URL(fileURLWithPath: path)
         }
+        return URL(fileURLWithPath: "/usr/bin/env")
+    }
+
+    private nonisolated static func runTailscale(_ arguments: [String]) -> Data? {
+        let executable = tailscaleExecutable()
+        let task = Process()
+        task.executableURL = executable
+        task.arguments = executable.lastPathComponent == "env" ? ["tailscale"] + arguments : arguments
 
         let output = Pipe()
         task.standardOutput = output
@@ -407,7 +414,47 @@ final class RemoteControlServer: ObservableObject {
         let data = output.fileHandleForReading.readDataToEndOfFile()
         task.waitUntilExit()
         guard task.terminationStatus == 0 else { return nil }
+        return data
+    }
+
+    private nonisolated static func readTailscaleDNSName() -> String? {
+        guard let data = runTailscale(["status", "--json"]) else { return nil }
         return tailscaleDNSName(from: data)
+    }
+
+    private nonisolated static func readTailscaleServeReady(port: Int) -> Bool {
+        guard let data = runTailscale(["serve", "status", "--json"]) else { return false }
+        return serveReady(from: data, port: port)
+    }
+
+    // `tailscale serve status --json` reports a Web handler map keyed by "<host>:<port>", each with
+    // a Proxy target. Ready means a :443 handler forwards to our loopback port.
+    nonisolated static func serveReady(from data: Data, port: Int) -> Bool {
+        guard
+            let object = try? JSONSerialization.jsonObject(with: data),
+            let root = object as? [String: Any],
+            let web = root["Web"] as? [String: Any]
+        else {
+            return false
+        }
+        let needle = "127.0.0.1:\(port)"
+        for (hostPort, value) in web {
+            guard
+                hostPort.hasSuffix(":443"),
+                let entry = value as? [String: Any],
+                let handlers = entry["Handlers"] as? [String: Any]
+            else {
+                continue
+            }
+            for handler in handlers.values {
+                if let handler = handler as? [String: Any],
+                   let proxy = handler["Proxy"] as? String,
+                   proxy.contains(needle) {
+                    return true
+                }
+            }
+        }
+        return false
     }
 
     private static func isTailscaleAddress(_ ip: String) -> Bool {

--- a/Sources/Toki/Server/RemoteControlServer.swift
+++ b/Sources/Toki/Server/RemoteControlServer.swift
@@ -72,6 +72,8 @@ final class RemoteControlServer: ObservableObject {
     // nil until the first check completes; true when `tailscale serve` fronts our port on 443,
     // so the hosted Toki RC UI can actually reach this Mac from a phone.
     @Published private(set) var tailscaleServeReady: Bool?
+    @Published private(set) var isEnablingServe = false
+    @Published private(set) var serveSetupError: String?
 
     @Published var hostMode: HostMode = .localhost {
         didSet {
@@ -425,6 +427,53 @@ final class RemoteControlServer: ObservableObject {
     private nonisolated static func readTailscaleServeReady(port: Int) -> Bool {
         guard let data = runTailscale(["serve", "status", "--json"]) else { return false }
         return serveReady(from: data, port: port)
+    }
+
+    // Run `tailscale serve` so the tailnet fronts our loopback port over HTTPS on 443. May fail if
+    // the user is not the tailnet operator; the captured stderr is surfaced with a link to the guide.
+    func enableTailscaleServe() {
+        guard !isEnablingServe else { return }
+        isEnablingServe = true
+        serveSetupError = nil
+        let checkPort = port
+        Task {
+            let failure = await Task.detached(priority: .userInitiated) {
+                Self.runTailscaleServe(port: checkPort)
+            }.value
+            isEnablingServe = false
+            if let failure {
+                serveSetupError = failure
+            } else {
+                refreshTailscaleStatus()
+            }
+        }
+    }
+
+    // Returns nil on success, or an error message to surface.
+    private nonisolated static func runTailscaleServe(port: Int) -> String? {
+        let executable = tailscaleExecutable()
+        let arguments = ["serve", "--bg", "http://127.0.0.1:\(port)"]
+        let task = Process()
+        task.executableURL = executable
+        task.arguments = executable.lastPathComponent == "env" ? ["tailscale"] + arguments : arguments
+
+        let errorPipe = Pipe()
+        task.standardError = errorPipe
+        task.standardOutput = FileHandle.nullDevice
+        do {
+            try task.run()
+        } catch {
+            return "Couldn't run tailscale. Make sure Tailscale is installed."
+        }
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        task.waitUntilExit()
+        if task.terminationStatus == 0 { return nil }
+        let message = String(data: errorData, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let message, !message.isEmpty {
+            return message
+        }
+        return "tailscale serve did not start. Try running it in Terminal (see the guide)."
     }
 
     // `tailscale serve status --json` reports a Web handler map keyed by "<host>:<port>", each with

--- a/Sources/Toki/Views/SettingsPanel.swift
+++ b/Sources/Toki/Views/SettingsPanel.swift
@@ -56,6 +56,7 @@ struct SettingsPanel: View {
     @ObservedObject private var remoteServer = RemoteControlServer.shared
     @State private var showingConnect = false
     @State private var showingTailscaleGuide = false
+    private let reachabilityTimer = Timer.publish(every: 5, on: .main, in: .common).autoconnect()
 
     var body: some View {
         ScrollViewReader { proxy in
@@ -643,12 +644,9 @@ struct SettingsPanel: View {
                     .padding(.horizontal, 4)
             }
 
-            if remoteServer.companionAppMode == .hosted, remoteServer.isRunning, remoteServer.connectURL != nil {
-                Text("Your phone reaches this Mac through `tailscale serve` on port 443. If it can't connect, make sure that command is running — see the setup guide next to Host.")
-                    .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .padding(.horizontal, 4)
+            if remoteServer.isRunning, remoteServer.connectURL != nil,
+               remoteServer.companionAppMode == .hosted || remoteServer.hostMode == .tailscale {
+                tailscaleReadinessRow
             }
 
             if remoteServer.isRunning, remoteServer.connectURL == nil {
@@ -671,6 +669,33 @@ struct SettingsPanel: View {
         .sheet(isPresented: $showingConnect) {
             RemoteConnectSheet()
         }
+        .onAppear { remoteServer.refreshTailscaleStatus() }
+        .onReceive(reachabilityTimer) { _ in
+            if remoteServer.isRunning,
+               remoteServer.companionAppMode == .hosted || remoteServer.hostMode == .tailscale {
+                remoteServer.refreshTailscaleStatus()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var tailscaleReadinessRow: some View {
+        let ready = remoteServer.tailscaleServeReady
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: ready == true ? "checkmark.circle.fill"
+                : ready == false ? "exclamationmark.triangle.fill" : "ellipsis.circle")
+                .foregroundStyle(ready == true ? Color.green
+                    : ready == false ? Color.orange : Color.secondary)
+            Text(ready == true
+                ? "Reachable from your phone."
+                : ready == false
+                    ? "`tailscale serve` isn't running on 443, so your phone can't reach this Mac yet. See the setup guide next to Host."
+                    : "Checking whether your phone can reach this Mac…")
+                .foregroundStyle(ready == false ? Color.orange : Color.secondary)
+        }
+        .font(.system(size: 11))
+        .fixedSize(horizontal: false, vertical: true)
+        .padding(.horizontal, 4)
     }
 
     private var connectHint: String {

--- a/Sources/Toki/Views/SettingsPanel.swift
+++ b/Sources/Toki/Views/SettingsPanel.swift
@@ -643,6 +643,14 @@ struct SettingsPanel: View {
                     .padding(.horizontal, 4)
             }
 
+            if remoteServer.companionAppMode == .hosted, remoteServer.isRunning, remoteServer.connectURL != nil {
+                Text("Your phone reaches this Mac through `tailscale serve` on port 443. If it can't connect, make sure that command is running — see the setup guide next to Host.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, 4)
+            }
+
             if remoteServer.isRunning, remoteServer.connectURL == nil {
                 Text(connectHint)
                     .font(.system(size: 11))
@@ -668,7 +676,7 @@ struct SettingsPanel: View {
     private var connectHint: String {
         if remoteServer.token == nil { return "Starting the server…" }
         if remoteServer.companionAppMode == .hosted {
-            return "Toki RC requires a Tailscale DNS host with HTTPS Serve enabled."
+            return "Toki RC needs a Tailscale DNS host. Use the setup guide next to Host to turn on MagicDNS and HTTPS Serve."
         }
         if remoteServer.companionAppMode == .localNetwork {
             return "No local network address found. Try Localhost or Same as host."

--- a/Sources/Toki/Views/SettingsPanel.swift
+++ b/Sources/Toki/Views/SettingsPanel.swift
@@ -5,6 +5,12 @@ private enum SettingsAnchor: Hashable {
     case remoteControl
 }
 
+// Top-level "where can my phone reach this Mac" choice, mapped onto the underlying host/app modes.
+private enum ReachMode: Hashable {
+    case network
+    case anywhere
+}
+
 // Full-page settings/config view opened from the header gear (no longer a bottom tab).
 struct ConfigPage: View {
     @ObservedObject var store: UsageStore
@@ -531,61 +537,83 @@ struct SettingsPanel: View {
                 .controlSize(.small)
             }
 
-            HStack(spacing: 8) {
-                Text("Host")
-                    .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 48, alignment: .leading)
-                Picker("", selection: $remoteServer.hostMode) {
-                    ForEach(remoteServer.availableHostModes) { mode in
-                        Text(mode.label).tag(mode)
-                    }
-                }
-                .labelsHidden()
-                .pickerStyle(.menu)
-                .controlSize(.small)
-                .fixedSize()
-                if remoteServer.hostMode == .tailscale || remoteServer.companionAppMode == .hosted {
-                    Button {
-                        showingTailscaleGuide = true
-                    } label: {
-                        Image(systemName: "info.circle")
-                            .font(.system(size: 12))
-                            .foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .help("How to set up Tailscale so you can connect from anywhere")
-                    .accessibilityLabel("Tailscale setup guide")
-                    .pointerOnHover()
-                    .popover(isPresented: $showingTailscaleGuide, arrowEdge: .bottom) {
-                        TailscaleSetupGuide(port: remoteServer.port)
-                    }
-                }
-                if remoteServer.hostMode == .custom {
-                    TextField("host or IP", text: $remoteServer.customHost)
-                        .textFieldStyle(.roundedBorder)
-                        .controlSize(.small)
-                }
-                Spacer(minLength: 0)
+            Picker("Reach", selection: reachBinding) {
+                Text("On my network").tag(ReachMode.network)
+                Text("From anywhere").tag(ReachMode.anywhere)
             }
+            .labelsHidden()
+            .pickerStyle(.segmented)
+            .controlSize(.small)
             .padding(.horizontal, 4)
 
-            HStack(spacing: 8) {
-                Text("App")
-                    .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 48, alignment: .leading)
-                Picker("", selection: $remoteServer.companionAppMode) {
-                    ForEach(RemoteControlServer.CompanionAppMode.allCases) { mode in
-                        Text(mode.label).tag(mode)
+            Text(reachBinding.wrappedValue == .network
+                ? "Your phone connects over Wi-Fi on the same network. No setup."
+                : "Reach this Mac from any network over HTTPS via Tailscale or a Cloudflare tunnel.")
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+                .padding(.horizontal, 4)
+
+            DisclosureGroup("Advanced") {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 8) {
+                        Text("Host")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 48, alignment: .leading)
+                        Picker("", selection: $remoteServer.hostMode) {
+                            ForEach(remoteServer.availableHostModes) { mode in
+                                Text(mode.label).tag(mode)
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.menu)
+                        .controlSize(.small)
+                        .fixedSize()
+                        if remoteServer.hostMode == .tailscale || remoteServer.companionAppMode == .hosted {
+                            Button {
+                                showingTailscaleGuide = true
+                            } label: {
+                                Image(systemName: "info.circle")
+                                    .font(.system(size: 12))
+                                    .foregroundStyle(.secondary)
+                            }
+                            .buttonStyle(.plain)
+                            .help("How to set up Tailscale so you can connect from anywhere")
+                            .accessibilityLabel("Tailscale setup guide")
+                            .pointerOnHover()
+                            .popover(isPresented: $showingTailscaleGuide, arrowEdge: .bottom) {
+                                TailscaleSetupGuide(port: remoteServer.port)
+                            }
+                        }
+                        if remoteServer.hostMode == .custom {
+                            TextField("host or IP", text: $remoteServer.customHost)
+                                .textFieldStyle(.roundedBorder)
+                                .controlSize(.small)
+                        }
+                        Spacer(minLength: 0)
+                    }
+
+                    HStack(spacing: 8) {
+                        Text("App")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 48, alignment: .leading)
+                        Picker("", selection: $remoteServer.companionAppMode) {
+                            ForEach(RemoteControlServer.CompanionAppMode.allCases) { mode in
+                                Text(mode.label).tag(mode)
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.menu)
+                        .controlSize(.small)
+                        .fixedSize()
+                        Spacer(minLength: 0)
                     }
                 }
-                .labelsHidden()
-                .pickerStyle(.menu)
-                .controlSize(.small)
-                .fixedSize()
-                Spacer(minLength: 0)
+                .padding(.top, 6)
             }
+            .font(.system(size: 11))
             .padding(.horizontal, 4)
 
             HStack(spacing: 8) {
@@ -731,6 +759,33 @@ struct SettingsPanel: View {
             }
         }
         .padding(.horizontal, 4)
+    }
+
+    private var reachBinding: Binding<ReachMode> {
+        Binding(
+            get: {
+                switch remoteServer.hostMode {
+                case .tailscale, .tunnel: return .anywhere
+                default: return .network
+                }
+            },
+            set: { mode in
+                switch mode {
+                case .network:
+                    remoteServer.hostMode = RemoteControlServer.localNetworkIP() != nil ? .localNetwork : .localhost
+                    remoteServer.companionAppMode = .sameHost
+                case .anywhere:
+                    let modes = remoteServer.availableHostModes
+                    if modes.contains(.tailscale) {
+                        remoteServer.hostMode = .tailscale
+                        remoteServer.companionAppMode = .hosted
+                    } else if modes.contains(.tunnel) {
+                        remoteServer.hostMode = .tunnel
+                        remoteServer.companionAppMode = .sameHost
+                    }
+                }
+            }
+        )
     }
 
     private var connectHint: String {

--- a/Sources/Toki/Views/SettingsPanel.swift
+++ b/Sources/Toki/Views/SettingsPanel.swift
@@ -681,20 +681,55 @@ struct SettingsPanel: View {
     @ViewBuilder
     private var tailscaleReadinessRow: some View {
         let ready = remoteServer.tailscaleServeReady
-        HStack(alignment: .top, spacing: 6) {
-            Image(systemName: ready == true ? "checkmark.circle.fill"
-                : ready == false ? "exclamationmark.triangle.fill" : "ellipsis.circle")
-                .foregroundStyle(ready == true ? Color.green
-                    : ready == false ? Color.orange : Color.secondary)
-            Text(ready == true
-                ? "Reachable from your phone."
-                : ready == false
-                    ? "`tailscale serve` isn't running on 443, so your phone can't reach this Mac yet. See the setup guide next to Host."
-                    : "Checking whether your phone can reach this Mac…")
-                .foregroundStyle(ready == false ? Color.orange : Color.secondary)
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .top, spacing: 6) {
+                Image(systemName: ready == true ? "checkmark.circle.fill"
+                    : ready == false ? "exclamationmark.triangle.fill" : "ellipsis.circle")
+                    .foregroundStyle(ready == true ? Color.green
+                        : ready == false ? Color.orange : Color.secondary)
+                Text(ready == true
+                    ? "Reachable from your phone."
+                    : ready == false
+                        ? "`tailscale serve` isn't running on 443, so your phone can't reach this Mac yet."
+                        : "Checking whether your phone can reach this Mac…")
+                    .foregroundStyle(ready == false ? Color.orange : Color.secondary)
+            }
+            .font(.system(size: 11))
+            .fixedSize(horizontal: false, vertical: true)
+
+            if ready == false {
+                HStack(spacing: 8) {
+                    Button {
+                        remoteServer.enableTailscaleServe()
+                    } label: {
+                        if remoteServer.isEnablingServe {
+                            HStack(spacing: 5) {
+                                ProgressView().controlSize(.small).scaleEffect(0.7)
+                                Text("Enabling…")
+                            }
+                        } else {
+                            Text("Enable HTTPS access")
+                        }
+                    }
+                    .controlSize(.small)
+                    .fixedSize()
+                    .disabled(remoteServer.isEnablingServe)
+                    .help("Run tailscale serve so your phone can reach this Mac over HTTPS")
+                    .pointerOnHover()
+
+                    Text("or set it up by hand with the guide next to Host.")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                }
+
+                if let error = remoteServer.serveSetupError {
+                    Text("Couldn't enable it automatically: \(error) You may need to run the command in Terminal (see the guide).")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
         }
-        .font(.system(size: 11))
-        .fixedSize(horizontal: false, vertical: true)
         .padding(.horizontal, 4)
     }
 
@@ -796,7 +831,7 @@ private extension View {
 private struct TailscaleSetupGuide: View {
     let port: Int
 
-    private var serveCommand: String { "tailscale serve --bg 443 http://127.0.0.1:\(port)" }
+    private var serveCommand: String { "tailscale serve --bg http://127.0.0.1:\(port)" }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {

--- a/Sources/Toki/Views/SettingsPanel.swift
+++ b/Sources/Toki/Views/SettingsPanel.swift
@@ -55,6 +55,7 @@ struct SettingsPanel: View {
 
     @ObservedObject private var remoteServer = RemoteControlServer.shared
     @State private var showingConnect = false
+    @State private var showingTailscaleGuide = false
 
     var body: some View {
         ScrollViewReader { proxy in
@@ -543,6 +544,22 @@ struct SettingsPanel: View {
                 .pickerStyle(.menu)
                 .controlSize(.small)
                 .fixedSize()
+                if remoteServer.hostMode == .tailscale || remoteServer.companionAppMode == .hosted {
+                    Button {
+                        showingTailscaleGuide = true
+                    } label: {
+                        Image(systemName: "info.circle")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("How to set up Tailscale so you can connect from anywhere")
+                    .accessibilityLabel("Tailscale setup guide")
+                    .pointerOnHover()
+                    .popover(isPresented: $showingTailscaleGuide, arrowEdge: .bottom) {
+                        TailscaleSetupGuide(port: remoteServer.port)
+                    }
+                }
                 if remoteServer.hostMode == .custom {
                     TextField("host or IP", text: $remoteServer.customHost)
                         .textFieldStyle(.roundedBorder)
@@ -737,5 +754,114 @@ private extension View {
             Divider()
                 .padding(.leading, 34)
         }
+    }
+}
+
+// One-time Tailscale setup so the hosted Toki RC interface can reach this Mac over HTTPS.
+// The hosted page is served over HTTPS and browsers block it from calling a plain-HTTP LAN
+// address, so a tailnet HTTPS host is required for the connect-from-anywhere path.
+private struct TailscaleSetupGuide: View {
+    let port: Int
+
+    private var serveCommand: String { "tailscale serve --bg 443 http://127.0.0.1:\(port)" }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Connect from anywhere with Tailscale")
+                    .font(.system(size: 13, weight: .semibold))
+                Text("Tailscale gives this Mac a private HTTPS address your phone can reach from any network. It is a one-time setup.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            step(1, "Install Tailscale on this Mac and sign in.") {
+                guideLink("Download Tailscale", "https://tailscale.com/download/mac")
+            }
+            step(2, "In the admin console, turn on MagicDNS, then enable HTTPS Certificates.") {
+                guideLink("Open DNS settings", "https://login.tailscale.com/admin/dns")
+            }
+            step(3, "Give Toki an HTTPS address on your tailnet. Run this in Terminal:") {
+                commandRow
+            }
+            step(4, "Install Tailscale on your phone and sign into the same account.") {
+                guideLink("Get the mobile app", "https://tailscale.com/download")
+            }
+            step(5, "Back here, set Host to Tailscale and App to Toki RC, then open Connect.") {
+                EmptyView()
+            }
+
+            Divider()
+
+            Text("Your agent data never touches Toki RC. It travels directly between your phone and this Mac over your tailnet.")
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 12) {
+                guideLink("Enabling HTTPS", "https://tailscale.com/kb/1153/enabling-https")
+                guideLink("tailscale serve", "https://tailscale.com/kb/1242/tailscale-serve")
+            }
+        }
+        .padding(16)
+        .frame(width: 344, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func step<Accessory: View>(
+        _ number: Int,
+        _ text: String,
+        @ViewBuilder accessory: () -> Accessory
+    ) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text("\(number)")
+                .font(.system(size: 10, weight: .bold))
+                .foregroundStyle(.white)
+                .frame(width: 17, height: 17)
+                .background(Color.accentColor, in: Circle())
+            VStack(alignment: .leading, spacing: 5) {
+                Text(text)
+                    .font(.system(size: 11))
+                    .fixedSize(horizontal: false, vertical: true)
+                accessory()
+            }
+        }
+    }
+
+    private var commandRow: some View {
+        HStack(spacing: 6) {
+            Text(serveCommand)
+                .font(.system(size: 10, design: .monospaced))
+                .textSelection(.enabled)
+                .padding(.vertical, 5)
+                .padding(.horizontal, 7)
+                .background(Color.primary.opacity(0.06), in: RoundedRectangle(cornerRadius: 6))
+                .fixedSize(horizontal: false, vertical: true)
+            Button {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(serveCommand, forType: .string)
+            } label: {
+                Image(systemName: "doc.on.doc")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .help("Copy command")
+            .accessibilityLabel("Copy the tailscale serve command")
+            .pointerOnHover()
+        }
+    }
+
+    private func guideLink(_ label: String, _ urlString: String) -> some View {
+        Link(destination: URL(string: urlString)!) {
+            HStack(spacing: 3) {
+                Text(label)
+                Image(systemName: "arrow.up.right")
+                    .font(.system(size: 8, weight: .semibold))
+            }
+            .font(.system(size: 11, weight: .medium))
+        }
+        .pointerOnHover()
     }
 }

--- a/Sources/Toki/Views/SettingsPanel.swift
+++ b/Sources/Toki/Views/SettingsPanel.swift
@@ -745,6 +745,8 @@ struct SettingsPanel: View {
         case .custom: return "Enter a host or IP to get a connect link."
         case .localNetwork: return "No local network address found. Try Localhost or Custom."
         case .tailscale: return "No Tailscale DNS name found. Make sure Tailscale is running and MagicDNS is enabled."
+        case .tunnel:
+            return remoteServer.tunnelError ?? "Starting a Cloudflare tunnel… this can take a few seconds."
         case .localhost: return "Preparing the connect link…"
         }
     }

--- a/Tests/TokiTests/RemoteControlServerTests.swift
+++ b/Tests/TokiTests/RemoteControlServerTests.swift
@@ -159,4 +159,29 @@ final class RemoteControlServerTests: XCTestCase {
 
         XCTAssertNil(url)
     }
+
+    func testServeReadyDetectsHandlerForOurPort() {
+        let json = """
+        {"TCP":{"443":{"HTTPS":true}},"Web":{"mac.tail1234.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:8765"}}}}}
+        """
+        XCTAssertTrue(RemoteControlServer.serveReady(from: Data(json.utf8), port: 8765))
+    }
+
+    func testServeReadyFalseForDifferentPort() {
+        let json = """
+        {"Web":{"mac.tail1234.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:9999"}}}}}
+        """
+        XCTAssertFalse(RemoteControlServer.serveReady(from: Data(json.utf8), port: 8765))
+    }
+
+    func testServeReadyFalseWhenNotServedOn443() {
+        let json = """
+        {"Web":{"mac.tail1234.ts.net:8443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:8765"}}}}}
+        """
+        XCTAssertFalse(RemoteControlServer.serveReady(from: Data(json.utf8), port: 8765))
+    }
+
+    func testServeReadyFalseForEmptyConfig() {
+        XCTAssertFalse(RemoteControlServer.serveReady(from: Data("{}".utf8), port: 8765))
+    }
 }

--- a/Tests/TokiTests/RemoteControlServerTests.swift
+++ b/Tests/TokiTests/RemoteControlServerTests.swift
@@ -184,4 +184,33 @@ final class RemoteControlServerTests: XCTestCase {
     func testServeReadyFalseForEmptyConfig() {
         XCTAssertFalse(RemoteControlServer.serveReady(from: Data("{}".utf8), port: 8765))
     }
+
+    func testParseTunnelHostFromCloudflaredOutput() {
+        let text = """
+        2026-07-29T10:00:00Z INF +----------------------------------------------------+
+        2026-07-29T10:00:00Z INF |  Your quick Tunnel has been created! Visit it at:   |
+        2026-07-29T10:00:00Z INF |  https://blue-green-fox-123.trycloudflare.com       |
+        2026-07-29T10:00:00Z INF +----------------------------------------------------+
+        """
+        XCTAssertEqual(
+            RemoteControlServer.parseTunnelHost(from: text),
+            "blue-green-fox-123.trycloudflare.com"
+        )
+    }
+
+    func testParseTunnelHostReturnsNilWithoutURL() {
+        XCTAssertNil(RemoteControlServer.parseTunnelHost(from: "2026-07-29 INF starting tunnel"))
+    }
+
+    func testTunnelHostBuildsHTTPSConnectURL() {
+        let url = RemoteControlServer.makeConnectURL(
+            companionAppMode: .sameHost,
+            hostMode: .tunnel,
+            host: "blue-green-fox-123.trycloudflare.com",
+            localNetworkHost: nil,
+            token: "abc",
+            port: 8765
+        )
+        XCTAssertEqual(url, "https://blue-green-fox-123.trycloudflare.com/?token=abc")
+    }
 }

--- a/Tests/test_remote_pwa.js
+++ b/Tests/test_remote_pwa.js
@@ -67,4 +67,13 @@ assert.match(html, /id="conn"/);
 assert.match(app, /function setConnected/);
 assert.match(css, /\.conn-dot/);
 
+// --- Attention notifications: permission affordance, transition-only firing, SW click handler ---
+assert.match(html, /id="enablealerts"/);
+assert.match(app, /function notifyAttention/);
+assert.match(app, /Notification\.permission!="granted"/);
+assert.match(app, /notifySeeded&&notifiedAttention\[a\.pid\]!=key/);
+assert.match(app, /showNotification\(title,opts\)/);
+assert.match(app, /requestPermission\(\)/);
+assert.match(sw, /addEventListener\("notificationclick"/);
+
 console.log("remote pwa + qr + ux tests passed");


### PR DESCRIPTION
Second beta of **2.5.4**, merging `release/v2.5.4` into `main`. Builds on `v2.5.4-beta.1` (which shipped the Remote Control companion app) with a round of improvements focused on making the connect-from-anywhere path easy and adding notifications.

## Connect from anywhere, without the hassle

- **Tailscale setup guide.** An info button next to the Host picker opens a popover with the one-time steps to connect from anywhere (install Tailscale, MagicDNS, HTTPS certificates, `tailscale serve`), including the links and a copyable command.
- **Live reachability indicator (#67).** Detects whether `tailscale serve` actually fronts the server port on 443 and shows it live: "Reachable from your phone" vs a prompt to finish setup, instead of handing you a QR that silently fails.
- **One-click HTTPS setup (#68).** When serve isn't running, an "Enable HTTPS access" button runs `tailscale serve` for you and re-checks reachability. Also fixes the guide's command (`tailscale serve --bg <target>` is the correct form).
- **Cloudflare Tunnel host (#69).** A new Host option (when `cloudflared` is installed) gives this Mac a public HTTPS address with no Tailscale, account, or DNS setup. The tunnel proxies to the same server, so the phone hits one origin.
- **Two-choice Reach control (#71).** Settings lead with a single choice, "On my network" or "From anywhere", with the detailed Host and App pickers tucked under Advanced. Fixes the confusing host × app cross-product.
- Clarified the hosted-mode hints to point at the guide.

## Notifications

- **Agent-needs-you notifications (#70).** The companion app fires a notification on the transition into an attention/permission state, shown via the service worker, with a one-tap prompt to enable alerts. Fires while the app is open or backgrounded; closed-app Web Push (VAPID + a push service) remains a follow-on.

## Validation

- Full build, `swift test`, and the web UI JS suite all green on the integrated branch.
- Unit tests for `serveReady`, `parseTunnelHost`, and tunnel connect-URL building; JS assertions for the notification wiring.
- `cloudflared` wasn't installed locally, so the live tunnel spawn wasn't runtime-exercised; its parsing and URL building are unit-tested.

## Release

- Targets **2.5.4**; `CHANGELOG.md` updated (#72). After merge, cut a fresh `v2.5.4-beta.N` tag for cross-machine testing.
