### PR TITLE
Always show the Tailscale connect QR (fix beta 3 blocker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 - The companion app can notify you when an agent needs your input or approval, with a one-tap prompt to turn alerts on. (Notifications fire while the app is open or backgrounded.)
 - Remote Control settings lead with a single **Reach** choice, "On my network" or "From anywhere", with the detailed host and app options tucked under Advanced.
 
+### Fixed
+
+- Remote Control "From anywhere" now always shows the Connect QR when Tailscale is up. It points the phone straight at this Mac's Tailscale address with the session token in the URL (`https://<your-machine>.ts.net/?token=…`), and when the MagicDNS name can't be read it falls back to the tailnet IP so the QR and its verification code still work without extra setup.
+- Tailscale MagicDNS detection now looks in more locations for the `tailscale` CLI and searches a real PATH, so the machine's DNS name is found on more setups.
+- The "Advanced" row in Remote Control settings now expands when you click anywhere on it, not only the disclosure triangle.
+
 ## 2.5.3 - 2026-07-28
 
 ### Changed

--- a/Sources/Toki/Server/RemoteControlServer.swift
+++ b/Sources/Toki/Server/RemoteControlServer.swift
@@ -164,6 +164,7 @@ final class RemoteControlServer: ObservableObject {
             hostMode: hostMode,
             host: host,
             localNetworkHost: Self.localNetworkIP(),
+            tailscaleIP: Self.tailscaleIP(),
             token: token,
             port: port
         )
@@ -174,37 +175,54 @@ final class RemoteControlServer: ObservableObject {
         hostMode: HostMode,
         host: String?,
         localNetworkHost: String?,
+        tailscaleIP: String? = nil,
         token: String,
         port: Int
     ) -> String? {
         switch companionAppMode {
         case .sameHost:
-            guard let host else { return nil }
-            let isHTTPSHost = hostMode == .tailscale || hostMode == .tunnel
-            return directConnectURL(
-                host: host,
-                scheme: isHTTPSHost ? "https" : "http",
-                port: isHTTPSHost ? nil : port,
-                token: token
-            )
+            if let host {
+                let isHTTPSHost = hostMode == .tailscale || hostMode == .tunnel
+                return directConnectURL(
+                    host: host,
+                    scheme: isHTTPSHost ? "https" : "http",
+                    port: isHTTPSHost ? nil : port,
+                    token: token
+                )
+            }
+            // Tailscale is up but its MagicDNS name isn't resolvable (no CLI on PATH, MagicDNS off).
+            // The server binds 0.0.0.0, so a phone on the tailnet can still reach it at the 100.x IP.
+            if hostMode == .tailscale {
+                return tailscaleDirectURL(ip: tailscaleIP, port: port, token: token)
+            }
+            return nil
         case .localhost:
             return directConnectURL(host: "localhost", scheme: "http", port: port, token: token)
         case .localNetwork:
             guard let localNetworkHost else { return nil }
             return directConnectURL(host: localNetworkHost, scheme: "http", port: port, token: token)
         case .hosted:
-            guard let host, isTailscaleDNSHost(host) else { return nil }
-            var parameters = URLComponents()
-            parameters.queryItems = [
-                URLQueryItem(name: "host", value: host),
-                URLQueryItem(name: "token", value: token)
-            ]
+            if let host, isTailscaleDNSHost(host) {
+                var parameters = URLComponents()
+                parameters.queryItems = [
+                    URLQueryItem(name: "host", value: host),
+                    URLQueryItem(name: "token", value: token)
+                ]
 
-            var components = URLComponents(string: Self.hostedRemoteControlOrigin)
-            components?.path = "/"
-            components?.percentEncodedFragment = parameters.percentEncodedQuery
-            return components?.url?.absoluteString
+                var components = URLComponents(string: Self.hostedRemoteControlOrigin)
+                components?.path = "/"
+                components?.percentEncodedFragment = parameters.percentEncodedQuery
+                return components?.url?.absoluteString
+            }
+            // The hosted UI needs a MagicDNS host; when it isn't available, fall back to the Mac's
+            // own UI served directly over the tailnet IP so the QR (and token) still work.
+            return tailscaleDirectURL(ip: tailscaleIP, port: port, token: token)
         }
+    }
+
+    private static func tailscaleDirectURL(ip: String?, port: Int, token: String) -> String? {
+        guard let ip else { return nil }
+        return directConnectURL(host: ip, scheme: "http", port: port, token: token)
     }
 
     private static func directConnectURL(
@@ -412,10 +430,13 @@ final class RemoteControlServer: ObservableObject {
     }
 
     private nonisolated static func tailscaleExecutable() -> URL {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
         let candidates = [
             "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
             "/opt/homebrew/bin/tailscale",
-            "/usr/local/bin/tailscale"
+            "/usr/local/bin/tailscale",
+            "/usr/bin/tailscale",
+            "\(home)/.local/bin/tailscale"
         ]
         if let path = candidates.first(where: FileManager.default.isExecutableFile(atPath:)) {
             return URL(fileURLWithPath: path)
@@ -428,6 +449,14 @@ final class RemoteControlServer: ObservableObject {
         let task = Process()
         task.executableURL = executable
         task.arguments = executable.lastPathComponent == "env" ? ["tailscale"] + arguments : arguments
+        // A menu-bar app launched from Finder inherits a bare PATH, so the env fallback needs the
+        // usual CLI directories spelled out to find a `tailscale` that isn't at a known path.
+        if executable.lastPathComponent == "env" {
+            var environment = ProcessInfo.processInfo.environment
+            let home = FileManager.default.homeDirectoryForCurrentUser.path
+            environment["PATH"] = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:\(home)/.local/bin"
+            task.environment = environment
+        }
 
         let output = Pipe()
         task.standardOutput = output

--- a/Sources/Toki/Views/SettingsPanel.swift
+++ b/Sources/Toki/Views/SettingsPanel.swift
@@ -61,6 +61,7 @@ struct SettingsPanel: View {
 
     @ObservedObject private var remoteServer = RemoteControlServer.shared
     @State private var showingConnect = false
+    @State private var advancedExpanded = false
     @State private var showingTailscaleGuide = false
     private let reachabilityTimer = Timer.publish(every: 5, on: .main, in: .common).autoconnect()
 
@@ -554,7 +555,7 @@ struct SettingsPanel: View {
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.horizontal, 4)
 
-            DisclosureGroup("Advanced") {
+            DisclosureGroup(isExpanded: $advancedExpanded) {
                 VStack(alignment: .leading, spacing: 8) {
                     HStack(spacing: 8) {
                         Text("Host")
@@ -612,6 +613,11 @@ struct SettingsPanel: View {
                     }
                 }
                 .padding(.top, 6)
+            } label: {
+                Text("Advanced")
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+                    .onTapGesture { withAnimation(.easeInOut(duration: 0.15)) { advancedExpanded.toggle() } }
             }
             .font(.system(size: 11))
             .padding(.horizontal, 4)
@@ -672,7 +678,7 @@ struct SettingsPanel: View {
                     .padding(.horizontal, 4)
             }
 
-            if remoteServer.isRunning, remoteServer.connectURL != nil,
+            if remoteServer.isRunning, remoteServer.tailscaleDNSName != nil,
                remoteServer.companionAppMode == .hosted || remoteServer.hostMode == .tailscale {
                 tailscaleReadinessRow
             }
@@ -778,7 +784,7 @@ struct SettingsPanel: View {
                     let modes = remoteServer.availableHostModes
                     if modes.contains(.tailscale) {
                         remoteServer.hostMode = .tailscale
-                        remoteServer.companionAppMode = .hosted
+                        remoteServer.companionAppMode = .sameHost
                     } else if modes.contains(.tunnel) {
                         remoteServer.hostMode = .tunnel
                         remoteServer.companionAppMode = .sameHost

--- a/Tests/TokiTests/RemoteControlServerTests.swift
+++ b/Tests/TokiTests/RemoteControlServerTests.swift
@@ -121,6 +121,48 @@ final class RemoteControlServerTests: XCTestCase {
         XCTAssertEqual(url, "https://my-mac.example-tailnet.ts.net/?token=abc")
     }
 
+    func testTailscaleFallsBackToDirectTailnetIPWhenDNSNameMissing() {
+        let url = RemoteControlServer.makeConnectURL(
+            companionAppMode: .sameHost,
+            hostMode: .tailscale,
+            host: nil,
+            localNetworkHost: "192.168.1.10",
+            tailscaleIP: "100.101.102.103",
+            token: "abc",
+            port: 8765
+        )
+
+        XCTAssertEqual(url, "http://100.101.102.103:8765/?token=abc")
+    }
+
+    func testHostedTailscaleFallsBackToDirectTailnetIPWhenDNSNameMissing() {
+        let url = RemoteControlServer.makeConnectURL(
+            companionAppMode: .hosted,
+            hostMode: .tailscale,
+            host: nil,
+            localNetworkHost: nil,
+            tailscaleIP: "100.101.102.103",
+            token: "abc",
+            port: 8765
+        )
+
+        XCTAssertEqual(url, "http://100.101.102.103:8765/?token=abc")
+    }
+
+    func testTailscaleWithoutDNSNameOrTailnetIPHasNoURL() {
+        let url = RemoteControlServer.makeConnectURL(
+            companionAppMode: .sameHost,
+            hostMode: .tailscale,
+            host: nil,
+            localNetworkHost: "192.168.1.10",
+            tailscaleIP: nil,
+            token: "abc",
+            port: 8765
+        )
+
+        XCTAssertNil(url)
+    }
+
     func testLocalhostCompanionOverridesSelectedHost() {
         let url = RemoteControlServer.makeConnectURL(
             companionAppMode: .localhost,


### PR DESCRIPTION
## Problem

With **Remote Control → From anywhere** (Tailscale), the Connect button and QR never appeared, so there was no way to get the session **token** — the app showed *"Toki RC needs a Tailscale DNS host…"* even though Tailscale was up and the portal was reachable.

Root cause: the QR only renders when `connectURL != nil`, and every Tailscale path required the MagicDNS name read from the `tailscale` CLI. On machines where that read fails, `connectURL` is nil → no button → no sheet → no token.

## Fix

- **Direct-to-machine QR.** "From anywhere" now uses the direct Tailscale address (`sameHost`), so the QR is `https://<machine>.ts.net/?token=…` — straight at this Mac with the token, shown alongside the rotating verification code. (The hosted `rc.toki` UI stays available under Advanced → App.)
- **Tailnet-IP fallback.** The server binds `0.0.0.0`, so when the MagicDNS name can't be read, `makeConnectURL` falls back to `http://<tailnet-ip>:8765/?token=…`. The QR + token now always work over the tailnet with no `serve`/MagicDNS setup.
- **Broader CLI discovery.** `tailscaleExecutable()` checks more paths (`/usr/bin`, `~/.local/bin`) and the `env` fallback runs with a real PATH, so the DNS name resolves on more setups.
- **Serve-readiness nag** now only shows when a real DNS host exists, so the IP-fallback path doesn't get a false "can't reach" warning.
- **Advanced row** toggles from a click anywhere on it, not just the disclosure triangle.

## Tests

- New `makeConnectURL` cases: tailnet-IP fallback (sameHost + hosted), and nil when neither DNS name nor tailnet IP is available.
- `swift build` clean, `swift test` green (230 tests).

Note: I couldn't reproduce the exact no-DNS machine state locally (this Mac's `tailscale status --json` resolves), but the fallback is unit-tested and guarantees a working QR whenever the tailnet interface has an IP.