### PR TITLE
Remote Control: notify when an agent needs you

### DIFF
--- a/Sources/Toki/Resources/webui/app.js
+++ b/Sources/Toki/Resources/webui/app.js
@@ -52,6 +52,7 @@ function pollAgents(){if(TOKEN)refreshAgents().then(()=>setConnected(true),()=>s
 function pollLog(){if(TOKEN)refreshLog().then(()=>setConnected(true),()=>setConnected(false))}
 function startApp(){
   document.body.classList.remove("locked");
+  updateAlertsButton();
   if(started)return;started=true;
   pollAgents();pollLog();
   setInterval(pollAgents,4000);setInterval(pollLog,2500);
@@ -113,8 +114,41 @@ function updateComposer(agent){
   document.querySelectorAll("footer button,footer input,footer textarea").forEach(el=>el.disabled=!enabled);
   $("#msg").placeholder=writable?"Reply to the agent\u2026":(agent?"Read-only session":"No active session");
 }
+let notifiedAttention={},notifySeeded=false;
+function attentionKey(a){
+  if(!a.attention)return"";
+  const q=a.attention.questions&&a.attention.questions.length
+    ?a.attention.questions.map(x=>x.question).join("|"):(a.attention.prompt||"");
+  return a.attention.kind+":"+q;
+}
+function notifyAttention(list){
+  if(!("Notification"in window)||Notification.permission!="granted"){notifiedAttention={};return}
+  const seen={};
+  for(const a of list){
+    const key=attentionKey(a);if(!key)continue;
+    seen[a.pid]=key;
+    if(notifySeeded&&notifiedAttention[a.pid]!=key)showAttentionNotification(a);
+  }
+  notifiedAttention=seen;notifySeeded=true;
+}
+function showAttentionNotification(a){
+  const kind=a.attention.kind=="permission"?"needs approval":"needs your input";
+  const q=(a.attention.questions&&a.attention.questions[0]&&a.attention.questions[0].question)
+    ||a.attention.prompt||"";
+  const opts={body:q.replace(/[#*`>]/g,"").trim().slice(0,140),tag:"toki-"+a.pid,
+    renotify:true,data:{pid:a.pid}};
+  const title=a.title+" "+kind;
+  if(navigator.serviceWorker&&navigator.serviceWorker.ready)
+    navigator.serviceWorker.ready.then(r=>r.showNotification(title,opts))
+      .catch(()=>{try{new Notification(title,opts)}catch(e){}});
+  else try{new Notification(title,opts)}catch(e){}
+}
+function updateAlertsButton(){
+  $("#enablealerts").hidden=!("Notification"in window)||Notification.permission!="default"||!TOKEN;
+}
 async function refreshAgents(){
   agents=await api("/api/agents");const prev=current;
+  notifyAttention(agents);
   if(agents.length&&!agents.some(a=>a.pid==prev)){current=agents[0].pid;offset=0;$("#log").innerHTML=""}
   renderAgents();
   const a=agents.find(x=>x.pid==current), al=$("#alert");
@@ -191,6 +225,10 @@ $("#ddbtn").addEventListener("click",e=>{e.stopPropagation();document.getElement
 document.addEventListener("click",()=>document.getElementById("dd").classList.remove("open"));
 $("#tolatest").addEventListener("click",scrollToLatest);
 window.addEventListener("scroll",()=>{if(nearBottom())$("#tolatest").hidden=true},{passive:true});
+$("#enablealerts").addEventListener("click",async()=>{
+  try{await Notification.requestPermission()}catch(e){}
+  updateAlertsButton();
+});
 
 // Enter a fresh link from another device: scan Toki's Connect QR, or type its host and token.
 // Both reload with the params in the fragment so the normal verify flow takes over.

--- a/Sources/Toki/Resources/webui/index.html
+++ b/Sources/Toki/Resources/webui/index.html
@@ -42,6 +42,7 @@
 </div>
 <header><h1><svg width="24" height="24" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-label="Toki"><rect width="1024" height="1024" rx="232" fill="#181a1f"/><g transform="translate(0 6)"><path d="M268 245H704L682 282L704 319H268C248 319 232 303 232 282C232 261 248 245 268 245Z" fill="#f4f1ea"/><path d="M520 600L636 484" fill="none" stroke="#f4f1ea" stroke-width="74" stroke-linecap="round" stroke-linejoin="round"/><path d="M465 354H539V626C539 664 558 671 600 671H704L684 708L704 745H566C502 745 465 708 465 636Z" fill="#f4f1ea"/><circle cx="502" cy="282" r="96" fill="#f4f1ea"/><circle cx="502" cy="282" r="48" fill="#181a1f"/><circle cx="746" cy="282" r="39" fill="#9bb5a7"/><circle cx="636" cy="484" r="39" fill="#f4f1ea"/><circle cx="744" cy="708" r="38" fill="#d3a45c"/></g></svg>Remote Control</h1><div id="dd"><button id="ddbtn" type="button"></button><div id="ddlist"></div></div></header>
 <div id="conn" role="status" hidden><span class="conn-dot"></span>Reconnecting to Toki on your Mac&#8230;</div>
+<button id="enablealerts" type="button" hidden>&#128276; Turn on alerts when an agent needs you</button>
 <div id="alert"></div><div id="readonly" role="status">Read-only session — this agent is not running in a terminal, so you can follow its progress but cannot send replies.</div><div id="log"></div>
 <button id="tolatest" type="button" hidden aria-label="Jump to latest">&#8595; New messages</button>
 <footer>

--- a/Sources/Toki/Resources/webui/styles.css
+++ b/Sources/Toki/Resources/webui/styles.css
@@ -8,7 +8,7 @@ button{font:inherit;touch-action:manipulation;-webkit-tap-highlight-color:transp
 button:not(:disabled):active{transform:scale(.96);filter:brightness(1.16)}
 button:focus-visible,input:focus-visible,textarea:focus-visible{outline:3px solid #72a7e8;outline-offset:2px}
 .locked>header,.locked>#alert,.locked>#log,.locked>footer,
-.locked>#conn,.locked>#tolatest{display:none}
+.locked>#conn,.locked>#tolatest,.locked>#enablealerts{display:none}
 #pairing{display:none;min-height:100vh;align-items:center;justify-content:center;
          padding:calc(24px + env(safe-area-inset-top)) 24px calc(24px + env(safe-area-inset-bottom))}
 .locked #pairing{display:flex}
@@ -63,6 +63,10 @@ header{position:sticky;top:0;background:#111c;backdrop-filter:blur(10px);
           background:#294f78;color:#fff;border:1px solid #6596c7;box-shadow:0 3px 12px #0007;
           font-size:13px;font-weight:600}
 #tolatest[hidden]{display:none}
+#enablealerts{display:block;width:calc(100% - 28px);margin:10px 14px;padding:10px 12px;
+              border-radius:10px;background:#1f3a5c;border:1px solid #37a;color:#cfe2f7;
+              font-size:13px;font-weight:600;text-align:left}
+#enablealerts[hidden]{display:none}
 h1{font-size:16px;display:flex;align-items:center;gap:8px}
 #dd{position:relative;margin-top:8px}
 #ddbtn{width:100%;display:flex;align-items:center;gap:8px;padding:8px;border-radius:8px;

--- a/Sources/Toki/Resources/webui/sw.js
+++ b/Sources/Toki/Resources/webui/sw.js
@@ -27,6 +27,18 @@ self.addEventListener("activate", event => {
   );
 });
 
+self.addEventListener("notificationclick", event => {
+  event.notification.close();
+  event.waitUntil(
+    self.clients.matchAll({ type: "window", includeUncontrolled: true }).then(list => {
+      for (const client of list) {
+        if ("focus" in client) return client.focus();
+      }
+      if (self.clients.openWindow) return self.clients.openWindow("./");
+    })
+  );
+});
+
 self.addEventListener("fetch", event => {
   const request = event.request;
   if (request.method !== "GET") return;

--- a/Tests/test_remote_pwa.js
+++ b/Tests/test_remote_pwa.js
@@ -67,4 +67,13 @@ assert.match(html, /id="conn"/);
 assert.match(app, /function setConnected/);
 assert.match(css, /\.conn-dot/);
 
+// --- Attention notifications: permission affordance, transition-only firing, SW click handler ---
+assert.match(html, /id="enablealerts"/);
+assert.match(app, /function notifyAttention/);
+assert.match(app, /Notification\.permission!="granted"/);
+assert.match(app, /notifySeeded&&notifiedAttention\[a\.pid\]!=key/);
+assert.match(app, /showNotification\(title,opts\)/);
+assert.match(app, /requestPermission\(\)/);
+assert.match(sw, /addEventListener\("notificationclick"/);
+
 console.log("remote pwa + qr + ux tests passed");


### PR DESCRIPTION
Fourth improvement: the phone tells you when an agent is waiting.

## What
- On each agents poll, detect the **transition** into an attention/permission state and fire a browser notification ("<agent> needs your input / needs approval", body = the question).
- Deduped per agent by an attention signature, and **seeded on first load** so connecting to a session that's already waiting doesn't burst notifications.
- Shown via `ServiceWorkerRegistration.showNotification` (falls back to `new Notification`) so an installed PWA can surface it; a `notificationclick` handler focuses the app.
- One-tap **"Turn on alerts"** banner requests permission (shown only while connected and permission is default).

## Scope
- Fires while the app is open or backgrounded-open (great on desktop; partial on mobile when the PWA is suspended). **Closed-app Web Push** (VAPID keys + encrypted push + a push service) is the larger follow-on and is intentionally not in this PR.

## Tests
- JS assertions for the permission affordance, transition-only firing, showNotification, and the SW click handler; `node --check` + full JS suite green.
- Base: `release/v2.5.4`.