### PR TITLE
Make the permissions checklist tell the truth, and its buttons do something

### DIFF
--- a/Sources/Toki/Permissions/SystemPermissions.swift
+++ b/Sources/Toki/Permissions/SystemPermissions.swift
@@ -82,7 +82,10 @@ struct SetupFacts: Equatable {
     var hasConnectedAccount = false
     /// Whether the user has agreed to Toki reading the Claude Code sign-in out of the Keychain.
     var keychainApproved = false
-    var claudeCodeDetected = false
+    /// A Claude Code sign-in was actually read - the row reports this rather than the gate.
+    var claudeSignInFound = false
+    /// A Claude account exists in config, so failing to read a sign-in is a problem worth naming.
+    var claudeAccountConfigured = false
     var notificationsEnabled = true
     /// Terminals installed on this Mac that Toki types replies into, with where each one stands.
     var automation: [AutomationTarget] = []
@@ -124,16 +127,36 @@ enum SetupChecklist {
 
         // Reading the sign-in Claude Code stored puts up the system's Keychain dialog, so on a
         // fresh install Toki waits to be told to look rather than doing it while you open a menu.
-        if isFirstRun || !facts.keychainApproved || facts.claudeCodeDetected {
+        // Once it is allowed the row reports what the read actually produced: saying "done" purely
+        // because the gate is open claimed success for a dialog that may have been refused.
+        if !facts.keychainApproved {
             steps.append(SetupStep(
                 kind: .claudeKeychain,
                 title: "Read your Claude Code sign-in",
-                detail: facts.keychainApproved
-                    ? "Toki reads the token Claude Code stored in your Keychain to show its quota."
-                    : "Claude Code keeps its token in your Keychain, and macOS asks you to allow Toki once. Without it, Claude Code quota can't be shown.",
-                status: facts.keychainApproved ? .done : .pending,
-                actionLabel: facts.keychainApproved ? nil : "Allow",
-                isRequestable: !facts.keychainApproved
+                detail: "Claude Code keeps its token in your Keychain, and macOS asks you to allow Toki once. Without it, Claude Code quota can't be shown.",
+                status: .pending,
+                actionLabel: "Allow",
+                isRequestable: true
+            ))
+        } else if facts.claudeSignInFound {
+            steps.append(SetupStep(
+                kind: .claudeKeychain,
+                title: "Read your Claude Code sign-in",
+                detail: "Toki is reading the token Claude Code stored in your Keychain.",
+                status: .done,
+                actionLabel: nil
+            ))
+        } else if facts.claudeAccountConfigured || isFirstRun {
+            // Allowed, but nothing came back. A refused Keychain dialog looks exactly like this,
+            // and so does a Claude Code that was never signed in - both are worth another look
+            // rather than a row claiming everything is fine.
+            steps.append(SetupStep(
+                kind: .claudeKeychain,
+                title: "Read your Claude Code sign-in",
+                detail: "Toki couldn't read a Claude Code sign-in. If macOS asked and the answer was Deny, try again and choose Always Allow; if Claude Code isn't signed in, run /login there first.",
+                status: .unknown,
+                actionLabel: "Try again",
+                isRequestable: true
             ))
         }
 
@@ -155,13 +178,13 @@ enum SetupChecklist {
                 kind: .automation,
                 subject: target.bundleID,
                 title: "Control \(target.name)",
-                detail: target.status == .blocked
-                    ? "Refused earlier, so replies can't reach agents running in \(target.name). Allow Toki under Privacy & Security › Automation."
-                    : "Lets Toki jump to an agent's tab, and type your replies from Remote Control into it.",
+                detail: automationDetail(for: target),
                 status: target.status,
                 actionLabel: target.status == .done ? nil : (target.status == .blocked ? "Open Settings" : "Allow"),
                 isOptional: true,
-                isRequestable: target.status == .pending
+                // `.unknown` means the app is closed and macOS would not say; asking is still the
+                // way to find out, and asking launches it.
+                isRequestable: target.status == .pending || target.status == .unknown
             ))
         }
 
@@ -213,6 +236,17 @@ enum SetupChecklist {
         }
 
         return steps
+    }
+
+    private static func automationDetail(for target: AutomationTarget) -> String {
+        switch target.status {
+        case .blocked:
+            return "Refused earlier, so replies can't reach agents running in \(target.name). Allow Toki under Privacy & Security › Automation."
+        case .unknown:
+            return "\(target.name) isn't running, so macOS won't say yet. Allow opens it and asks."
+        default:
+            return "Lets Toki jump to an agent's tab, and type your replies from Remote Control into it."
+        }
     }
 
     /// Steps still worth acting on - what the badge counts.
