### PR TITLE
Remote Control: one-click tailscale serve

### DIFF
--- a/Sources/Toki/Server/RemoteControlServer.swift
+++ b/Sources/Toki/Server/RemoteControlServer.swift
@@ -72,6 +72,8 @@ final class RemoteControlServer: ObservableObject {
     // nil until the first check completes; true when `tailscale serve` fronts our port on 443,
     // so the hosted Toki RC UI can actually reach this Mac from a phone.
     @Published private(set) var tailscaleServeReady: Bool?
+    @Published private(set) var isEnablingServe = false
+    @Published private(set) var serveSetupError: String?
 
     @Published var hostMode: HostMode = .localhost {
         didSet {
@@ -425,6 +427,53 @@ final class RemoteControlServer: ObservableObject {
     private nonisolated static func readTailscaleServeReady(port: Int) -> Bool {
         guard let data = runTailscale(["serve", "status", "--json"]) else { return false }
         return serveReady(from: data, port: port)
+    }
+
+    // Run `tailscale serve` so the tailnet fronts our loopback port over HTTPS on 443. May fail if
+    // the user is not the tailnet operator; the captured stderr is surfaced with a link to the guide.
+    func enableTailscaleServe() {
+        guard !isEnablingServe else { return }
+        isEnablingServe = true
+        serveSetupError = nil
+        let checkPort = port
+        Task {
+            let failure = await Task.detached(priority: .userInitiated) {
+                Self.runTailscaleServe(port: checkPort)
+            }.value
+            isEnablingServe = false
+            if let failure {
+                serveSetupError = failure
+            } else {
+                refreshTailscaleStatus()
+            }
+        }
+    }
+
+    // Returns nil on success, or an error message to surface.
+    private nonisolated static func runTailscaleServe(port: Int) -> String? {
+        let executable = tailscaleExecutable()
+        let arguments = ["serve", "--bg", "http://127.0.0.1:\(port)"]
+        let task = Process()
+        task.executableURL = executable
+        task.arguments = executable.lastPathComponent == "env" ? ["tailscale"] + arguments : arguments
+
+        let errorPipe = Pipe()
+        task.standardError = errorPipe
+        task.standardOutput = FileHandle.nullDevice
+        do {
+            try task.run()
+        } catch {
+            return "Couldn't run tailscale. Make sure Tailscale is installed."
+        }
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        task.waitUntilExit()
+        if task.terminationStatus == 0 { return nil }
+        let message = String(data: errorData, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let message, !message.isEmpty {
+            return message
+        }
+        return "tailscale serve did not start. Try running it in Terminal (see the guide)."
     }
 
     // `tailscale serve status --json` reports a Web handler map keyed by "<host>:<port>", each with

--- a/Sources/Toki/Views/SettingsPanel.swift
+++ b/Sources/Toki/Views/SettingsPanel.swift
@@ -681,20 +681,55 @@ struct SettingsPanel: View {
     @ViewBuilder
     private var tailscaleReadinessRow: some View {
         let ready = remoteServer.tailscaleServeReady
-        HStack(alignment: .top, spacing: 6) {
-            Image(systemName: ready == true ? "checkmark.circle.fill"
-                : ready == false ? "exclamationmark.triangle.fill" : "ellipsis.circle")
-                .foregroundStyle(ready == true ? Color.green
-                    : ready == false ? Color.orange : Color.secondary)
-            Text(ready == true
-                ? "Reachable from your phone."
-                : ready == false
-                    ? "`tailscale serve` isn't running on 443, so your phone can't reach this Mac yet. See the setup guide next to Host."
-                    : "Checking whether your phone can reach this Mac…")
-                .foregroundStyle(ready == false ? Color.orange : Color.secondary)
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .top, spacing: 6) {
+                Image(systemName: ready == true ? "checkmark.circle.fill"
+                    : ready == false ? "exclamationmark.triangle.fill" : "ellipsis.circle")
+                    .foregroundStyle(ready == true ? Color.green
+                        : ready == false ? Color.orange : Color.secondary)
+                Text(ready == true
+                    ? "Reachable from your phone."
+                    : ready == false
+                        ? "`tailscale serve` isn't running on 443, so your phone can't reach this Mac yet."
+                        : "Checking whether your phone can reach this Mac…")
+                    .foregroundStyle(ready == false ? Color.orange : Color.secondary)
+            }
+            .font(.system(size: 11))
+            .fixedSize(horizontal: false, vertical: true)
+
+            if ready == false {
+                HStack(spacing: 8) {
+                    Button {
+                        remoteServer.enableTailscaleServe()
+                    } label: {
+                        if remoteServer.isEnablingServe {
+                            HStack(spacing: 5) {
+                                ProgressView().controlSize(.small).scaleEffect(0.7)
+                                Text("Enabling…")
+                            }
+                        } else {
+                            Text("Enable HTTPS access")
+                        }
+                    }
+                    .controlSize(.small)
+                    .fixedSize()
+                    .disabled(remoteServer.isEnablingServe)
+                    .help("Run tailscale serve so your phone can reach this Mac over HTTPS")
+                    .pointerOnHover()
+
+                    Text("or set it up by hand with the guide next to Host.")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                }
+
+                if let error = remoteServer.serveSetupError {
+                    Text("Couldn't enable it automatically: \(error) You may need to run the command in Terminal (see the guide).")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
         }
-        .font(.system(size: 11))
-        .fixedSize(horizontal: false, vertical: true)
         .padding(.horizontal, 4)
     }
 
@@ -796,7 +831,7 @@ private extension View {
 private struct TailscaleSetupGuide: View {
     let port: Int
 
-    private var serveCommand: String { "tailscale serve --bg 443 http://127.0.0.1:\(port)" }
+    private var serveCommand: String { "tailscale serve --bg http://127.0.0.1:\(port)" }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {


### PR DESCRIPTION
Second of the Remote Control ease-of-use improvements (builds on #67).

## What
- When readiness shows serve isn't running, an **"Enable HTTPS access"** button runs `tailscale serve --bg http://127.0.0.1:8765` for the user and re-checks readiness on success (flips the indicator green).
- Shows a spinner while enabling; on failure (e.g. the user isn't the tailnet operator) surfaces the CLI error with a fallback to the manual guide.
- **Bug fix:** the setup guide's command used `--bg 443 http://...`, which is an invalid two-target form. Corrected to `tailscale serve --bg http://127.0.0.1:8765` (verified against `tailscale serve --help`; serve defaults to HTTPS on 443).

## Notes
- Builds clean. The one-click and the guide now show the same, correct command.
- Base: `release/v2.5.4`.