### PR TITLE
Keep the companion session for as long as the Mac says it lasts

### DIFF
--- a/Sources/Toki/Resources/webui/app.js
+++ b/Sources/Toki/Resources/webui/app.js
@@ -66,10 +66,55 @@ function feedback(kind = "tap") {
 
 const SESSION_KEY = "toki-session:" + API_BASE + ":" + LINK_TOKEN;
 
-let TOKEN = "";
-try {
-  TOKEN = sessionStorage.getItem(SESSION_KEY) || "";
-} catch (e) {}
+// The session lives in localStorage, not sessionStorage, because sessionStorage dies with the tab:
+// closing the browser -- or iOS discarding a backgrounded tab, which it does within minutes --
+// threw away a session the Mac still considered valid and sent you back to the six-digit code. The
+// server decides how long a session lasts (an hour to two days, chosen in Settings); the phone's
+// copy should last exactly as long, and no longer, so the expiry is stored with it and honoured on
+// load. Revoke on the Mac still ends it immediately, since the token stops being accepted.
+function loadSession() {
+  let raw = null;
+  try {
+    raw = localStorage.getItem(SESSION_KEY);
+  } catch (e) {}
+  if (!raw) return "";
+  // Sessions stored before this change were bare tokens with no expiry; treat them as valid and
+  // let the server be the judge, rather than dropping a working session on upgrade.
+  let saved;
+  try {
+    saved = JSON.parse(raw);
+  } catch (e) {
+    return raw;
+  }
+  if (!saved || !saved.token) return "";
+  if (saved.expires && Date.now() >= saved.expires) {
+    clearSession();
+    return "";
+  }
+  return saved.token;
+}
+
+function saveSession(token, expiresInSeconds) {
+  const record = { token };
+  // /api/pair reports the lifetime it granted; without it the token is kept until the server
+  // rejects it.
+  if (expiresInSeconds > 0) record.expires = Date.now() + expiresInSeconds * 1000;
+  try {
+    localStorage.setItem(SESSION_KEY, JSON.stringify(record));
+  } catch (e) {}
+}
+
+function clearSession() {
+  try {
+    localStorage.removeItem(SESSION_KEY);
+  } catch (e) {}
+  // Older builds kept it here; clear both so an upgrade cannot leave a stale copy behind.
+  try {
+    sessionStorage.removeItem(SESSION_KEY);
+  } catch (e) {}
+}
+
+let TOKEN = loadSession();
 
 let current = null;
 let offset = 0;
@@ -164,16 +209,20 @@ async function api(p, o) {
   // second time. The probe above is a GET and is the only thing repeated.
   const transport = await tokenTransportOnce();
   const r = await tokenedRequest(p, o, transport === "query");
-  if (r.status == 403) lockApp();
-  if (!r.ok) throw new Error(await r.text());
+  if (!r.ok) {
+    const detail = await r.text();
+    // 403 covers more than a dead session: the host setting refuses networks it was not meant to
+    // answer, and that is a "you are on the wrong Wi-Fi" which fixes itself. Only a token the Mac
+    // rejects should end the session -- otherwise walking out of the house would sign you out.
+    if (r.status == 403 && detail.includes("bad token")) lockApp();
+    throw new Error(detail);
+  }
   return r.json();
 }
 
 function lockApp() {
   TOKEN = "";
-  try {
-    sessionStorage.removeItem(SESSION_KEY);
-  } catch (e) {}
+  clearSession();
   document.body.classList.add("locked");
   $("#paircontrols").hidden = false;
   $("#connectmethods").hidden = true;
@@ -184,9 +233,7 @@ function lockApp() {
 
 function invalidLink(message) {
   TOKEN = "";
-  try {
-    sessionStorage.removeItem(SESSION_KEY);
-  } catch (e) {}
+  clearSession();
   try {
     localStorage.removeItem(CONN_KEY);
   } catch (e) {}
@@ -230,6 +277,15 @@ function startApp() {
   setInterval(pollLog, 2500);
 }
 
+// A backgrounded tab has its timers throttled to a crawl or stopped outright, so returning to the
+// app showed whatever was on screen when you left until the next tick happened to fire. Poll the
+// moment it is visible again.
+document.addEventListener("visibilitychange", () => {
+  if (document.visibilityState != "visible" || !started || !TOKEN) return;
+  pollAgents();
+  pollLog();
+});
+
 $("#pairform").addEventListener("submit", async e => {
   e.preventDefault();
   const code = $("#paircode").value.replace(/\s/g, "");
@@ -255,9 +311,7 @@ $("#pairform").addEventListener("submit", async e => {
       throw new Error(body.error || "verification failed");
     }
     TOKEN = body.token;
-    try {
-      sessionStorage.setItem(SESSION_KEY, TOKEN);
-    } catch (e) {}
+    saveSession(TOKEN, body.expiresIn);
     $("#pairstatus").textContent = "";
     startApp();
   } catch (err) {
@@ -757,9 +811,7 @@ function goHome() {
   try {
     localStorage.removeItem(CONN_KEY);
   } catch (e) {}
-  try {
-    sessionStorage.removeItem(SESSION_KEY);
-  } catch (e) {}
+  clearSession();
   location.replace(location.pathname);
 }
 

--- a/Tests/test_remote_pwa.js
+++ b/Tests/test_remote_pwa.js
@@ -120,6 +120,8 @@ assert.match(html, /id="pairhome"/);
 assert.match(css, /#pairhome\{[^}]*position:absolute/);
 const homeSource = app.match(/^function goHome\([\s\S]*?^}/m);
 assert.ok(homeSource, "goHome must be a top-level function in app.js");
+const clearSource = app.match(/^function clearSession\([\s\S]*?^}/m);
+assert.ok(clearSource, "clearSession must be a top-level function in app.js");
 const steps = [];
 const home = vm.createContext({
   CONN_KEY: "toki-conn",
@@ -128,11 +130,15 @@ const home = vm.createContext({
   sessionStorage: { removeItem(k) { steps.push("session:" + k); } },
   location: { pathname: "/", replace(url) { steps.push("replace:" + url); } },
 });
+vm.runInContext(clearSource[0], home);
 vm.runInContext(homeSource[0], home);
 
 vm.runInContext("goHome()", home);
 assert.deepEqual(steps, [
   "local:toki-conn",
+  // The session now lives in localStorage so it survives the tab closing; the sessionStorage
+  // removal stays behind it to clear what an older build of this page left there.
+  "local:toki-session:https://my-mac.example-tailnet.ts.net:abc",
   "session:toki-session:https://my-mac.example-tailnet.ts.net:abc",
   // The bare path: no query and no fragment, so nothing revives the connection we just left.
   "replace:/",
@@ -182,5 +188,61 @@ assert.match(app, /function savedConn/);
 assert.match(app, /const REVIVE\s*=\s*PARAMS\.get\("token"\)\s*\?\s*null\s*:\s*savedConn\(\)/);
 assert.match(app, /localStorage\.setItem\(CONN_KEY/);
 assert.match(app, /localStorage\.removeItem\(CONN_KEY\)/);
+
+// --- The session outlives the tab, and no longer than the Mac says it should ---
+// sessionStorage dies when the browser closes and when iOS discards a backgrounded tab, which
+// ended sessions the Mac still considered live. localStorage keeps them for exactly the lifetime
+// /api/pair granted.
+const sessionSources = ["loadSession", "saveSession", "clearSession"].map(name => {
+  const found = app.match(new RegExp("^function " + name + "\\([\\s\\S]*?^}", "m"));
+  assert.ok(found, name + " must be a top-level function in app.js");
+  return found[0];
+});
+
+function sessionContext(stored, now) {
+  const store = { value: stored };
+  const context = vm.createContext({
+    SESSION_KEY: "k",
+    Date: { now: () => now },
+    localStorage: {
+      getItem: () => store.value,
+      setItem: (_, v) => { store.value = v; },
+      removeItem: () => { store.value = null; },
+    },
+    sessionStorage: { removeItem() {} },
+  });
+  sessionSources.forEach(source => vm.runInContext(source, context));
+  return { context, store };
+}
+
+// A session stored with a future expiry is restored.
+const live = sessionContext(JSON.stringify({ token: "tok", expires: 2000 }), 1000);
+assert.equal(vm.runInContext("loadSession()", live.context), "tok");
+
+// Past its expiry it is dropped rather than replayed against a server that would refuse it.
+const dead = sessionContext(JSON.stringify({ token: "tok", expires: 500 }), 1000);
+assert.equal(vm.runInContext("loadSession()", dead.context), "");
+assert.equal(dead.store.value, null, "an expired session must be cleared from storage");
+
+// Sessions written by an older build were bare tokens; upgrading must not sign those devices out.
+const legacy = sessionContext("bare-token", 1000);
+assert.equal(vm.runInContext("loadSession()", legacy.context), "bare-token");
+
+// saveSession records the lifetime /api/pair reported.
+const fresh = sessionContext(null, 1000);
+vm.runInContext("saveSession('new-token', 60)", fresh.context);
+assert.deepEqual(JSON.parse(fresh.store.value), { token: "new-token", expires: 1000 + 60 * 1000 });
+
+// No lifetime reported: keep the token and let the server be the judge.
+vm.runInContext("saveSession('no-expiry', 0)", fresh.context);
+assert.deepEqual(JSON.parse(fresh.store.value), { token: "no-expiry" });
+
+// --- A 403 that isn't about the token must not end the session ---
+// The host setting refuses networks it was not meant to answer; that is a different Wi-Fi, not a
+// dead session, and signing out there would make leaving the house a logout.
+assert.match(app, /detail\.includes\("bad token"\)/);
+
+// --- Coming back to a backgrounded tab polls immediately ---
+assert.match(app, /addEventListener\("visibilitychange"/);
 
 console.log("remote pwa + qr + ux tests passed");

--- a/docs/remote-control.md
+++ b/docs/remote-control.md
@@ -42,6 +42,12 @@ chose in Settings (12 hours by default, 2 days maximum). The session token is se
 `Authorization` header, so it stays out of your phone's browser history and out of the logs of
 anything sitting between the phone and the Mac.
 
+That session lasts as long as it says it does: the phone keeps it until the lifetime you chose runs
+out, so closing the browser, locking the phone, or leaving the tab in the background does not send
+you back to the six-digit code. It is stored on the device that paired, which is what a session of
+hours-to-days means in practice — **Revoke** in Settings is what ends one early, and it takes
+effect on that device's next request.
+
 ### Who can reach the server
 
 The **Host** setting is not just a display preference — it decides which networks the server will


### PR DESCRIPTION
Closes #96.

Pairing grants a session of an hour to two days, but the phone kept the token in `sessionStorage` — which is scoped to the tab and cleared when it closes. Closing the browser ended the session, and so did iOS discarding a backgrounded tab, which it does within minutes of the phone locking. The Mac still considered the session live; the phone had thrown its half away, so it went back to asking for the six-digit code.

The token now lives in `localStorage` alongside the expiry `/api/pair` reported, and is dropped on load once that passes rather than being replayed against a server that would refuse it. Tokens written by an older build have no expiry recorded — those are kept and left to the server to judge, so upgrading does not sign anyone out.

Two things came out of the same read:

- **A 403 no longer ends the session on its own.** The host setting answers with 403 for a network it was not meant to serve, which made walking out of the house look identical to a dead token and signed the phone out. Only a refusal that names the token does that now.
- **Returning to a backgrounded tab polls immediately**, instead of waiting out a timer the browser had throttled to a crawl, so the transcript is current when you look at it.

`Revoke` in Settings is unaffected and remains the way to end a session early — the token stops being accepted, which is the only thing that ever made it valid. `docs/remote-control.md` now says what a session's lifetime actually means, since the previous behaviour contradicted it.

## Tests

`Tests/test_remote_pwa.js` gains coverage for the storage logic itself — a live session restored, an expired one dropped *and cleared*, a legacy bare token preserved across upgrade, and `saveSession` recording the granted lifetime (or omitting it when none was reported). The existing `goHome` test needed updating: it evaluates that function in isolation, and it now calls `clearSession`, so both are loaded into the VM context and the expected call order includes the localStorage removal.

All six Node suites and the 48 Python companion-server tests pass locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hohPTY9DSjEDSiseYo3Tw)_