@@ -269,7 +303,10 @@ enum SetupChecklist {
         // read happens regardless, and a row reading "pending" for something already working
         // would be a lie with a button attached.
         facts.keychainApproved = store.allowsKeychainReads
-        facts.claudeCodeDetected = store.snapshots.contains { $0.provider.isClaudeAccount }
+        facts.claudeAccountConfigured = store.snapshots.contains { $0.provider.isClaudeAccount }
+        // What the read produced, from either route: a connected account or a live detection.
+        facts.claudeSignInFound = facts.claudeAccountConfigured
+            || store.detectedProviders.contains { $0.provider.isClaudeAccount }
         facts.notificationsEnabled = store.preferences.notificationsEnabled
         // Off the main actor: this is a TCC lookup per terminal, and the list is rebuilt every
         // time the app becomes active - which is exactly when TCC is least likely to answer fast.
@@ -330,7 +367,11 @@ enum SystemPermissions {
         let status = automationPermission(bundleID: bundleID, askUserIfNeeded: false)
         if status == noErr { return .done }
         if status == notPermitted { return .blocked }
-        if status == wouldRequireConsent || status == targetNotRunning { return .pending }
+        if status == wouldRequireConsent { return .pending }
+        // The app is not running, so macOS will not say. Reporting "not granted yet" there was
+        // wrong for every terminal that happened to be closed - including ones already allowed -
+        // and it is the state most terminals are in when the checklist is read.
+        if status == targetNotRunning { return .unknown }
         return .unknown
     }
 
@@ -358,6 +399,13 @@ enum SystemPermissions {
         return withExtendedLifetime(descriptor) {
             AEDeterminePermissionToAutomateTarget(target, AEEventClass(typeWildCard), AEEventID(typeWildCard), askUserIfNeeded)
         }
+    }
+
+    /// Notifications live in their own Settings pane, not under Privacy & Security.
+    @MainActor
+    static func openNotificationSettings() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension") else { return }
+        NSWorkspace.shared.open(url)
     }
 
     @MainActor

