### PR TITLE
Remote Control: live reachability indicator

### DIFF
--- a/Sources/Toki/Server/RemoteControlServer.swift
+++ b/Sources/Toki/Server/RemoteControlServer.swift
@@ -69,6 +69,9 @@ final class RemoteControlServer: ObservableObject {
     @Published private(set) var pairingCode: String?
     @Published private(set) var lastError: String?
     @Published private(set) var tailscaleDNSName: String?
+    // nil until the first check completes; true when `tailscale serve` fronts our port on 443,
+    // so the hosted Toki RC UI can actually reach this Mac from a phone.
+    @Published private(set) var tailscaleServeReady: Bool?
 
     @Published var hostMode: HostMode = .localhost {
         didSet {
@@ -249,6 +252,7 @@ final class RemoteControlServer: ObservableObject {
         process = task
         inputPipe = input
         isRunning = true
+        refreshTailscaleStatus()
         sendActiveAgentSnapshot()
     }
 
@@ -370,31 +374,34 @@ final class RemoteControlServer: ObservableObject {
         !host.isEmpty && host.lowercased().hasSuffix(".ts.net")
     }
 
-    private func refreshTailscaleStatus() {
+    func refreshTailscaleStatus() {
+        let checkPort = port
         Task {
-            let name = await Task.detached(priority: .utility) {
-                Self.readTailscaleDNSName()
+            let result = await Task.detached(priority: .utility) {
+                (name: Self.readTailscaleDNSName(), serve: Self.readTailscaleServeReady(port: checkPort))
             }.value
-            tailscaleDNSName = name
+            tailscaleDNSName = result.name
+            tailscaleServeReady = result.serve
         }
     }
 
-    private nonisolated static func readTailscaleDNSName() -> String? {
+    private nonisolated static func tailscaleExecutable() -> URL {
         let candidates = [
             "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
             "/opt/homebrew/bin/tailscale",
             "/usr/local/bin/tailscale"
         ]
-        let executable = candidates.first(where: FileManager.default.isExecutableFile(atPath:))
-
-        let task = Process()
-        if let executable {
-            task.executableURL = URL(fileURLWithPath: executable)
-            task.arguments = ["status", "--json"]
-        } else {
-            task.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            task.arguments = ["tailscale", "status", "--json"]
+        if let path = candidates.first(where: FileManager.default.isExecutableFile(atPath:)) {
+            return URL(fileURLWithPath: path)
         }
+        return URL(fileURLWithPath: "/usr/bin/env")
+    }
+
+    private nonisolated static func runTailscale(_ arguments: [String]) -> Data? {
+        let executable = tailscaleExecutable()
+        let task = Process()
+        task.executableURL = executable
+        task.arguments = executable.lastPathComponent == "env" ? ["tailscale"] + arguments : arguments
 
         let output = Pipe()
         task.standardOutput = output
@@ -407,7 +414,47 @@ final class RemoteControlServer: ObservableObject {
         let data = output.fileHandleForReading.readDataToEndOfFile()
         task.waitUntilExit()
         guard task.terminationStatus == 0 else { return nil }
+        return data
+    }
+
+    private nonisolated static func readTailscaleDNSName() -> String? {
+        guard let data = runTailscale(["status", "--json"]) else { return nil }
         return tailscaleDNSName(from: data)
+    }
+
+    private nonisolated static func readTailscaleServeReady(port: Int) -> Bool {
+        guard let data = runTailscale(["serve", "status", "--json"]) else { return false }
+        return serveReady(from: data, port: port)
+    }
+
+    // `tailscale serve status --json` reports a Web handler map keyed by "<host>:<port>", each with
+    // a Proxy target. Ready means a :443 handler forwards to our loopback port.
+    nonisolated static func serveReady(from data: Data, port: Int) -> Bool {
+        guard
+            let object = try? JSONSerialization.jsonObject(with: data),
+            let root = object as? [String: Any],
+            let web = root["Web"] as? [String: Any]
+        else {
+            return false
+        }
+        let needle = "127.0.0.1:\(port)"
+        for (hostPort, value) in web {
+            guard
+                hostPort.hasSuffix(":443"),
+                let entry = value as? [String: Any],
+                let handlers = entry["Handlers"] as? [String: Any]
+            else {
+                continue
+            }
+            for handler in handlers.values {
+                if let handler = handler as? [String: Any],
+                   let proxy = handler["Proxy"] as? String,
+                   proxy.contains(needle) {
+                    return true
+                }
+            }
+        }
+        return false
     }
 
     private static func isTailscaleAddress(_ ip: String) -> Bool {

--- a/Sources/Toki/Views/SettingsPanel.swift
+++ b/Sources/Toki/Views/SettingsPanel.swift
@@ -56,6 +56,7 @@ struct SettingsPanel: View {
     @ObservedObject private var remoteServer = RemoteControlServer.shared
     @State private var showingConnect = false
     @State private var showingTailscaleGuide = false
+    private let reachabilityTimer = Timer.publish(every: 5, on: .main, in: .common).autoconnect()
 
     var body: some View {
         ScrollViewReader { proxy in
@@ -643,12 +644,9 @@ struct SettingsPanel: View {
                     .padding(.horizontal, 4)
             }
 
-            if remoteServer.companionAppMode == .hosted, remoteServer.isRunning, remoteServer.connectURL != nil {
-                Text("Your phone reaches this Mac through `tailscale serve` on port 443. If it can't connect, make sure that command is running — see the setup guide next to Host.")
-                    .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .padding(.horizontal, 4)
+            if remoteServer.isRunning, remoteServer.connectURL != nil,
+               remoteServer.companionAppMode == .hosted || remoteServer.hostMode == .tailscale {
+                tailscaleReadinessRow
             }
 
             if remoteServer.isRunning, remoteServer.connectURL == nil {
@@ -671,6 +669,33 @@ struct SettingsPanel: View {
         .sheet(isPresented: $showingConnect) {
             RemoteConnectSheet()
         }
+        .onAppear { remoteServer.refreshTailscaleStatus() }
+        .onReceive(reachabilityTimer) { _ in
+            if remoteServer.isRunning,
+               remoteServer.companionAppMode == .hosted || remoteServer.hostMode == .tailscale {
+                remoteServer.refreshTailscaleStatus()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var tailscaleReadinessRow: some View {
+        let ready = remoteServer.tailscaleServeReady
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: ready == true ? "checkmark.circle.fill"
+                : ready == false ? "exclamationmark.triangle.fill" : "ellipsis.circle")
+                .foregroundStyle(ready == true ? Color.green
+                    : ready == false ? Color.orange : Color.secondary)
+            Text(ready == true
+                ? "Reachable from your phone."
+                : ready == false
+                    ? "`tailscale serve` isn't running on 443, so your phone can't reach this Mac yet. See the setup guide next to Host."
+                    : "Checking whether your phone can reach this Mac…")
+                .foregroundStyle(ready == false ? Color.orange : Color.secondary)
+        }
+        .font(.system(size: 11))
+        .fixedSize(horizontal: false, vertical: true)
+        .padding(.horizontal, 4)
     }
 
     private var connectHint: String {

--- a/Tests/TokiTests/RemoteControlServerTests.swift
+++ b/Tests/TokiTests/RemoteControlServerTests.swift
@@ -159,4 +159,29 @@ final class RemoteControlServerTests: XCTestCase {
 
         XCTAssertNil(url)
     }
+
+    func testServeReadyDetectsHandlerForOurPort() {
+        let json = """
+        {"TCP":{"443":{"HTTPS":true}},"Web":{"mac.tail1234.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:8765"}}}}}
+        """
+        XCTAssertTrue(RemoteControlServer.serveReady(from: Data(json.utf8), port: 8765))
+    }
+
+    func testServeReadyFalseForDifferentPort() {
+        let json = """
+        {"Web":{"mac.tail1234.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:9999"}}}}}
+        """
+        XCTAssertFalse(RemoteControlServer.serveReady(from: Data(json.utf8), port: 8765))
+    }
+
+    func testServeReadyFalseWhenNotServedOn443() {
+        let json = """
+        {"Web":{"mac.tail1234.ts.net:8443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:8765"}}}}}
+        """
+        XCTAssertFalse(RemoteControlServer.serveReady(from: Data(json.utf8), port: 8765))
+    }
+
+    func testServeReadyFalseForEmptyConfig() {
+        XCTAssertFalse(RemoteControlServer.serveReady(from: Data("{}".utf8), port: 8765))
+    }
 }


### PR DESCRIPTION
First of the Remote Control ease-of-use improvements.

## What
Detects whether the connect-from-anywhere path is actually reachable and shows it live in settings, instead of generating a QR that silently fails when `tailscale serve` isn't running.

- New `tailscale serve status --json` check (`serveReady(from:port:)`) that confirms a :443 handler forwards to Toki's loopback port.
- Live indicator when Host = Tailscale or App = Toki RC and the server is running:
  - ✅ "Reachable from your phone."
  - ⚠️ "`tailscale serve` isn't running on 443… see the setup guide next to Host."
  - ⋯ "Checking…" until the first probe returns.
- Refreshes on a 5s timer while relevant, so it flips green within seconds of `tailscale serve` starting.

## Tests
- Unit tests for `serveReady` parsing: matching port, wrong port, non-443, empty config.
- Full build + `swift test` green.

Base: `release/v2.5.4` (part of the 2.5.4 line, gated to main by #66).