### PR TITLE
Companion app: interface refresh + security hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Text fields across the app now support the standard Cut, Copy, Paste, and Select All shortcuts (the menu-bar app previously shipped no Edit menu, so Cmd+V did nothing).
 - Fixed the companion app layout on iPad (and other large screens): the composer no longer drifts up the page while scrolling. The shell is now pinned to the viewport height with the transcript scrolling inside it, so the header and reply bar stay put.
 - The companion app has an eye toggle in the header that masks agent names in the picker, handy for screen recordings, plus a subtle background grain.
+- The companion app interface got a visual refresh built on a cohesive color system: layered surfaces with hairline borders, chat-style message bubbles, a brand-teal "private by design" note, and refined buttons, inputs, and code blocks for a cleaner, more legible read on the phone.
 
 ### Fixed
 

--- a/Sources/Toki/Resources/toki_remote.py
+++ b/Sources/Toki/Resources/toki_remote.py
@@ -1016,6 +1016,12 @@ SESSION_TTL = 12 * 60 * 60
 SESSION_TTL_CHOICES = (60 * 60, 12 * 60 * 60, 24 * 60 * 60, 2 * 24 * 60 * 60)
 PAIRING_WINDOW = 60
 PAIRING_MAX_FAILURES = 5
+MAX_BODY_BYTES = 256 * 1024
+CSP = (
+    "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; "
+    "img-src 'self' data:; connect-src 'self'; worker-src 'self'; manifest-src 'self'; "
+    "base-uri 'none'; form-action 'self'; object-src 'none'; frame-ancestors 'none'"
+)
 SESSIONS = {}
 PAIRING_FAILURES = {}
 AUTH_LOCK = threading.Lock()
@@ -1047,12 +1053,26 @@ class Handler(BaseHTTPRequestHandler):
             self.send_header("Access-Control-Allow-Origin", HOSTED_ORIGIN)
             self.send_header("Vary", "Origin")
 
+    def _secure(self, document=False):
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("Referrer-Policy", "no-referrer")
+        if document:
+            self.send_header("Content-Security-Policy", CSP)
+            self.send_header("X-Frame-Options", "DENY")
+
+    def _read_body(self):
+        length = int(self.headers.get("Content-Length", 0))
+        if length > MAX_BODY_BYTES:
+            return None
+        return self.rfile.read(length)
+
     def _json(self, obj, code=200):
         body = json.dumps(obj).encode()
         self.send_response(code)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
         self.send_header("Cache-Control", "no-store")
+        self._secure()
         self._cors()
         self.end_headers()
         self.wfile.write(body)
@@ -1071,9 +1091,11 @@ class Handler(BaseHTTPRequestHandler):
         if not secrets.compare_digest(link_token, TOKEN):
             return self._json({"error": "bad link token"}, 403)
 
-        length = int(self.headers.get("Content-Length", 0))
+        raw = self._read_body()
+        if raw is None:
+            return self._json({"error": "request too large"}, 413)
         try:
-            body = json.loads(self.rfile.read(length))
+            body = json.loads(raw)
         except ValueError:
             return self._json({"error": "bad json"}, 400)
         code = str(body.get("code", "")).replace(" ", "")
@@ -1108,6 +1130,7 @@ class Handler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header("Content-Type", ctype)
         self.send_header("Content-Length", str(len(body)))
+        self._secure(document=True)
         self.end_headers()
         self.wfile.write(body)
 
@@ -1210,9 +1233,11 @@ class Handler(BaseHTTPRequestHandler):
             return self._json({"error": "bad token"}, 403)
         if url.path != "/api/send":
             return self._json({"error": "not found"}, 404)
-        length = int(self.headers.get("Content-Length", 0))
+        raw = self._read_body()
+        if raw is None:
+            return self._json({"error": "request too large"}, 413)
         try:
-            body = json.loads(self.rfile.read(length))
+            body = json.loads(raw)
         except ValueError:
             return self._json({"error": "bad json"}, 400)
         agent = next((a for a in discover_agents() if a["pid"] == body.get("pid")), None)

