### PR TITLE
v2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.6.1 - 2026-08-08
+
+### Fixed
+
+- **A Claude Code account no longer reads "Not connected" just because Claude Code has not run for a while.** Toki sent whatever access token was sitting in the Keychain without ever looking at the `expiresAt` beside it. Claude Code renews that token lazily, when it next runs, so overnight the stored token goes stale and every Toki refresh replayed it and collected an HTTP 401. Toki now checks the expiry first and skips the request entirely when the token is past it, showing "Signed out" with what to do about it rather than a raw `authentication_error` payload.
+- **Toki recovers on its own the moment the token is renewed.** An expired token records no API call, so the usual refresh interval never gates the retry: the next tick, or opening Toki, re-reads the Keychain and picks up a token Claude Code has just renewed. That re-read is local and costs nothing until the sign-in is usable again.
+- A stored `claude-swap` account that is not the active one says so plainly. Nothing renews the copy Toki reads for an inactive account, so it expires within hours of being stored and stays that way; the card now points at `claude-swap` instead of reporting a failure with no remedy.
+- Repeatedly replaying a dead token no longer gets the usage endpoint to rate-limit the account, which used to hide the real state behind a stale reading once the 401s turned into 429s.
+- An error whose request ID happens to contain "429" is no longer misread as a rate limit. The check matched that substring anywhere in the response body, so an unrelated failure could be quietly papered over with the previous snapshot instead of surfaced.
+
 ## 2.6.0 - 2026-08-08
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version 2.6.0" src="https://img.shields.io/badge/version-2.6.0-2f80ed">
+  <img alt="Version 2.6.1" src="https://img.shields.io/badge/version-2.6.1-2f80ed">
   <img alt="Downloads" src="https://img.shields.io/github/downloads/aashutoshrathi/toki/total">
   <img alt="Stars" src="https://img.shields.io/github/stars/aashutoshrathi/toki">
   <img alt="macOS 14+" src="https://img.shields.io/badge/macOS-14%2B-111111">