--- a/Sources/Toki/Store/UsageStore+Notifications.swift
+++ b/Sources/Toki/Store/UsageStore+Notifications.swift
@@ -81,12 +81,16 @@ extension UsageStore {
     // rather than arriving with the first low-quota warning.
     func sendTestNotification() {
         let detail = "Toki will tell you here when quota runs low or an agent is waiting on you."
-        deliverNotification(title: "Toki notifications are on", detail: detail) { delivered, failureDetail in
+        deliverNotification(title: "Toki notifications are on", detail: detail) { handedOver, failureDetail in
+            // "Handed to macOS", not "delivered": nothing here can see whether it was shown, and
+            // claiming it arrived is what made a silent notification look like a working one.
             self.appendEvent(
                 kind: .notification,
                 title: "Test notification",
-                detail: delivered ? detail : "Not delivered: \(failureDetail ?? detail)",
-                deliveredNotification: delivered
+                detail: handedOver
+                    ? "Sent to macOS. If nothing appeared, allow Toki under System Settings › Notifications."
+                    : "Not sent: \(failureDetail ?? detail)",
+                deliveredNotification: handedOver
             )
         }
     }

--- a/Sources/Toki/Views/SetupChecklistView.swift
+++ b/Sources/Toki/Views/SetupChecklistView.swift
@@ -147,6 +147,17 @@ struct SetupChecklistView: View {
 
             Spacer(minLength: 4)
 
+            // macOS decides on its own whether a notification appears, and there is no way to ask
+            // it after the fact, so the only honest follow-up is a way to go and look.
+            if step.kind == .notifications, notificationTestSent {
+                Button("Open Settings") {
+                    SystemPermissions.openNotificationSettings()
+                }
+                .controlSize(.small)
+                .fixedSize()
+                .pointerOnHover()
+            }
+
             if let label = step.actionLabel {
                 Button {
                     perform(step)

--- a/Tests/TokiTests/SetupChecklistTests.swift
+++ b/Tests/TokiTests/SetupChecklistTests.swift
@@ -19,19 +19,32 @@ final class SetupChecklistTests: XCTestCase {
         XCTAssertEqual(step(.claudeKeychain, in: facts)?.actionLabel, "Allow")
     }
 
-    func testTheKeychainRowDisappearsOnceApprovedAndNoClaudeAccountIsThere() {
+    func testTheKeychainRowDisappearsOnceApprovedAndThereIsNoClaudeToRead() {
         var facts = SetupFacts()
         facts.keychainApproved = true
-        facts.claudeCodeDetected = false
+        facts.claudeSignInFound = false
+        facts.claudeAccountConfigured = false
         XCTAssertNil(step(.claudeKeychain, in: facts))
     }
 
-    func testAnApprovedKeychainStillExplainsItselfWhileClaudeIsConnected() {
+    func testAnApprovedKeychainReadsAsDoneOnlyWhenASignInWasActuallyRead() {
         var facts = SetupFacts()
         facts.keychainApproved = true
-        facts.claudeCodeDetected = true
+        facts.claudeSignInFound = true
         XCTAssertEqual(step(.claudeKeychain, in: facts)?.status, .done)
         XCTAssertNil(step(.claudeKeychain, in: facts)?.actionLabel)
+    }
+
+    // A refused Keychain dialog leaves the gate open and the read empty. Reporting that as "done"
+    // claimed success for something that never happened and removed the only way to retry.
+    func testAConfiguredClaudeAccountWithNoReadableSignInOffersARetry() {
+        var facts = SetupFacts()
+        facts.keychainApproved = true
+        facts.claudeAccountConfigured = true
+        facts.claudeSignInFound = false
+        XCTAssertEqual(step(.claudeKeychain, in: facts)?.status, .unknown)
+        XCTAssertEqual(step(.claudeKeychain, in: facts)?.actionLabel, "Try again")
+        XCTAssertTrue(step(.claudeKeychain, in: facts)?.isRequestable ?? false)
     }
 
     // Nothing is delivered while Toki's own switch is off, so macOS is never asked and there is
@@ -67,6 +80,19 @@ final class SetupChecklistTests: XCTestCase {
         var facts = SetupFacts()
         facts.automation = [AutomationTarget(name: "Terminal", bundleID: "com.apple.Terminal", status: .blocked)]
         XCTAssertEqual(step(.automation, in: facts)?.actionLabel, "Open Settings")
+    }
+
+    // macOS will not answer for an app that is not running, and most terminals are closed when the
+    // checklist is read. Calling that "not granted yet" marked already-allowed terminals as
+    // outstanding forever; it is unknown, and asking is still how you find out.
+    func testAClosedTerminalIsUnknownRatherThanNotGranted() {
+        var facts = SetupFacts()
+        facts.automation = [AutomationTarget(name: "iTerm", bundleID: "com.googlecode.iterm2", status: .unknown)]
+        let row = step(.automation, in: facts)
+        XCTAssertEqual(row?.status, .unknown)
+        XCTAssertEqual(row?.actionLabel, "Allow")
+        XCTAssertTrue(row?.isRequestable ?? false, "asking is what opens it and settles the question")
+        XCTAssertTrue(SetupChecklist.outstanding(steps(facts)).isEmpty, "unknown is not a chore")
     }
 
     func testAccessibilityIsOnlyRaisedWhileAnEditorThatNeedsItIsRunning() {
@@ -156,6 +182,7 @@ final class SetupChecklistTests: XCTestCase {
         facts.keychainApproved = true
         facts.accessibilityGranted = true
         facts.launchAtLoginEnabled = true
+        facts.claudeSignInFound = true
         facts.automation = [AutomationTarget(name: "Terminal", bundleID: "com.apple.Terminal", status: .blocked)]
         let order = SetupChecklist.requestOrder(SetupChecklist.steps(from: facts, mode: .firstRun))
         // Notifications can't be read back, so it stays askable; everything else here is settled,

--- a/Tests/TokiTests/SetupChecklistTests.swift
+++ b/Tests/TokiTests/SetupChecklistTests.swift
@@ -92,7 +92,12 @@ final class SetupChecklistTests: XCTestCase {
         XCTAssertEqual(row?.status, .unknown)
         XCTAssertEqual(row?.actionLabel, "Allow")
         XCTAssertTrue(row?.isRequestable ?? false, "asking is what opens it and settles the question")
-        XCTAssertTrue(SetupChecklist.outstanding(steps(facts)).isEmpty, "unknown is not a chore")
+        // Other rows in a bare fixture are legitimately outstanding; what matters is that a
+        // terminal macOS refuses to answer for is not one of them.
+        XCTAssertFalse(
+            SetupChecklist.outstanding(steps(facts)).contains { $0.kind == .automation },
+            "a closed terminal is unknown, not an outstanding chore"
+        )
     }
 
     func testAccessibilityIsOnlyRaisedWhileAnEditorThatNeedsItIsRunning() {


### PR DESCRIPTION
Closes #94.

Three rows were reporting states they had never checked, and the buttons on two of them could not work. All three were introduced with the checklist in 2.7.0.

**Automation was wrong for every closed terminal.** macOS will not say whether Automation is allowed for an app that is not running — `AEDeterminePermissionToAutomateTarget` answers `procNotFound`. That was mapped to `.pending`, so a terminal that had been allowed months ago still sat in the list as an outstanding chore, with an **Allow** button that produced no dialog because macOS had already decided. It now reads as unknown, the row says the app is closed, and **Allow** opens it and asks — which is the only thing that can settle it. Unknown also stops counting toward the outstanding badge.

**The Keychain row claimed success it had not verified.** It read `allowsKeychainReads`, which is unconditionally true for any install past onboarding, so it reported "done" whether or not the read worked — including when the macOS dialog had been denied — and offered no way to retry. It now reports what the read produced: **done** when a sign-in was actually found, and a **Try again** when the gate is open but nothing came back, which is what both a refused dialog and a never-signed-in Claude Code look like from here.

**Send a test could not report anything true.** The notification path assumes authorization instead of asking for it (a deliberate workaround for a `UNUserNotificationCenter` crash), so a suppressed notification was logged as *delivered* and the row looked like it had worked. The event now records that it was handed to macOS rather than delivered, and once a test is sent the row offers the Notifications settings pane — going to look is the only way to know.

## What this does not change

The delivery mechanism itself. Moving to `UNUserNotificationCenter` would let Toki read the real authorization state and stop guessing, but it means re-testing the crash the current path exists to avoid, which is its own change rather than a line in this one. #94 has the detail.

## Tests

`SetupChecklistTests` gains cases for the closed-terminal state (unknown, still requestable, not outstanding) and for the keychain row's three outcomes, and the existing keychain cases were rewritten against the new facts — `claudeSignInFound` and `claudeAccountConfigured` replace the old `claudeCodeDetected`, which conflated "we may read" with "we did read".

---
_Generated by [Claude Code](https://claude.ai/code/session_016hohPTY9DSjEDSiseYo3Tw)_