--- a/Sources/Toki/Resources/toki_remote.py
+++ b/Sources/Toki/Resources/toki_remote.py
@@ -1061,8 +1061,11 @@ class Handler(BaseHTTPRequestHandler):
             self.send_header("X-Frame-Options", "DENY")
 
     def _read_body(self):
-        length = int(self.headers.get("Content-Length", 0))
-        if length > MAX_BODY_BYTES:
+        try:
+            length = int(self.headers.get("Content-Length", 0))
+        except (TypeError, ValueError):
+            return None
+        if length < 0 or length > MAX_BODY_BYTES:
             return None
         return self.rfile.read(length)
 

--- a/Sources/Toki/Resources/webui/index.html
+++ b/Sources/Toki/Resources/webui/index.html
@@ -3,7 +3,7 @@
 <title>Toki Remote Control</title><link rel="icon" href="favicon.svg" type="image/svg+xml">
 <link rel="apple-touch-icon" href="apple-touch-icon.png">
 <link rel="manifest" href="manifest.webmanifest">
-<meta name="theme-color" content="#111111">
+<meta name="theme-color" content="#101216">
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">

--- a/Sources/Toki/Resources/webui/styles.css
+++ b/Sources/Toki/Resources/webui/styles.css
@@ -1,9 +1,33 @@
-:root{color-scheme:dark light}
+:root{
+  color-scheme:dark light;
+  --bg:#101216;
+  --surface-1:#181b21;
+  --surface-2:#20242d;
+  --surface-3:#282d38;
+  --line:#2b3039;
+  --line-strong:#3a404c;
+  --text:#eceef2;
+  --text-2:#a3a9b5;
+  --text-3:#727884;
+  --accent:#4a8bd6;
+  --accent-2:#6aa3e6;
+  --accent-surface:#1a2c46;
+  --accent-line:#37567f;
+  --teal-surface:#132723;
+  --teal-line:#2b5750;
+  --user-surface:#213c2b;
+  --user-line:#39694a;
+  --warn:#e6a24a; --warn-surface:#2e2413; --warn-line:#6c5227;
+  --danger:#e07474; --danger-surface:#2a1618; --danger-line:#7a3638;
+  --r-sm:8px; --r:10px; --r-md:12px; --r-lg:14px; --r-xl:18px; --r-pill:999px;
+  --tail:5px;
+}
 *{box-sizing:border-box;margin:0}
 /* Flex column pinned to the dynamic viewport height: the transcript scrolls inside #log while the
    header and composer stay put. Avoids iOS/iPadOS Safari's position:fixed-on-body-scroll drift. */
