### PR TITLE
Fix one-click tailscale serve hanging on Enabling…

### DIFF
--- a/Sources/Toki/Server/RemoteControlServer.swift
+++ b/Sources/Toki/Server/RemoteControlServer.swift
@@ -481,18 +481,38 @@ final class RemoteControlServer: ObservableObject {
         task.executableURL = executable
         task.arguments = executable.lastPathComponent == "env" ? ["tailscale"] + arguments : arguments
 
-        let errorPipe = Pipe()
-        task.standardError = errorPipe
+        // Capture stderr to a temp file, not a Pipe. `serve --bg` can leave a descriptor open,
+        // and a blocking pipe read would then never reach EOF (hangs the caller forever).
+        let logURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("toki-serve-\(UUID().uuidString).log")
+        FileManager.default.createFile(atPath: logURL.path, contents: nil)
+        let logHandle = try? FileHandle(forWritingTo: logURL)
+        defer {
+            try? logHandle?.close()
+            try? FileManager.default.removeItem(at: logURL)
+        }
+        task.standardError = logHandle ?? FileHandle.nullDevice
         task.standardOutput = FileHandle.nullDevice
+
         do {
             try task.run()
         } catch {
             return "Couldn't run tailscale. Make sure Tailscale is installed."
         }
-        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
-        task.waitUntilExit()
+
+        // Never block the UI indefinitely: `tailscale serve` can stall while provisioning a cert.
+        let deadline = Date().addingTimeInterval(25)
+        while task.isRunning, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.2)
+        }
+        if task.isRunning {
+            task.terminate()
+            return "Enabling HTTPS timed out. Make sure Tailscale is running and HTTPS Certificates are enabled, or run the command in Terminal (see the guide)."
+        }
+
+        try? logHandle?.close()
         if task.terminationStatus == 0 { return nil }
-        let message = String(data: errorData, encoding: .utf8)?
+        let message = (try? String(contentsOf: logURL, encoding: .utf8))?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         if let message, !message.isEmpty {
             return message


### PR DESCRIPTION
Follow-up bug fix to #68. The "Enable HTTPS access" button could spin on "Enabling…" forever.

## Cause
`runTailscaleServe` read stderr from a **Pipe** with a blocking `readDataToEndOfFile()`. `tailscale serve --bg` can leave a descriptor open on that pipe, so the read never reaches EOF and the background task never returns — `isEnablingServe` stays true.

## Fix
- Capture stderr to a temp **file** instead of a pipe (a file read can't deadlock).
- Cap the wait at 25s and terminate + report a timeout if serve stalls (e.g. provisioning a cert).
- Surface the CLI's own message on failure, so `tailscale serve` printing "Tailscale is stopped" now shows up as the error instead of hanging.

Verified: the command exits ~2s in a shell ("Tailscale is stopped" when Tailscale is off); rebuilt the app and the spinner now resolves to that message.
Base: `release/v2.5.4`.