### PR TITLE
Document Remote Control over Tailscale, and how replies reach the TTY

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  <code>/toki</code> keeps your active AI coding accounts, current-session quota, and weekly quota one click away.
+  <code>/toki</code> keeps your active AI coding accounts, current-session quota, and weekly quota one click away, and lets you answer a waiting agent from your phone.
 </p>
 
 | Menu bar | Widget |
@@ -33,6 +33,8 @@ Toki is built for people who jump between Claude Code, Codex, Copilot, Gemini, G
 It works especially well with [`claude-swap`](https://github.com/realiti4/claude-swap): Toki discovers the same Claude Code account registry, shows active and inactive accounts, and lets you switch accounts without reimplementing credential-management logic.
 
 Toki stays local. Credentials are read from your Mac, your configured commands, or provider auth files. The app does not run a cloud service.
+
+When an agent is waiting on you and you are not at your desk, Remote Control lets your phone answer it over your own tailnet, typing into the terminal the agent is already running in.
 
 ## Install
 
@@ -72,6 +74,8 @@ scripts/install-app.sh        # build a bundle and install to ~/Applications
 
 **Agents waiting on you.** A session parked on a permission prompt or a question is called out with a red dot and the question itself — on the card, the tab, and the menu bar — so you don't discover it twenty minutes later.
 
+**Remote Control from your phone, over Tailscale.** Follow a running agent's transcript from another room and answer it: send a message, approve or reject a permission prompt, pick an option, or clear the session. Replies are delivered to the agent's own TTY — `tmux send-keys` where there is a pane, iTerm2 by tty otherwise, Terminal as a fallback — so they land in the session already running rather than starting a new one, and the agent cannot tell the difference. Tailscale is the recommended route and keeps this off the public internet entirely; the host setting decides which networks the server will answer at all. Off by default. See [Remote Control](docs/remote-control.md).
+
 **Daily usage heatmap.** Thirty days, filterable by provider, read from each tool's own session history — so it covers work done before Toki was installed.
 
 **Insights and notifications.** An on-device Apple Intelligence summary on macOS 26+ (deterministic recommendation elsewhere), low-quota and session warnings with cooldowns and DND, and a session mode for tracking burn during a focused run. The insight card can be hidden from Settings.
@@ -88,14 +92,16 @@ scripts/install-app.sh        # build a bundle and install to ~/Applications
 |---|---|
 | [Configuration](docs/configuration.md) | Config file, accounts, labels, refresh cadence, state |
 | [Providers](docs/providers.md) | Claude Code, Codex, Pi, OpenCode, and the detection-only ones |
-| [Features](docs/features.md) | Agents, heatmap, widgets, quota rings, notch mode, insights, notifications, updates |
-| [Remote Control](docs/remote-control.md) | Replying to agents from your phone: setup, how the three gates work, gotchas |
+| [Features](docs/features.md) | Agents, Remote Control, heatmap, widgets, quota rings, notch mode, insights, notifications, updates |
+| [Remote Control](docs/remote-control.md) | Answering agents from your phone over Tailscale: setup, the three gates, paired devices, gotchas |
 | [Development](docs/development.md) | Building, concurrency checking, conventions, troubleshooting |
 | [Release signing](docs/release-signing.md) | Apple secrets for signing and notarizing release builds |
 
 ## Privacy
 
 Toki stays local. Credentials are read from your Mac's Keychain or the provider auth files already on it; there is no cloud service and no telemetry. Session history is read for token counts, costs, timestamps, and titles — never message content. Diagnostics contain error categories and status codes only.
+
+Remote Control is the one feature that reads message content, because showing you a transcript is the point of it. It is off by default. When it is on, the transcript travels from your Mac straight to your phone and nowhere else: there is no relay and no account. If you use the hosted companion interface, that host serves the page only and never receives your agent data — and serving the page from your own Mac instead removes it from the picture entirely, which is why that is the recommended setting.
 
 Backwards-compatible fallbacks for the old TokenBar config paths are still honoured.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -8,6 +8,34 @@ Clicking an agent with a terminal TTY selects its tab in iTerm2 or Terminal; oth
 
 **Agents waiting on you** are marked with a red dot and the question they asked — on the card, on the Agents tab, and in the menu bar. Supported for Claude Code and OpenCode. The signal is a tool call that has gone unanswered for at least ten seconds: a tool that is genuinely running writes its result promptly, so quiet time is what separates "working" from "blocked on you".
 
+## Remote Control
+
+Follow a running agent from your phone and answer it: send a message, approve or reject a permission prompt, tap one of the options it offered, send a bare terminal key, or clear the session. Claude Code, Codex, and OpenCode sessions are supported. Off by default; turn it on in Settings.
+
+**Replies go to the agent's TTY.** The same terminal discovery the Agents tab uses to jump to a session is what delivers input to it, in order of preference:
+
+1. `tmux send-keys` against the pane whose `pane_tty` matches, where the agent runs under tmux.
+2. iTerm2, addressed by tty through AppleScript, which does not steal focus or disturb the window you are looking at.
+3. Terminal.app, by selecting the tab with that tty and sending keystrokes through System Events.
+
+The text and the submitting Return are sent as two events with a short gap. Sent together, a TUI like Claude Code reads the trailing carriage return as part of the paste and inserts a newline instead of submitting.
+
+Because this is terminal input, a reply lands in the conversation already running rather than starting a new one, and works with any agent whose interface is a terminal, including ones with no remote API of their own. It also means an agent without a TTY cannot be replied to: Codex desktop, editor extensions, and anything not attached to a terminal appear in the list as **read-only**, grouped below the ones you can answer so the agent actually waiting on you is the one selected by default.
+
+**Reach is a setting, not a side effect.** The host you pick decides which networks the server will answer, enforced per connection before authentication:
+
+| Host | Answers requests from |
+|:---|:---|
+| Localhost | this Mac only |
+| Tailscale (recommended) | your tailnet, plus this Mac |
+| Local network | your LAN and tailnet, plus this Mac |
+| Cloudflare Tunnel (public) | the tunnel process on this Mac |
+| Custom | anywhere, since Toki cannot classify the host you named |
+
+Tailscale is recommended because it is private by construction: your Mac and phone join a network only your devices are on, and nothing is reachable from the public internet. A phone connects by scanning a QR code and entering a six-digit code shown on the Mac, which rotates every two minutes; that exchange grants a session lasting between one hour and two days, and every paired device is listed in Settings with its own Revoke button.
+
+[Remote Control](remote-control.md) covers the setup, the gates in full, and the gotchas.
+
 ## Daily usage heatmap
 
 Thirty days of activity, filterable by provider, covering Claude Code, OpenCode, and Pi. Read from each tool's own session history, so it reflects work done before Toki was installed. Hover a day for its detail.


### PR DESCRIPTION
2.6.0 shipped Remote Control, and the only trace of it in the docs was a single row in the README's documentation table. Someone reading **What it does** would not learn the app can answer a waiting agent from a phone at all.

## What changed

**README** gains a Remote Control entry in the feature list, a line in *Why Toki* about answering an agent when you are not at your desk, and a tagline that mentions it.

**`docs/features.md`** gains a Remote Control section, placed next to Agents deliberately: the terminal discovery that jumps to a session is the same machinery that delivers input to it.

## Why the TTY detail is in there

It is not implementation trivia. It explains both what the feature can do and what it cannot, in one idea:

1. `tmux send-keys` against the pane whose `pane_tty` matches, where the agent runs under tmux.
2. iTerm2, addressed by tty through AppleScript, which does not steal focus.
3. Terminal.app, by selecting the tab with that tty and sending keystrokes via System Events.

Because a reply is terminal input, it lands in the conversation already running rather than starting a new one, and it works with any agent whose interface is a terminal, including ones with no remote API of their own. The same fact is why an agent without a TTY (Codex desktop, editor extensions) cannot be replied to and is listed **read-only**.

The section also carries the reach table, so the host setting reads as the access control it is rather than a display preference, and says why Tailscale is the recommendation: private by construction, not merely gated.

## One correction, not an addition

The README's privacy section claimed session history is read "never message content". That stopped being true the moment a transcript could be streamed to a phone. It now names Remote Control as the one feature that reads content, notes it is off by default, and says where the data goes: straight from your Mac to your phone, no relay, no account, and the hosted interface serves the page only.

Docs only, no code changes. All internal doc links verified to resolve.