-body{font:15px/1.45 -apple-system,system-ui,sans-serif;background:#111;color:#eee;
-     display:flex;flex-direction:column;height:100dvh;overflow:hidden}
+body{font:15px/1.45 -apple-system,system-ui,sans-serif;background:var(--bg);color:var(--text);
+     display:flex;flex-direction:column;height:100dvh;overflow:hidden;
+     -webkit-font-smoothing:antialiased}
 /* Subtle film grain over the whole app: an inline SVG noise field, fixed behind the content. */
 body::before{content:"";position:fixed;inset:0;z-index:-1;pointer-events:none;opacity:.05;
   background:url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='g'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/></filter><rect width='100%25' height='100%25' filter='url(%23g)'/></svg>")}
@@ -11,174 +35,187 @@ button{font:inherit;touch-action:manipulation;-webkit-tap-highlight-color:transp
        transition:transform .08s ease,filter .12s ease,background-color .12s ease,
                   border-color .12s ease,box-shadow .12s ease}
 button:not(:disabled):active{transform:scale(.96);filter:brightness(1.16)}
-button:focus-visible,input:focus-visible,textarea:focus-visible{outline:3px solid #72a7e8;outline-offset:2px}
+button:focus-visible,input:focus-visible,textarea:focus-visible{outline:2.5px solid var(--accent-2);outline-offset:2px}
 .locked>header,.locked>#alert,.locked>#log,.locked>footer,
 .locked>#conn,.locked>#tolatest,.locked>#enablealerts{display:none}
 /* margin:auto on the form (below) centers it when there's room but aligns to the top and stays
    scrollable when the form is taller than the viewport; justify-content:center would push its top
    above the scroll origin and clip it. */
-#pairing{display:none;position:fixed;inset:0;z-index:15;background:#111;overflow-y:auto;
+#pairing{display:none;position:fixed;inset:0;z-index:15;background:
+         radial-gradient(120% 80% at 50% -10%,#17242a 0%,var(--bg) 60%);overflow-y:auto;
          padding:calc(24px + env(safe-area-inset-top)) 24px calc(24px + env(safe-area-inset-bottom))}
 .locked #pairing{display:flex}
-#pairform{width:min(100%,360px);margin:auto;padding:22px;border:1px solid #444;border-radius:14px;
-          background:#1b1b1b;text-align:center}
+#pairform{width:min(100%,360px);margin:auto;padding:24px 22px;border:1px solid var(--line);
+          border-radius:var(--r-xl);background:var(--surface-1);text-align:center;
+          box-shadow:0 18px 50px #0007,0 1px 0 #ffffff0d inset}
 .pair-brand{display:flex;align-items:center;justify-content:center;gap:8px;
-            color:#bbb;font-size:14px;font-weight:600;margin-bottom:14px}
-#pairform h2{font-size:20px;margin-bottom:6px}
-#pairform p{color:#aaa;margin-bottom:16px}
-#paircode{width:100%;text-align:center;font:600 24px/1.2 ui-monospace,monospace;
-          letter-spacing:.12em;margin-bottom:10px}
-#pairform button{width:100%;padding:10px 16px;border-radius:8px;background:#2a4a72;color:#fff;
-                 border:1px solid #58a;font-size:15px}
-#pairstatus{font-size:13px;color:#e88;min-height:20px;margin-top:8px}
-.privacy-note{display:flex;flex-direction:column;gap:3px;margin-top:12px;padding:11px;
-              border-radius:9px;background:#151d19;color:#98a49c;text-align:left;font-size:12px}
-.privacy-note strong{color:#b9c9bf}
+            color:var(--text-2);font-size:13px;font-weight:600;letter-spacing:.01em;margin-bottom:16px}
+#pairform h2{font-size:21px;letter-spacing:-.01em;margin-bottom:6px}
+#pairform p{color:var(--text-2);margin-bottom:18px}
+#paircode{width:100%;text-align:center;font:600 26px/1.2 ui-monospace,monospace;
+          letter-spacing:.14em;margin-bottom:12px}
+#pairform button{width:100%;padding:12px 16px;border-radius:var(--r);font-size:15px;font-weight:600;
+                 color:#fff;border:1px solid var(--accent-line);
+                 background:linear-gradient(180deg,var(--accent-2),var(--accent));
+                 box-shadow:0 1px 0 #ffffff40 inset,0 4px 14px #0d2a4d66}
+#pairstatus{font-size:13px;color:var(--danger);min-height:20px;margin-top:8px}
+.privacy-note{display:flex;flex-direction:column;gap:3px;margin-top:14px;padding:12px;
+              border-radius:var(--r-md);background:var(--teal-surface);border:1px solid var(--teal-line);
+              color:#9ab3ac;text-align:left;font-size:12px}
+.privacy-note strong{color:#bcd6ce}
 #paircontrols[hidden]{display:none}
 #connectmethods[hidden]{display:none}
-.or{display:flex;align-items:center;gap:10px;margin:14px 0;color:#8a8a8a;font-size:12px}
+.or{display:flex;align-items:center;gap:10px;margin:16px 0;color:var(--text-3);font-size:12px}
 .or[hidden]{display:none}
-.or::before,.or::after{content:"";flex:1;height:1px;background:#3a3a3a}
+.or::before,.or::after{content:"";flex:1;height:1px;background:var(--line)}
 #manualfields{display:flex;flex-direction:column;gap:8px}
 #manualfields input{flex:none;text-align:left;font:16px/1.3 ui-monospace,monospace}
+#pairform #manualconnect{background:var(--surface-2);border-color:var(--line-strong);
+                         box-shadow:0 1px 0 #ffffff0d inset}
 #scanbtn{width:100%;display:flex;align-items:center;justify-content:center;gap:8px;
-         margin-top:10px;padding:10px 16px;border-radius:8px;background:#20304a;
-         color:#dce7f5;border:1px solid #3c5a82;font-size:15px;font-weight:600}
+         margin-top:10px;padding:11px 16px;border-radius:var(--r);background:var(--accent-surface);
+         color:#dce7f5;border:1px solid var(--accent-line);font-size:15px;font-weight:600}
 #scanbtn[hidden]{display:none}
 #scanner{position:fixed;inset:0;z-index:20;background:#000;display:flex;
          flex-direction:column;align-items:center;justify-content:center;gap:16px;text-align:center;
          padding:calc(24px + env(safe-area-inset-top)) 20px calc(24px + env(safe-area-inset-bottom))}
 #scanner[hidden]{display:none}
-.scan-stage{position:relative;width:min(80vw,320px);aspect-ratio:1;border-radius:18px;
+.scan-stage{position:relative;width:min(80vw,320px);aspect-ratio:1;border-radius:var(--r-xl);
             overflow:hidden;background:#111}
 #scanvideo{width:100%;height:100%;object-fit:cover}
-.scan-box{position:absolute;inset:12%;border:3px solid #f4f1eacc;border-radius:14px;
+.scan-box{position:absolute;inset:12%;border:3px solid #f4f1eacc;border-radius:var(--r-lg);
           box-shadow:0 0 0 100vmax #0009;pointer-events:none}
 #scanhint{color:#ddd;font-size:15px;max-width:320px}
-#scanstatus{color:#ef8e8e;font-size:13px;min-height:18px}
-#scancancel{padding:11px 22px;border-radius:10px;background:#222;color:#eee;
-            border:1px solid #555;font-size:15px}
-header{flex:none;background:#111c;backdrop-filter:blur(10px);
-       padding:calc(12px + env(safe-area-inset-top)) 14px 12px;border-bottom:1px solid #333;z-index:2}
+#scanstatus{color:var(--danger);font-size:13px;min-height:18px}
+#scancancel{padding:11px 22px;border-radius:var(--r);background:var(--surface-2);color:#eee;
+            border:1px solid var(--line-strong);font-size:15px}
+header{flex:none;background:color-mix(in srgb,var(--bg) 80%,transparent);backdrop-filter:blur(12px);
+       -webkit-backdrop-filter:blur(12px);
+       padding:calc(12px + env(safe-area-inset-top)) 14px 12px;border-bottom:1px solid var(--line);z-index:2}
 #conn{display:flex;align-items:center;gap:8px;margin:10px 14px;padding:9px 12px;
-      border-radius:10px;background:#3a2a16;border:1px solid #7a5a2c;color:#e8c489;font-size:13px}
+      border-radius:var(--r);background:var(--warn-surface);border:1px solid var(--warn-line);
+      color:#e8c489;font-size:13px}
 #conn[hidden]{display:none}
-.conn-dot{width:9px;height:9px;border-radius:50%;background:#e8a54a;flex:none;
+.conn-dot{width:9px;height:9px;border-radius:50%;background:var(--warn);flex:none;
           animation:connpulse 1.1s ease-in-out infinite}
 @keyframes connpulse{0%,100%{opacity:.35}50%{opacity:1}}
 #tolatest{position:fixed;left:50%;transform:translateX(-50%);z-index:3;
-          bottom:calc(var(--footer-height,180px) + 12px);padding:8px 16px;border-radius:999px;
-          background:#294f78;color:#fff;border:1px solid #6596c7;box-shadow:0 3px 12px #0007;
+          bottom:calc(var(--footer-height,180px) + 12px);padding:9px 16px;border-radius:var(--r-pill);
+          background:var(--accent);color:#fff;border:1px solid var(--accent-2);box-shadow:0 4px 16px #0008;
           font-size:13px;font-weight:600}
 #tolatest[hidden]{display:none}
-#enablealerts{display:block;width:calc(100% - 28px);margin:10px 14px;padding:10px 12px;
-              border-radius:10px;background:#1f3a5c;border:1px solid #37a;color:#cfe2f7;
-              font-size:13px;font-weight:600;text-align:left}
+#enablealerts{display:block;width:calc(100% - 28px);margin:10px 14px;padding:11px 12px;
+              border-radius:var(--r);background:var(--accent-surface);border:1px solid var(--accent-line);
+              color:#cfe2f7;font-size:13px;font-weight:600;text-align:left}
 #enablealerts[hidden]{display:none}
-h1{font-size:16px;display:flex;align-items:center;gap:8px}
+h1{font-size:16px;display:flex;align-items:center;gap:8px;letter-spacing:-.01em}
 .hdr-top{display:flex;align-items:center;gap:10px}
 .hdr-top h1{flex:1;min-width:0}
 #privacytoggle{flex:none;display:inline-flex;align-items:center;justify-content:center;
-  width:36px;height:36px;border-radius:9px;background:#222;border:1px solid #444;color:#bbb}
-#privacytoggle:not(:disabled):hover{color:#eee;border-color:#666}
-#privacytoggle[aria-pressed="true"]{background:#20304a;border-color:#3c5a82;color:#dce7f5}
+  width:36px;height:36px;border-radius:var(--r-sm);background:var(--surface-2);border:1px solid var(--line);color:var(--text-2)}
+#privacytoggle:not(:disabled):hover{color:var(--text);border-color:var(--line-strong)}
+#privacytoggle[aria-pressed="true"]{background:var(--accent-surface);border-color:var(--accent-line);color:#dce7f5}
 #privacytoggle svg{width:18px;height:18px}
 .eye-off{display:none}
 body.privacy .eye-open{display:none}
 body.privacy .eye-off{display:inline}
-#dd{position:relative;margin-top:8px}
-#ddbtn{width:100%;display:flex;align-items:center;gap:8px;padding:8px;border-radius:8px;
-       background:#222;color:#eee;border:1px solid #444;font-size:15px;text-align:left}
+#dd{position:relative;margin-top:10px}
+#ddbtn{width:100%;display:flex;align-items:center;gap:8px;padding:9px 10px;border-radius:var(--r-sm);
+       background:var(--surface-2);color:var(--text);border:1px solid var(--line);font-size:15px;text-align:left}
 #dd .t{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-#dd .caret{color:#888;flex:none}
-#dd .dot{color:#f55}
-#ddlist{display:none;position:absolute;left:0;right:0;top:calc(100% + 4px);z-index:5;
-        background:#1b1b1b;border:1px solid #444;border-radius:8px;overflow-y:auto;max-height:60vh}
+#dd .caret{color:var(--text-3);flex:none}
+#dd .dot{color:var(--danger)}
+#ddlist{display:none;position:absolute;left:0;right:0;top:calc(100% + 6px);z-index:5;
+        background:var(--surface-1);border:1px solid var(--line-strong);border-radius:var(--r);
+        overflow-y:auto;max-height:60vh;box-shadow:0 12px 32px #0009}
 #dd.open #ddlist{display:block}
-.dditem{display:flex;align-items:center;gap:8px;padding:10px;cursor:pointer}
-.dditem:hover,.dditem.sel{background:#2a2a2a}
+.dditem{display:flex;align-items:center;gap:8px;padding:11px 10px;cursor:pointer}
+.dditem:not(:last-child){border-bottom:1px solid var(--line)}
+.dditem:hover,.dditem.sel{background:var(--surface-3)}
 .plogo{width:16px;height:16px;flex:none}
-#alert{display:none;margin:10px 14px;padding:12px 14px;border-radius:12px;
-       background:#2a1616;border:1px solid #a33;box-shadow:0 2px 10px #0004;
+#alert{display:none;margin:10px 14px;padding:13px 14px;border-radius:var(--r-lg);
+       background:var(--danger-surface);border:1px solid var(--danger-line);box-shadow:0 4px 18px #0005;
        min-height:0;max-height:60vh;overflow-y:auto}
-#alert.q{background:#16233a;border-color:#3a6aa0}
+#alert.q{background:var(--accent-surface);border-color:var(--accent-line)}
 #alert .ahead{display:flex;align-items:center;gap:7px;font-size:11px;font-weight:700;
-              letter-spacing:.04em;text-transform:uppercase;color:#c99;margin-bottom:8px}
+              letter-spacing:.05em;text-transform:uppercase;color:#d69a9a;margin-bottom:9px}
 #alert.q .ahead{color:#8fb4e0}
 #alert .ahead::before{content:"";width:7px;height:7px;border-radius:50%;background:currentColor;
                       box-shadow:0 0 0 4px color-mix(in srgb,currentColor 22%,transparent)}
-#alert .qq{font-weight:600;margin:2px 0 8px;font-size:15px;line-height:1.45}
+#alert .qq{font-weight:600;margin:2px 0 9px;font-size:15px;line-height:1.45}
 #alert .qq p{margin:5px 0}
-#alert .qq code{background:#0005;padding:1px 5px;border-radius:4px;
+#alert .qq code{background:#0006;padding:1px 5px;border-radius:5px;
                 font-family:ui-monospace,monospace;font-size:13px}
 #alert .qq:not(:first-of-type){margin-top:14px;padding-top:12px;border-top:1px solid #ffffff1a}
-#readonly{display:none;margin:10px 14px;padding:10px 12px;border-radius:10px;
-          background:#3c3218;border:1px solid #79652c;color:#e2cc8c;font-size:13px}
-.opt{display:flex;align-items:flex-start;gap:10px;width:100%;margin:7px 0 0;padding:11px 12px;
-     border-radius:10px;background:#243a55;border:1px solid #45688f;color:#fff;font-size:14px;
+#readonly{display:none;margin:10px 14px;padding:11px 12px;border-radius:var(--r);
+          background:var(--warn-surface);border:1px solid var(--warn-line);color:#e2cc8c;font-size:13px}
+.opt{display:flex;align-items:flex-start;gap:10px;width:100%;margin:8px 0 0;padding:12px;
+     border-radius:var(--r);background:#22385480;border:1px solid var(--accent-line);color:#fff;font-size:14px;
      text-align:left;line-height:1.4}
 .opt:not(:disabled):hover{background:#2c496b;border-color:#5a83b0}
-.opt b{flex:none;min-width:22px;height:22px;display:inline-flex;align-items:center;
+.opt b{flex:none;min-width:23px;height:23px;display:inline-flex;align-items:center;
        justify-content:center;border-radius:6px;background:#ffffff26;font-size:12px;font-weight:700}
 .opt span{flex:1;min-width:0}
-.decision-row{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:9px}
-.decision{min-height:44px;border-radius:10px;color:#fff;font-weight:650}
+.decision-row{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:10px}
+.decision{min-height:46px;border-radius:var(--r);color:#fff;font-weight:650}
 .decision.approve{background:#23563c;border:1px solid #3f8a65}
 .decision.reject{background:#5b2929;border:1px solid #a14a4a}
 #log{flex:1;min-height:0;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:8px 14px}
-.m{margin:8px 0;padding:9px 12px;border-radius:12px;max-width:92%;
+.m{margin:8px 0;padding:10px 13px;border-radius:var(--r-lg);max-width:88%;border:1px solid transparent;
    word-break:break-word;overflow-wrap:anywhere}
-.user{background:#2a4a2a;margin-left:auto;white-space:pre-wrap}
+.user{background:var(--user-surface);border-color:var(--user-line);margin-left:auto;
+      border-bottom-right-radius:var(--tail);white-space:pre-wrap}
 .m.pending{opacity:.55}
-.m.failed{opacity:.85;border:1px solid #a14a4a;cursor:pointer}
+.m.failed{opacity:.85;border:1px solid var(--danger-line);cursor:pointer}
 .m.user.failed::after{content:"Failed to send. Tap to retry.";display:block;margin-top:4px;
-                      font-size:11px;color:#ef8e8e}
-.m.typing{background:#222;display:inline-flex;gap:5px;align-items:center;padding:13px 14px}
+                      font-size:11px;color:var(--danger)}
+.m.typing{background:var(--surface-1);border-color:var(--line);display:inline-flex;gap:5px;align-items:center;padding:14px 15px}
 .m.typing .td{width:6px;height:6px;border-radius:50%;background:#8ea0b5;animation:tblink 1.2s infinite}
 .m.typing .td:nth-child(2){animation-delay:.2s}
 .m.typing .td:nth-child(3){animation-delay:.4s}
 @keyframes tblink{0%,60%,100%{opacity:.3;transform:translateY(0)}30%{opacity:1;transform:translateY(-2px)}}
 @media(prefers-reduced-motion:reduce){.m.typing .td{animation:none;opacity:.6}}
-.assistant{background:#222}
-.assistant pre{background:#161620;padding:8px;border-radius:8px;overflow-x:auto;
-               font-size:12.5px;margin:6px 0}
-.assistant code{background:#161620;padding:1px 4px;border-radius:4px;
+.assistant{background:var(--surface-1);border-color:var(--line);border-bottom-left-radius:var(--tail)}
+.assistant pre{background:#0f1118;border:1px solid var(--line);padding:9px 10px;border-radius:var(--r-sm);overflow-x:auto;
+               font-size:12.5px;margin:7px 0}
+.assistant code{background:#0f1118;padding:1px 5px;border-radius:5px;
                 font-family:ui-monospace,monospace;font-size:13px}
 .assistant p{margin:5px 0}
-.assistant a{color:#8bf}
+.assistant a{color:var(--accent-2)}
 .assistant .table-wrap{max-width:100%;margin:8px 0;overflow-x:auto;
-                       border:1px solid #444;border-radius:8px}
+                       border:1px solid var(--line);border-radius:var(--r-sm)}
 .assistant table{width:100%;min-width:max-content;border-collapse:collapse;font-size:13px}
-.assistant th,.assistant td{padding:6px 9px;border-right:1px solid #444;
-                            border-bottom:1px solid #444;vertical-align:top}
-.assistant th{background:#2c2c2c;font-weight:600}
+.assistant th,.assistant td{padding:6px 9px;border-right:1px solid var(--line);
+                            border-bottom:1px solid var(--line);vertical-align:top}
+.assistant th{background:var(--surface-2);font-weight:600}
 .assistant tr:last-child td{border-bottom:0}
 .assistant th:last-child,.assistant td:last-child{border-right:0}
-.assistant tbody tr:nth-child(even){background:#1b1b1b}
-.tool{background:#1a1a2e;color:#9ab;font-size:13px;font-family:ui-monospace,monospace}
-footer{flex:none;background:#161616;
-       border-top:1px solid #333;padding:10px 14px calc(10px + env(safe-area-inset-bottom))}
+.assistant tbody tr:nth-child(even){background:#ffffff06}
+.tool{background:var(--surface-2);border-color:var(--line);color:var(--text-2);font-size:13px;font-family:ui-monospace,monospace}
+.tool b{color:#c3cad6}
+footer{flex:none;background:var(--surface-1);
+       border-top:1px solid var(--line);padding:10px 14px calc(10px + env(safe-area-inset-bottom))}
 .keys{display:grid;grid-template-columns:repeat(8,minmax(0,1fr));gap:6px;margin-bottom:8px}
-.keys button{min-width:0;min-height:52px;padding:5px 2px;border-radius:10px;
-             background:linear-gradient(#303030,#252525);color:#eee;border:1px solid #494949;
-             box-shadow:0 1px 0 #555 inset,0 2px 5px #0005;display:flex;
+.keys button{min-width:0;min-height:52px;padding:5px 2px;border-radius:var(--r);
+             background:linear-gradient(180deg,var(--surface-3),var(--surface-2));color:#eee;border:1px solid var(--line-strong);
+             box-shadow:0 1px 0 #ffffff12 inset,0 2px 5px #0006;display:flex;
              flex-direction:column;align-items:center;justify-content:center;gap:1px;font-size:16px}
-.keys button small{font-size:9px;color:#999;font-weight:500}
+.keys button small{font-size:9px;color:var(--text-3);font-weight:500}
 .row{display:flex;gap:6px;align-items:flex-end}
-input{flex:1;padding:10px;border-radius:8px;background:#222;color:#eee;
-      border:1px solid #444;font-size:16px}
-.row textarea{flex:1;min-width:0;min-height:44px;max-height:132px;padding:10px;
-              resize:none;overflow-y:auto;border-radius:10px;background:#222;color:#eee;
-              border:1px solid #444;font:16px/1.4 -apple-system,system-ui,sans-serif}
-.row button{width:48px;min-width:48px;height:44px;padding:10px;border-radius:10px;
-            background:linear-gradient(#356596,#294f78);color:#fff;border:1px solid #6596c7;
-            box-shadow:0 1px 0 #83add4 inset;font-size:15px;font-weight:650;
+input{flex:1;padding:11px;border-radius:var(--r-sm);background:var(--surface-2);color:var(--text);
+      border:1px solid var(--line);font-size:16px}
+.row textarea{flex:1;min-width:0;min-height:44px;max-height:132px;padding:11px;
+              resize:none;overflow-y:auto;border-radius:var(--r);background:var(--surface-2);color:var(--text);
+              border:1px solid var(--line);font:16px/1.4 -apple-system,system-ui,sans-serif}
+.row button{width:48px;min-width:48px;height:44px;padding:10px;border-radius:var(--r);
+            background:linear-gradient(180deg,var(--accent-2),var(--accent));color:#fff;border:1px solid var(--accent-line);
+            box-shadow:0 1px 0 #ffffff40 inset,0 3px 10px #0d2a4d55;font-size:15px;font-weight:650;
             display:flex;align-items:center;justify-content:center;gap:6px}
 .row button svg{width:22px;height:22px;fill:currentColor}
-.composer-hint{margin-top:4px;color:#777;font-size:10px;text-align:right}
-#status{font-size:12px;color:#999;margin-top:3px;min-height:18px;
+.composer-hint{margin-top:5px;color:var(--text-3);font-size:10px;text-align:right}
+#status{font-size:12px;color:var(--text-2);margin-top:3px;min-height:18px;
         transition:color .15s ease}
 #status.success{color:#77c99a}
-#status.error{color:#ef8e8e}
-#status.sending{color:#8ebbe8}
+#status.error{color:var(--danger)}
+#status.sending{color:var(--accent-2)}
 footer button:disabled,footer input:disabled,footer textarea:disabled{opacity:.45;cursor:not-allowed}


### PR DESCRIPTION
Ships in **v2.5.4-beta.6**.

Two passes over the Remote Control companion web app (the phone-facing PWA in `Sources/Toki/Resources/webui`, served by `toki_remote.py`).

## 1. Interface refresh (presentation only)
Every id/class stays the same, so `app.js` is untouched.
- **Design tokens** at `:root` (surfaces, hairlines, text, accent, brand-teal, semantic, radii); scattered hex values now derive from them.
- **Depth + hierarchy:** layered surfaces with hairline borders and subtle shadows; the pairing card sits on a soft radial background.
- **Chat feel:** message bubbles gained asymmetric tails, clearer user/assistant contrast, and bordered code blocks.
- **Brand tie-in:** the "Private by design" note uses the Remote Control teal.
- **Connect screen:** Scan QR is the primary CTA; the manual host/token Connect is now a quieter secondary button (previously a second bright primary due to a cascade quirk).
- Refined primary/send buttons, keycaps, inputs, alert/option cards, focus rings; `theme-color` updated.

## 2. Security hardening
An XSS on this page equals terminal RCE (it injects keystrokes), so defense-in-depth matters.
- **Strict Content-Security-Policy** on served pages (`script-src 'self'`, `object-src 'none'`, `frame-ancestors 'none'`, `connect-src 'self'`, ...), plus `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`, `X-Frame-Options: DENY`.
- **Request-body cap (256 KB)** so a bogus `Content-Length` cannot exhaust memory; rejects negative and non-numeric lengths too.

Existing `markdown.js`/`app.js` were already XSS-safe (escape-first, `https?:`-only links); the CSP is belt-and-suspenders.

## Verification
- Rendered the real `index.html` plus a full chat mock in Chrome: all states read cleanly, **zero CSP violations**, no layout regressions.
- `Tests/test_remote_control_server.py` (10) and `Tests/test_remote_pwa.js` pass.
- Reviewed by Codex; its one finding (negative `Content-Length` bypassing the cap) is fixed in the final commit.

_Not changed:_ the server still binds `0.0.0.0` over plain HTTP by design (token + rotating code gate; docs scope it to trusted tailnets/LANs).
