### PR TITLE
Changelog: Remote Control ease-of-use (2.5.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - **Remote Control (#64): follow and reply to your agents from your phone.** Toki can run a local Remote Control server and pair a browser over Tailscale (recommended), your local network, or this Mac, using a six-digit code that rotates every two minutes and a scoped session you can limit from 1 hour up to 2 days. The web app lists the same active agents as the menu bar, streams their transcripts with GitHub-style Markdown tables, and lets you reply, send terminal keys, and approve or reject prompts; non-terminal sessions such as Codex desktop are clearly read-only. It installs as a phone app (PWA) with an offline-capable shell and Add to Home Screen, and you can start a session by scanning the Connect QR or entering a host and token by hand. Agent data stays between your browser and your Mac; the hosted interface only serves the UI. A teal status icon in the header opens the Remote Control settings while the server is running.
 - Remote Control settings include a built-in Tailscale setup guide. An info button next to the Host picker walks through the one-time steps to connect from anywhere (MagicDNS, HTTPS certificates, and `tailscale serve`), with the links and a copyable command you need.
+- Remote Control shows a live reachability indicator for the connect-from-anywhere path: it tells you when your phone can actually reach this Mac, or that `tailscale serve` still needs to start, instead of handing you a QR that silently fails.
+- One-click HTTPS setup: when `tailscale serve` isn't running, an "Enable HTTPS access" button starts it for you and re-checks reachability.
+- New **Cloudflare Tunnel** host option (when `cloudflared` is installed) gives you a public HTTPS address with no Tailscale, account, or DNS setup.
+- The companion app can notify you when an agent needs your input or approval, with a one-tap prompt to turn alerts on. (Notifications fire while the app is open or backgrounded.)
+- Remote Control settings lead with a single **Reach** choice, "On my network" or "From anywhere", with the detailed host and app options tucked under Advanced.
 
 ## 2.5.3 - 2026-07-28
 


### PR DESCRIPTION
Documents the five Remote Control ease-of-use improvements (#67–#71) under 2.5.4: live reachability, one-click tailscale serve, Cloudflare Tunnel, attention notifications, and the two-choice Reach control.