--- a/Sources/Toki/API/ClaudeCodeUsageClient.swift
+++ b/Sources/Toki/API/ClaudeCodeUsageClient.swift
@@ -28,6 +28,25 @@ struct ClaudeCodeUsageClient {
     private func snapshotOrError(for record: ClaudeCodeAccountRecord) async -> AccountSnapshot {
         do {
             return try await snapshot(for: record)
+        } catch let expiry as ClaudeSignInExpiredError {
+            DiagnosticLogger.shared.record(.info, component: "usage", code: "claude_sign_in_expired",
+                                           detail: "account=\(record.email ?? record.id) active=\(record.isActive)")
+            return AccountSnapshot(
+                id: record.id,
+                name: record.displayName,
+                provider: .claudeCode,
+                primary: "Signed out",
+                subtitle: record.email ?? expiry.localizedDescription,
+                remainingRatio: nil,
+                metrics: [MetricLine(label: "Sign-in", value: expiry.localizedDescription)],
+                accountInfo: accountInfoLines(for: record),
+                isError: true,
+                switchTarget: switchTarget(for: record),
+                switchCommand: account.claudeSwapCommand,
+                emoji: record.label?.emoji,
+                colorHex: record.label?.color,
+                isSignInExpired: true
+            )
         } catch {
             DiagnosticLogger.shared.record(.error, component: "usage", code: "claude_account_failed", detail: diagnosticErrorDetail(error))
             return AccountSnapshot(
@@ -35,9 +54,9 @@ struct ClaudeCodeUsageClient {
                 name: record.displayName,
                 provider: .claudeCode,
                 primary: "Unavailable",
-                subtitle: record.email ?? error.localizedDescription,
+                subtitle: record.email ?? describe(error),
                 remainingRatio: nil,
-                metrics: [MetricLine(label: "Error", value: error.localizedDescription)],
+                metrics: [MetricLine(label: "Error", value: describe(error))],
                 accountInfo: accountInfoLines(for: record),
                 isError: true,
                 switchTarget: switchTarget(for: record),
@@ -48,6 +67,13 @@ struct ClaudeCodeUsageClient {
         }
     }
 
+    private func describe(_ error: Error) -> String {
+        guard let http = error as? HTTPStatusError, http.statusCode == 401 else {
+            return error.localizedDescription
+        }
+        return "Anthropic rejected this sign-in. Open Claude Code and run /login, then refresh Toki."
+    }
+
     private func snapshot(for record: ClaudeCodeAccountRecord) async throws -> AccountSnapshot {
         if let loadError = record.loadError {
             throw LocalizedErrorMessage(loadError)
@@ -56,11 +82,14 @@ struct ClaudeCodeUsageClient {
             throw LocalizedErrorMessage("No credentials found")
         }
 
-        let accessToken = try ClaudeCodeCredentialReader.extractAccessToken(from: credentials)
+        let token = try ClaudeCodeCredentialReader.extractToken(from: credentials)
+        guard !token.isExpired() else {
+            throw ClaudeSignInExpiredError(accountLabel: record.email, isActiveAccount: record.isActive)
+        }
         let json = try await requestJSON(
             url: URL(string: "https://api.anthropic.com/api/oauth/usage")!,
             headers: [
-                "Authorization": "Bearer \(accessToken)",
+                "Authorization": "Bearer \(token.accessToken)",
                 "anthropic-beta": "oauth-2025-04-20"
             ]
         )

--- a/Sources/Toki/API/ClaudeCodeUsageClient.swift
+++ b/Sources/Toki/API/ClaudeCodeUsageClient.swift
@@ -74,22 +74,37 @@ struct ClaudeCodeUsageClient {
         return "Anthropic rejected this sign-in. Open Claude Code and run /login, then refresh Toki."
     }
 
-    private func snapshot(for record: ClaudeCodeAccountRecord) async throws -> AccountSnapshot {
+    enum Disposition: Equatable {
+        case useToken(String)
+        case expired(ClaudeSignInExpiredError)
+    }
+
+    static func disposition(for record: ClaudeCodeAccountRecord, now: Date = Date()) throws -> Disposition {
         if let loadError = record.loadError {
             throw LocalizedErrorMessage(loadError)
         }
         guard let credentials = record.credentials, !credentials.isEmpty else {
             throw LocalizedErrorMessage("No credentials found")
         }
-
         let token = try ClaudeCodeCredentialReader.extractToken(from: credentials)
-        guard !token.isExpired() else {
-            throw ClaudeSignInExpiredError(accountLabel: record.email, isActiveAccount: record.isActive)
+        guard !token.isExpired(asOf: now) else {
+            return .expired(ClaudeSignInExpiredError(accountLabel: record.email, isActiveAccount: record.isActive))
+        }
+        return .useToken(token.accessToken)
+    }
+
+    private func snapshot(for record: ClaudeCodeAccountRecord) async throws -> AccountSnapshot {
+        let accessToken: String
+        switch try Self.disposition(for: record) {
+        case .expired(let expiry):
+            throw expiry
+        case .useToken(let token):
+            accessToken = token
         }
         let json = try await requestJSON(
             url: URL(string: "https://api.anthropic.com/api/oauth/usage")!,
             headers: [
-                "Authorization": "Bearer \(token.accessToken)",
+                "Authorization": "Bearer \(accessToken)",
                 "anthropic-beta": "oauth-2025-04-20"
             ]
         )
@@ -103,7 +118,7 @@ struct ClaudeCodeUsageClient {
         let remainingRatio = max(0, min(1, 1 - usedRatio))
         let percentLeft = Int((remainingRatio * 100).rounded())
         let primary = "\(percentLeft)% left"
-        let email = record.email ?? ClaudeCodeCredentialReader.emailIdentifier(from: credentials)
+        let email = record.email ?? record.credentials.flatMap(ClaudeCodeCredentialReader.emailIdentifier)
 
         // Surface Claude Code's single rolling window the same way Codex exposes its windows,
         // so consumers like the quota-rings panel can show "resets in <time>" beside it. The
@@ -121,7 +136,7 @@ struct ClaudeCodeUsageClient {
             remainingRatio: remainingRatio,
             progressRatio: usedRatio,
             metrics: usage.metrics,
-            accountInfo: accountInfoLines(for: record, credentials: credentials),
+            accountInfo: accountInfoLines(for: record, credentials: record.credentials),
             switchTarget: switchTarget(for: record),
             switchCommand: account.claudeSwapCommand,
             emoji: record.label?.emoji,

--- a/Sources/Toki/API/UsageFetcher.swift
+++ b/Sources/Toki/API/UsageFetcher.swift
@@ -131,7 +131,7 @@ enum UsageFetcher {
                let previous = previousSnapshots(for: account, previousByID: previousByID) {
                 return AccountFetchResult(snapshots: previous, apiCallKeys: attemptedKeys)
             }
-            if snapshots.contains(where: \.isSignInExpired) {
+            if suppressesAPICallTimestamp(snapshots) {
                 return AccountFetchResult(snapshots: snapshots, apiCallKeys: [])
             }
             return AccountFetchResult(snapshots: snapshots, apiCallKeys: attemptedKeys)
@@ -224,6 +224,10 @@ enum UsageFetcher {
             return httpError.statusCode == 429
         }
         return isRateLimitDescription(error.localizedDescription)
+    }
+
+    static func suppressesAPICallTimestamp(_ snapshots: [AccountSnapshot]) -> Bool {
+        !snapshots.isEmpty && snapshots.allSatisfy(\.isSignInExpired)
     }
 
     static func isRateLimitDescription(_ value: String) -> Bool {

--- a/Sources/Toki/API/UsageFetcher.swift
+++ b/Sources/Toki/API/UsageFetcher.swift
@@ -131,7 +131,12 @@ enum UsageFetcher {
                let previous = previousSnapshots(for: account, previousByID: previousByID) {
                 return AccountFetchResult(snapshots: previous, apiCallKeys: attemptedKeys)
             }
+            if snapshots.contains(where: \.isSignInExpired) {
+                return AccountFetchResult(snapshots: snapshots, apiCallKeys: [])
+            }
             return AccountFetchResult(snapshots: snapshots, apiCallKeys: attemptedKeys)
+        } catch is ClaudeSignInExpiredError {
+            return AccountFetchResult(snapshots: [expiredSnapshot(for: account)], apiCallKeys: [])
         } catch let error as HTTPStatusError where error.statusCode == 429 {
             if let previous = previousSnapshots(for: account, previousByID: previousByID) {
                 return AccountFetchResult(snapshots: previous, apiCallKeys: attemptedKeys)
@@ -221,11 +226,27 @@ enum UsageFetcher {
         return isRateLimitDescription(error.localizedDescription)
     }
 
-    private static func isRateLimitDescription(_ value: String) -> Bool {
+    static func isRateLimitDescription(_ value: String) -> Bool {
         let normalized = value.lowercased()
         return normalized.contains("http 429")
             || normalized.contains("status 429")
-            || normalized.contains("429")
+            || normalized.contains("rate_limit_error")
+            || normalized.contains("rate limited")
+    }
+
+    private static func expiredSnapshot(for account: AccountConfig) -> AccountSnapshot {
+        let expiry = ClaudeSignInExpiredError(accountLabel: account.name, isActiveAccount: true)
+        return AccountSnapshot(
+            id: account.id,
+            name: account.name,
+            provider: account.provider,
+            primary: "Signed out",
+            subtitle: expiry.localizedDescription,
+            remainingRatio: nil,
+            metrics: [MetricLine(label: "Sign-in", value: expiry.localizedDescription)],
+            isError: true,
+            isSignInExpired: true
+        )
     }
 
     private static func errorSnapshot(for account: AccountConfig, error: Error) -> AccountSnapshot {

--- a/Sources/Toki/Config/Constants.swift
+++ b/Sources/Toki/Config/Constants.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-let appVersion = "2.6.0"
+let appVersion = "2.6.1"
 let appUserAgent = "Toki/\(appVersion)"
 // GitHub Pages renders docs/*.md from the default branch; the extensionless path is the HTML one.
 let docsBaseURL = "https://toki.aashutosh.dev/docs"

--- a/Sources/Toki/Credentials/ClaudeCodeCredentialReader.swift
+++ b/Sources/Toki/Credentials/ClaudeCodeCredentialReader.swift
@@ -177,7 +177,23 @@ enum ClaudeCodeCredentialReader {
         return CredentialBundle(credentials: trimmed, source: rawPath)
     }
 
+    struct OAuthToken {
+        var accessToken: String
+        var expiresAt: Date?
+
+        static let expiryLeeway: TimeInterval = 60
+
+        func isExpired(asOf now: Date = Date()) -> Bool {
+            guard let expiresAt else { return false }
+            return expiresAt.timeIntervalSince(now) <= OAuthToken.expiryLeeway
+        }
+    }
+
     static func extractAccessToken(from credentials: String) throws -> String {
+        try extractToken(from: credentials).accessToken
+    }
+
+    static func extractToken(from credentials: String) throws -> OAuthToken {
         // try? rather than try: a parse failure must not escape as the raw Cocoa error
         // ("The data couldn't be read..."), which names neither the data nor a remedy.
         guard let data = credentials.data(using: .utf8),
@@ -196,7 +212,22 @@ enum ClaudeCodeCredentialReader {
                 "Your Claude Code sign-in has no access token in it. Open Claude Code and run /login again, then hit refresh in Toki. The sign-in holds: \(keyList(oauth))."
             )
         }
-        return token
+        return OAuthToken(accessToken: token, expiresAt: expiryDate(from: oauth["expiresAt"]))
+    }
+
+    static func expiryDate(from value: Any?) -> Date? {
+        let milliseconds: Double
+        switch value {
+        case let number as NSNumber:
+            milliseconds = number.doubleValue
+        case let text as String:
+            guard let parsed = Double(text) else { return nil }
+            milliseconds = parsed
+        default:
+            return nil
+        }
+        guard milliseconds > 0, milliseconds.isFinite else { return nil }
+        return Date(timeIntervalSince1970: milliseconds / 1000)
     }
 
     private static func keyList(_ json: [String: Any]) -> String {

--- a/Sources/Toki/Credentials/ClaudeCodeCredentialReader.swift
+++ b/Sources/Toki/Credentials/ClaudeCodeCredentialReader.swift
@@ -219,6 +219,7 @@ enum ClaudeCodeCredentialReader {
         let milliseconds: Double
         switch value {
         case let number as NSNumber:
+            guard CFGetTypeID(number) != CFBooleanGetTypeID() else { return nil }
             milliseconds = number.doubleValue
         case let text as String:
             guard let parsed = Double(text) else { return nil }

--- a/Sources/Toki/Models/AccountSnapshot.swift
+++ b/Sources/Toki/Models/AccountSnapshot.swift
@@ -41,6 +41,7 @@ struct AccountSnapshot: Identifiable, Hashable {
     // True for providers with no usage/quota API at all (Grok, Copilot) - the card still
     // shows identity and active-session count, but never a percentage or progress bar.
     var isAgentDetectionOnly: Bool = false
+    var isSignInExpired: Bool = false
 
     static let loadingPrimary = "Refreshing"
 

--- a/Sources/Toki/Models/Errors.swift
+++ b/Sources/Toki/Models/Errors.swift
@@ -6,7 +6,7 @@ struct LocalizedErrorMessage: LocalizedError {
     var errorDescription: String? { message }
 }
 
-struct ClaudeSignInExpiredError: LocalizedError {
+struct ClaudeSignInExpiredError: LocalizedError, Equatable {
     var accountLabel: String?
     var isActiveAccount: Bool
 

--- a/Sources/Toki/Models/Errors.swift
+++ b/Sources/Toki/Models/Errors.swift
@@ -6,6 +6,19 @@ struct LocalizedErrorMessage: LocalizedError {
     var errorDescription: String? { message }
 }
 
+struct ClaudeSignInExpiredError: LocalizedError {
+    var accountLabel: String?
+    var isActiveAccount: Bool
+
+    var errorDescription: String? {
+        if isActiveAccount {
+            return "Sign-in expired. Open Claude Code to renew it - Toki picks the new token up on its own."
+        }
+        let account = accountLabel.map { " for \($0)" } ?? ""
+        return "Stored sign-in expired\(account). Run claude-swap to switch to it once, which renews the token."
+    }
+}
+
 struct HTTPStatusError: LocalizedError {
     var statusCode: Int
     var body: String

--- a/Sources/Toki/Views/AccountCard.swift
+++ b/Sources/Toki/Views/AccountCard.swift
@@ -115,7 +115,7 @@ struct AccountCard: View {
                 if let switchTarget = snapshot.switchTarget {
                     VStack(alignment: .trailing, spacing: 4) {
                         if snapshot.isError {
-                            StatusBadge(text: "not connected")
+                            StatusBadge(text: snapshot.isSignInExpired ? "signed out" : "not connected")
                         }
                         Button {
                             store.switchClaudeAccount(target: switchTarget, command: snapshot.switchCommand)
@@ -394,7 +394,8 @@ struct AccountCard: View {
     }
 
     private var collapsedStatus: String {
-        snapshot.isError ? "Not connected" : snapshot.primary
+        if snapshot.isSignInExpired { return snapshot.primary }
+        return snapshot.isError ? "Not connected" : snapshot.primary
     }
 
     /// The failure reason, gathered from wherever the provider happened to record it.
@@ -403,7 +404,7 @@ struct AccountCard: View {
     /// The subtitle is only usable when it isn't an email address, since Claude fills it with
     /// the account's address whenever it knows one.
     private var errorDetail: String {
-        if let recorded = snapshot.metrics.first(where: { $0.label == "Error" })?.value,
+        if let recorded = snapshot.metrics.first(where: { $0.label == "Error" || $0.label == "Sign-in" })?.value,
            !recorded.isEmpty {
             return recorded
         }

--- a/Tests/TokiTests/ClaudeSignInExpiryTests.swift
+++ b/Tests/TokiTests/ClaudeSignInExpiryTests.swift
@@ -78,6 +78,71 @@ final class ClaudeSignInExpiryTests: XCTestCase {
         }
     }
 
+    // MARK: - Disposition: what the client does before ever touching the network
+
+    private func record(credentials: String?, isActive: Bool = true, email: String? = "a@b.com", loadError: String? = nil) -> ClaudeCodeAccountRecord {
+        ClaudeCodeAccountRecord(
+            id: "claude-1-a@b.com",
+            name: email ?? "Claude",
+            email: email,
+            organizationName: nil,
+            organizationUUID: nil,
+            accountNumber: 1,
+            isActive: isActive,
+            source: "test",
+            credentials: credentials,
+            loadError: loadError,
+            label: nil
+        )
+    }
+
+    private func credentialBlob(expiresAt: TimeInterval) -> String {
+        let millis = Int((Date().timeIntervalSince1970 + expiresAt) * 1000)
+        return #"{"claudeAiOauth":{"accessToken":"live-token","expiresAt":\#(millis)}}"#
+    }
+
+    // The regression that shipped: an expired token was sent anyway and came back 401. The
+    // decision must reach `.expired` without ever yielding a token to send.
+    func testExpiredTokenIsNeverOfferedForUse() throws {
+        let disposition = try ClaudeCodeUsageClient.disposition(for: record(credentials: credentialBlob(expiresAt: -3600)))
+        guard case .expired(let expiry) = disposition else {
+            return XCTFail("expected .expired, got \(disposition)")
+        }
+        XCTAssertTrue(expiry.isActiveAccount)
+    }
+
+    // The mirror-image regression to guard against: a good token must NOT be misread as expired,
+    // or a working account would show "Signed out" and never call the API.
+    func testValidTokenIsOfferedForUse() throws {
+        let disposition = try ClaudeCodeUsageClient.disposition(for: record(credentials: credentialBlob(expiresAt: 3600)))
+        XCTAssertEqual(disposition, .useToken("live-token"))
+    }
+
+    func testTokenWithNoExpiryIsOfferedForUse() throws {
+        let blob = #"{"claudeAiOauth":{"accessToken":"live-token"}}"#
+        XCTAssertEqual(try ClaudeCodeUsageClient.disposition(for: record(credentials: blob)), .useToken("live-token"))
+    }
+
+    func testInactiveStoredAccountReportsTheSwapRemedyWhenExpired() throws {
+        let disposition = try ClaudeCodeUsageClient.disposition(for: record(credentials: credentialBlob(expiresAt: -60), isActive: false))
+        guard case .expired(let expiry) = disposition else {
+            return XCTFail("expected .expired, got \(disposition)")
+        }
+        XCTAssertFalse(expiry.isActiveAccount)
+        XCTAssertTrue(expiry.localizedDescription.contains("claude-swap"), expiry.localizedDescription)
+    }
+
+    func testMissingCredentialsThrowRatherThanReportingExpiry() {
+        XCTAssertThrowsError(try ClaudeCodeUsageClient.disposition(for: record(credentials: nil)))
+        XCTAssertThrowsError(try ClaudeCodeUsageClient.disposition(for: record(credentials: "")))
+    }
+
+    func testLoadErrorSurfacesRatherThanReportingExpiry() {
+        XCTAssertThrowsError(try ClaudeCodeUsageClient.disposition(for: record(credentials: credentialBlob(expiresAt: 3600), loadError: "Keychain locked"))) { error in
+            XCTAssertTrue(error.localizedDescription.contains("Keychain locked"), error.localizedDescription)
+        }
+    }
+
     // MARK: - Rate-limit classification
 
     func testRequestIdThatMerelyContains429IsNotMistakenForARateLimit() {

--- a/Tests/TokiTests/ClaudeSignInExpiryTests.swift
+++ b/Tests/TokiTests/ClaudeSignInExpiryTests.swift
@@ -31,6 +31,16 @@ final class ClaudeSignInExpiryTests: XCTestCase {
         }
     }
 
+    // A JSON boolean bridges to NSNumber; `true` would otherwise read as 1ms past the epoch and
+    // report a usable token as long expired.
+    func testBooleanExpiryIsNotMistakenForAnEpoch() throws {
+        for raw in ["true", "false"] {
+            let token = try ClaudeCodeCredentialReader.extractToken(from: credentials(expiresAt: raw))
+            XCTAssertNil(token.expiresAt, "expiresAt \(raw) should not produce a date")
+            XCTAssertFalse(token.isExpired(), "expiresAt \(raw) should leave the token usable")
+        }
+    }
+
     // MARK: - Expiry decisions
 
     func testTokenWithoutExpiryIsNeverTreatedAsExpired() throws {
@@ -141,6 +151,39 @@ final class ClaudeSignInExpiryTests: XCTestCase {
         XCTAssertThrowsError(try ClaudeCodeUsageClient.disposition(for: record(credentials: credentialBlob(expiresAt: 3600), loadError: "Keychain locked"))) { error in
             XCTAssertTrue(error.localizedDescription.contains("Keychain locked"), error.localizedDescription)
         }
+    }
+
+    // MARK: - Throttle: an expired sibling must not un-throttle a working account
+
+    private func snapshot(expired: Bool) -> AccountSnapshot {
+        AccountSnapshot(
+            id: expired ? "claude-2" : "claude-1",
+            name: "Claude",
+            provider: .claudeCode,
+            primary: expired ? "Signed out" : "80% left",
+            subtitle: "a@b.com",
+            remainingRatio: expired ? nil : 0.8,
+            metrics: [],
+            isError: expired,
+            switchTarget: nil,
+            switchCommand: nil,
+            emoji: nil,
+            colorHex: nil,
+            isSignInExpired: expired
+        )
+    }
+
+    func testTimestampIsSuppressedOnlyWhenEveryAccountExpired() {
+        XCTAssertTrue(UsageFetcher.suppressesAPICallTimestamp([snapshot(expired: true)]))
+        XCTAssertTrue(UsageFetcher.suppressesAPICallTimestamp([snapshot(expired: true), snapshot(expired: true)]))
+    }
+
+    func testTimestampIsRecordedWhenAnyAccountMadeACall() {
+        // The user's exact setup: one working account, one expired stored account. The working
+        // account's call must be timestamped so it is not re-polled every tick.
+        XCTAssertFalse(UsageFetcher.suppressesAPICallTimestamp([snapshot(expired: false), snapshot(expired: true)]))
+        XCTAssertFalse(UsageFetcher.suppressesAPICallTimestamp([snapshot(expired: false)]))
+        XCTAssertFalse(UsageFetcher.suppressesAPICallTimestamp([]))
     }
 
     // MARK: - Rate-limit classification

--- a/Tests/TokiTests/ClaudeSignInExpiryTests.swift
+++ b/Tests/TokiTests/ClaudeSignInExpiryTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import XCTest
+@testable import Toki
+
+final class ClaudeSignInExpiryTests: XCTestCase {
+    private func credentials(expiresAt: String) -> String {
+        #"{"claudeAiOauth":{"accessToken":"token-123","expiresAt":\#(expiresAt)}}"#
+    }
+
+    private func milliseconds(fromNow offset: TimeInterval) -> String {
+        String(Int((Date().timeIntervalSince1970 + offset) * 1000))
+    }
+
+    // MARK: - Expiry parsing
+
+    func testExpiryIsParsedFromEpochMilliseconds() throws {
+        let token = try ClaudeCodeCredentialReader.extractToken(from: credentials(expiresAt: "1786000000000"))
+        XCTAssertEqual(token.accessToken, "token-123")
+        XCTAssertEqual(token.expiresAt?.timeIntervalSince1970 ?? 0, 1786000000, accuracy: 0.001)
+    }
+
+    func testExpiryIsParsedWhenStoredAsAString() throws {
+        let token = try ClaudeCodeCredentialReader.extractToken(from: credentials(expiresAt: "\"1786000000000\""))
+        XCTAssertEqual(token.expiresAt?.timeIntervalSince1970 ?? 0, 1786000000, accuracy: 0.001)
+    }
+
+    func testUnusableExpiryValuesAreIgnoredRatherThanGuessed() {
+        for raw in ["null", "0", "-1", #""not-a-number""#] {
+            let token = try? ClaudeCodeCredentialReader.extractToken(from: credentials(expiresAt: raw))
+            XCTAssertNil(token?.expiresAt, "expiresAt \(raw) should not produce a date")
+        }
+    }
+
+    // MARK: - Expiry decisions
+
+    func testTokenWithoutExpiryIsNeverTreatedAsExpired() throws {
+        let credentials = #"{"claudeAiOauth":{"accessToken":"token-123"}}"#
+        let token = try ClaudeCodeCredentialReader.extractToken(from: credentials)
+        XCTAssertNil(token.expiresAt)
+        XCTAssertFalse(token.isExpired())
+    }
+
+    func testTokenPastItsExpiryIsExpired() throws {
+        let token = try ClaudeCodeCredentialReader.extractToken(from: credentials(expiresAt: milliseconds(fromNow: -3600)))
+        XCTAssertTrue(token.isExpired())
+    }
+
+    func testTokenExpiringInsideTheLeewayIsTreatedAsExpired() throws {
+        let token = try ClaudeCodeCredentialReader.extractToken(from: credentials(expiresAt: milliseconds(fromNow: 30)))
+        XCTAssertTrue(token.isExpired())
+    }
+
+    func testTokenComfortablyInTheFutureIsUsable() throws {
+        let token = try ClaudeCodeCredentialReader.extractToken(from: credentials(expiresAt: milliseconds(fromNow: 3600)))
+        XCTAssertFalse(token.isExpired())
+    }
+
+    // MARK: - What the user is told
+
+    func testActiveAccountIsToldToOpenClaudeCodeAndThatRecoveryIsAutomatic() {
+        let message = ClaudeSignInExpiredError(accountLabel: "a@b.com", isActiveAccount: true).localizedDescription
+        XCTAssertTrue(message.contains("Open Claude Code"), message)
+        XCTAssertFalse(message.contains("claude-swap"), message)
+    }
+
+    func testStoredAccountIsToldToSwapAndIsNamed() {
+        let message = ClaudeSignInExpiredError(accountLabel: "work@example.com", isActiveAccount: false).localizedDescription
+        XCTAssertTrue(message.contains("claude-swap"), message)
+        XCTAssertTrue(message.contains("work@example.com"), message)
+    }
+
+    func testExpiryMessagesNeverEchoTheToken() throws {
+        let token = try ClaudeCodeCredentialReader.extractToken(from: credentials(expiresAt: milliseconds(fromNow: -60)))
+        XCTAssertTrue(token.isExpired())
+        for active in [true, false] {
+            let message = ClaudeSignInExpiredError(accountLabel: "a@b.com", isActiveAccount: active).localizedDescription
+            XCTAssertFalse(message.contains(token.accessToken), message)
+        }
+    }
+
+    // MARK: - Rate-limit classification
+
+    func testRequestIdThatMerelyContains429IsNotMistakenForARateLimit() {
+        let body = #"HTTP 401: {"type":"error","error":{"type":"authentication_error"},"request_id":"req_011Cdp429ZzcDbgSb8o9H3Wy"}"#
+        XCTAssertFalse(UsageFetcher.isRateLimitDescription(body), body)
+    }
+
+    func testGenuineRateLimitBodiesAreStillRecognised() {
+        let bodies = [
+            #"HTTP 429: {"error":{"type":"rate_limit_error","message":"Rate limited. Please try again later."}}"#,
+            "status 429",
+            "Rate limited. Please try again later."
+        ]
+        for body in bodies {
+            XCTAssertTrue(UsageFetcher.isRateLimitDescription(body), body)
+        }
+    }
+}


### PR DESCRIPTION
## What was wrong

A Claude Code account would sit at **Not connected** with a raw `HTTP 401: {"type":"error","error":{"type":"authentication_error"...}}` on the card, while Claude Code itself worked fine at that very moment.

Both read the same credential. There is exactly one Keychain item for service `Claude Code-credentials` (confirmed with `SecItemCopyMatching` + `kSecMatchLimitAll`), no `ANTHROPIC_API_KEY`, no `apiKeyHelper`. Toki was reading it correctly.

The problem is *when*. `ClaudeCodeUsageClient` pulled `accessToken` and sent it, and `extractAccessToken` never looked at the `expiresAt` sitting next to it in the same blob. Neither `expiresAt` nor `refreshToken` appeared anywhere in `Sources/`. Claude Code renews that token lazily, when it next runs, so between sessions the stored copy is expired and Toki spent a request every 7.5 minutes learning that from Anthropic.

The timeline on my machine, in UTC:

| time | event |
|---|---|
| 04:10:59 | 2x 401 |
| 04:18:48 | 2x 401 |
| 04:23:21 | 2x 401 |
| **04:23:32** | **Keychain `mdat` updated, token renewed** |
| ~04:24 | `claude` process starts |
| 04:25:00 | one error, and it is a 429; the other account stopped failing |

Every 401 landed before Claude Code ran. Starting it is what fixed the account. 494 of these had accumulated since 21 July, and enough in a row that the usage endpoint began rate-limiting; the 429s then hid the real state behind the previous reading, because 429 falls back to the last good snapshot.

The inactive `claude-swap` account is the version of this with no way out. Its credentials live under service `claude-swap`, written once at swap time and never touched again, so it expires within hours of being stored and stays expired forever.

## What this does

Checks the expiry before the request and skips the call entirely when the token is past due, with a 60s leeway. The card shows **Signed out** and what to do, instead of an `authentication_error` payload.

Recovery is immediate and automatic. An expired sign-in records **no API call**, so `apiLastCalledAt` never advances and the refresh interval never gates the retry. The next tick, or opening the popover (`AppDelegate.swift:233` already forces a refresh), re-reads the Keychain and picks up a freshly renewed token. That re-read is a local Keychain read and costs nothing until the sign-in is usable again.

An inactive stored account is told to run `claude-swap`, since that is the only thing that renews its copy.

Toki does **not** perform the refresh itself. It could, with the `refreshToken` already in the blob, but Anthropic rotates refresh tokens on use, so Toki writing one back races Claude Code doing its own refresh, and losing that race logs you out of Claude Code. Not a trade a usage monitor should make.

## Also fixed

`isRateLimitDescription` matched `"429"` anywhere in a 200-char response body. A `request_id` like `req_011Cdp429ZzcDbgSb8o9H3Wy` classified an unrelated failure as a rate limit and papered over it with a stale snapshot. It now matches the status token and the error type.

## Testing

12 new tests in `ClaudeSignInExpiryTests`: expiry parsing (numeric and string epoch millis, and the unusable values that must not be guessed at), the expiry decision including the leeway boundary, that a sign-in with no `expiresAt` is never treated as expired, that the messages never echo the token, and both directions of the rate-limit classification.

Full suite: 269 tests, 0 failures.

Not covered: the end-to-end path where the token renews between two refresh ticks. That needs a live Keychain and a real renewal, so it stays manual.