### PR TITLE
Stop reporting a working tailscale serve as missing

### DIFF
--- a/Sources/Toki/Server/RemoteControlServer.swift
+++ b/Sources/Toki/Server/RemoteControlServer.swift
@@ -101,12 +101,27 @@ final class RemoteControlServer: ObservableObject {
     @Published private(set) var pairingCode: String?
     @Published private(set) var lastError: String?
     @Published private(set) var tailscaleDNSName: String?
-    // nil until the first check completes; true when `tailscale serve` fronts our port on 443,
-    // so the hosted Toki RC UI can actually reach this Mac from a phone.
-    @Published private(set) var tailscaleServeReady: Bool?
+    // nil until the first check completes. Everything the UI needs about serve comes from here.
+    @Published private(set) var serveState: ServeState?
+
+    /// True when serve fronts our port, false when it demonstrably does not, nil while unknown -
+    /// which now includes "the status could not be read", since that is not evidence of anything.
+    var tailscaleServeReady: Bool? {
+        switch serveState {
+        case .ready: return true
+        case .conflict, .notServing: return false
+        case .unreadable, nil: return nil
+        }
+    }
+
+    /// Why serve status could not be read, when that is what happened.
+    var serveStatusProblem: String? {
+        if case let .unreadable(reason) = serveState { return reason }
+        return nil
+    }
     // True when HTTPS :443 already serves a different app; auto-serve is suppressed so it can't
     // clobber it, and the UI warns before a manual enable replaces it.
-    @Published private(set) var tailscaleServeConflict = false
+    var tailscaleServeConflict: Bool { serveState == .conflict }
     // Why the Tailscale DNS name couldn't be read (command missing, not logged in, MagicDNS off),
     // surfaced in settings so a failed lookup explains itself instead of silently using the IP.
     @Published private(set) var tailscaleStatusDiagnostic: String?
@@ -601,14 +616,12 @@ final class RemoteControlServer: ObservableObject {
             let result = await Task.detached(priority: .utility) {
                 let status = Self.readTailscaleStatus()
                 let serve = Self.readTailscaleServe(port: checkPort)
-                return (name: status.name, diagnostic: status.diagnostic, cli: status.cliAvailable,
-                        ready: serve.ready, conflict: serve.conflict)
+                return (name: status.name, diagnostic: status.diagnostic, cli: status.cliAvailable, serve: serve)
             }.value
             tailscaleDNSName = result.name
             tailscaleStatusDiagnostic = result.diagnostic
             tailscaleCLIAvailable = result.cli
-            tailscaleServeReady = result.ready
-            tailscaleServeConflict = result.conflict
+            serveState = result.serve
             enableTailscaleServeIfNeeded()
         }
     }
@@ -779,9 +792,12 @@ final class RemoteControlServer: ObservableObject {
         return "Tailscale reports this Mac as \(name), which isn't a .ts.net name. Enter the host by hand."
     }
 
-    private nonisolated static func readTailscaleServe(port: Int) -> (ready: Bool, conflict: Bool) {
-        guard let data = runTailscale(["serve", "status", "--json"]).data else { return (false, false) }
-        return (serveReady(from: data, port: port), serveConflict(from: data, port: port))
+    private nonisolated static func readTailscaleServe(port: Int) -> ServeState {
+        let run = runTailscale(["serve", "status", "--json"])
+        guard run.foundCLI else {
+            return .unreadable("Toki couldn't run the tailscale command to check HTTPS.")
+        }
+        return serveState(from: run.data, port: port)
     }
 
     // Why `tailscale serve` refused, in words, plus the one command that clears it where there is
@@ -964,60 +980,74 @@ final class RemoteControlServer: ObservableObject {
 
     // `tailscale serve status --json` reports a Web handler map keyed by "<host>:<port>", each with
     // a Proxy target. Ready means a :443 handler forwards to our loopback port.
-    nonisolated static func serveReady(from data: Data, port: Int) -> Bool {
-        guard
-            let object = try? JSONSerialization.jsonObject(with: data),
-            let root = object as? [String: Any],
-            let web = root["Web"] as? [String: Any]
-        else {
-            return false
-        }
-        let needle = "127.0.0.1:\(port)"
-        for (hostPort, value) in web {
-            guard
-                hostPort.hasSuffix(":443"),
-                let entry = value as? [String: Any],
-                let handlers = entry["Handlers"] as? [String: Any]
-            else {
-                continue
-            }
-            for handler in handlers.values {
-                if let handler = handler as? [String: Any],
-                   let proxy = handler["Proxy"] as? String,
-                   proxy.contains(needle) {
-                    return true
-                }
-            }
-        }
-        return false
+    /// What `tailscale serve status --json` says about our port. "Could not read it" is a
+    /// separate answer from "nothing is served": they used to render identically, which meant a
+    /// failed status read told the user their serve was off and offered to fix a working setup.
+    enum ServeState: Equatable, Sendable {
+        case ready
+        case conflict
+        case notServing
+        case unreadable(String)
     }
 
-    // True when HTTPS :443 already serves a different app at the root path. Auto-serve must skip
-    // this case: `tailscale serve` at root would replace the user's other service silently.
-    nonisolated static func serveConflict(from data: Data, port: Int) -> Bool {
-        guard
-            let object = try? JSONSerialization.jsonObject(with: data),
-            let root = object as? [String: Any],
-            let web = root["Web"] as? [String: Any]
-        else {
-            return false
+    /// Hosts that mean "this Mac" in a serve target. Tailscale writes 127.0.0.1 today, but the
+    /// spelling is not part of any contract, and matching one literal string is what made a
+    /// working serve read as absent.
+    private static let loopbackHosts: Set<String> = ["127.0.0.1", "localhost", "::1", "0.0.0.0"]
+
+    /// True when a serve target points at this Mac on `port`, whatever scheme, path or spelling
+    /// of loopback it uses.
+    nonisolated static func proxyTargetsLocalPort(_ proxy: String, port: Int) -> Bool {
+        var rest = proxy.trimmingCharacters(in: .whitespaces)
+        if let scheme = rest.range(of: "://") {
+            rest = String(rest[scheme.upperBound...])
         }
-        let needle = "127.0.0.1:\(port)"
+        if let slash = rest.firstIndex(of: "/") {
+            rest = String(rest[..<slash])
+        }
+        guard let colon = rest.lastIndex(of: ":") else { return false }
+        let host = String(rest[..<colon])
+            .trimmingCharacters(in: CharacterSet(charactersIn: "[]"))
+            .lowercased()
+        guard Int(rest[rest.index(after: colon)...]) == port else { return false }
+        return loopbackHosts.contains(host)
+    }
+
+    /// The port a `Web` key is serving on. Keys are "<host>:<port>", and an IPv6 host has colons
+    /// of its own, so only the last one separates the port.
+    nonisolated static func servedPort(fromWebKey key: String) -> Int? {
+        guard let colon = key.lastIndex(of: ":") else { return nil }
+        return Int(key[key.index(after: colon)...])
+    }
+
+    nonisolated static func serveState(from data: Data?, port: Int) -> ServeState {
+        guard let data else {
+            return .unreadable("Toki couldn't read `tailscale serve status`.")
+        }
+        guard let object = try? JSONSerialization.jsonObject(with: data), let root = object as? [String: Any] else {
+            return .unreadable("Tailscale's serve status wasn't readable.")
+        }
+        // A tailnet with nothing served answers with valid JSON and no Web map. That is a real
+        // "not serving", not a failure to read.
+        guard let web = root["Web"] as? [String: Any] else { return .notServing }
+
+        var sawConflict = false
         for (hostPort, value) in web {
-            guard
-                hostPort.hasSuffix(":443"),
-                let entry = value as? [String: Any],
-                let handlers = entry["Handlers"] as? [String: Any],
-                let rootHandler = handlers["/"] as? [String: Any]
-            else {
-                continue
+            guard servedPort(fromWebKey: hostPort) == 443,
+                  let entry = value as? [String: Any],
+                  let handlers = entry["Handlers"] as? [String: Any] else { continue }
+            for handler in handlers.values {
+                guard let handler = handler as? [String: Any],
+                      let proxy = handler["Proxy"] as? String else { continue }
+                if proxyTargetsLocalPort(proxy, port: port) { return .ready }
             }
-            // Any root handler conflicts unless it's a proxy to our own port; a Path/Text static
-            // handler or a proxy elsewhere would be replaced by our serve command.
-            if let proxy = rootHandler["Proxy"] as? String, proxy.contains(needle) { continue }
-            return true
+            // Something else owns the root path here; serving over it would replace it silently.
+            if let rootHandler = handlers["/"] as? [String: Any] {
+                let proxy = rootHandler["Proxy"] as? String
+                if proxy == nil || !proxyTargetsLocalPort(proxy!, port: port) { sawConflict = true }
+            }
         }
-        return false
+        return sawConflict ? .conflict : .notServing
     }
 
     private static func isTailscaleAddress(_ ip: String) -> Bool {

--- a/Sources/Toki/Server/RemoteControlServer.swift
+++ b/Sources/Toki/Server/RemoteControlServer.swift
@@ -993,7 +993,7 @@ final class RemoteControlServer: ObservableObject {
     /// Hosts that mean "this Mac" in a serve target. Tailscale writes 127.0.0.1 today, but the
     /// spelling is not part of any contract, and matching one literal string is what made a
     /// working serve read as absent.
-    private static let loopbackHosts: Set<String> = ["127.0.0.1", "localhost", "::1", "0.0.0.0"]
+    private nonisolated static let loopbackHosts: Set<String> = ["127.0.0.1", "localhost", "::1", "0.0.0.0"]
 
     /// True when a serve target points at this Mac on `port`, whatever scheme, path or spelling
     /// of loopback it uses.

--- a/Sources/Toki/Views/SettingsPanel.swift
+++ b/Sources/Toki/Views/SettingsPanel.swift
@@ -779,6 +779,11 @@ struct SettingsPanel: View {
     // A string literal per state rather than nested ternaries inside the Text, so each state's
     // wording is readable and stays formatted (the backticks are markdown to Text).
     private var readinessMessage: LocalizedStringKey {
+        // A status Toki could not read is not evidence that serve is off. Saying so sent people to
+        // fix a working setup; now it says what it could not do.
+        if let problem = remoteServer.serveStatusProblem {
+            return LocalizedStringKey(problem + " Serve may well be running - this is Toki failing to check, not Tailscale failing to serve.")
+        }
         switch remoteServer.tailscaleServeReady {
         case .some(true):
             return "Reachable from your phone."
@@ -801,16 +806,16 @@ struct SettingsPanel: View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .top, spacing: 6) {
                 Image(systemName: ready == true ? "checkmark.circle.fill"
-                    : ready == false ? "exclamationmark.triangle.fill" : "ellipsis.circle")
+                    : (ready == false || remoteServer.serveStatusProblem != nil) ? "exclamationmark.triangle.fill" : "ellipsis.circle")
                     .foregroundStyle(ready == true ? Color.green
-                        : ready == false ? Color.orange : Color.secondary)
+                        : (ready == false || remoteServer.serveStatusProblem != nil) ? Color.orange : Color.secondary)
                 Text(readinessMessage)
-                    .foregroundStyle(ready == false && !remoteServer.isEnablingServe ? Color.orange : Color.secondary)
+                    .foregroundStyle((ready == false || remoteServer.serveStatusProblem != nil) && !remoteServer.isEnablingServe ? Color.orange : Color.secondary)
             }
             .font(.system(size: 11))
             .fixedSize(horizontal: false, vertical: true)
 
-            if ready == false {
+            if ready == false || remoteServer.serveStatusProblem != nil {
                 if remoteServer.tailscaleCLIAvailable == false {
                     // Nothing to click: with no CLI Toki cannot run serve at all, so hand over the
                     // exact command instead of a button that would only fail.

--- a/Tests/TokiTests/RemoteControlServerTests.swift
+++ b/Tests/TokiTests/RemoteControlServerTests.swift
@@ -354,54 +354,87 @@ final class RemoteControlServerTests: XCTestCase {
         )
     }
 
+    private func serveState(_ json: String, port: Int = 8765) -> RemoteControlServer.ServeState {
+        RemoteControlServer.serveState(from: Data(json.utf8), port: port)
+    }
+
     func testServeReadyDetectsHandlerForOurPort() {
-        let json = """
+        XCTAssertEqual(serveState("""
         {"TCP":{"443":{"HTTPS":true}},"Web":{"mac.tail1234.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:8765"}}}}}
-        """
-        XCTAssertTrue(RemoteControlServer.serveReady(from: Data(json.utf8), port: 8765))
+        """), .ready)
     }
 
-    func testServeReadyFalseForDifferentPort() {
-        let json = """
-        {"Web":{"mac.tail1234.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:9999"}}}}}
-        """
-        XCTAssertFalse(RemoteControlServer.serveReady(from: Data(json.utf8), port: 8765))
+    // The spellings Tailscale is free to use for the same thing. Matching one literal string is
+    // what reported a working serve as absent.
+    func testServeReadyAcceptsEveryWayOfSpellingThisMac() {
+        for proxy in ["http://127.0.0.1:8765", "127.0.0.1:8765", "http://localhost:8765",
+                      "https://localhost:8765/", "http://[::1]:8765", "http+insecure://127.0.0.1:8765"] {
+            XCTAssertEqual(
+                serveState("{\"Web\":{\"mac.tail1234.ts.net:443\":{\"Handlers\":{\"/\":{\"Proxy\":\"\(proxy)\"}}}}}"),
+                .ready,
+                "\(proxy) points at this Mac and should count as served"
+            )
+        }
     }
 
-    func testServeReadyFalseWhenNotServedOn443() {
-        let json = """
+    // Ours may not be the only handler on 443; finding it anywhere is what matters.
+    func testServeReadyFindsOurPortOnANonRootPath() {
+        XCTAssertEqual(serveState("""
+        {"Web":{"mac.tail1234.ts.net:443":{"Handlers":{"/":{"Text":"hi"},"/toki":{"Proxy":"http://127.0.0.1:8765"}}}}}
+        """), .ready)
+    }
+
+    func testServeStateIsNotServingForADifferentPort() {
+        XCTAssertEqual(serveState("""
+        {"Web":{"mac.tail1234.ts.net:443":{"Handlers":{"/other":{"Proxy":"http://127.0.0.1:9999"}}}}}
+        """), .notServing)
+    }
+
+    func testServeStateIgnoresHandlersThatAreNotOn443() {
+        XCTAssertEqual(serveState("""
         {"Web":{"mac.tail1234.ts.net:8443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:8765"}}}}}
-        """
-        XCTAssertFalse(RemoteControlServer.serveReady(from: Data(json.utf8), port: 8765))
+        """), .notServing)
     }
 
-    func testServeReadyFalseForEmptyConfig() {
-        XCTAssertFalse(RemoteControlServer.serveReady(from: Data("{}".utf8), port: 8765))
+    func testServeStateIsNotServingForAnEmptyConfig() {
+        XCTAssertEqual(serveState("{}"), .notServing)
+    }
+
+    // The distinction the UI was missing: nothing served is a fact, an unreadable status is not.
+    func testUnreadableStatusIsNotReportedAsNotServing() {
+        XCTAssertEqual(RemoteControlServer.serveState(from: nil, port: 8765),
+                       .unreadable("Toki couldn't read `tailscale serve status`."))
+        guard case .unreadable = serveState("not json at all") else {
+            return XCTFail("unparseable output must not read as a working answer")
+        }
     }
 
     func testServeConflictWhenRootServesAnotherApp() {
-        let json = """
+        XCTAssertEqual(serveState("""
         {"Web":{"mac.tail1234.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:9999"}}}}}
-        """
-        XCTAssertTrue(RemoteControlServer.serveConflict(from: Data(json.utf8), port: 8765))
+        """), .conflict)
     }
 
-    func testNoServeConflictWhenRootIsOurPort() {
-        let json = """
+    func testAStaticRootHandlerIsAConflictToo() {
+        XCTAssertEqual(serveState("""
+        {"Web":{"mac.tail1234.ts.net:443":{"Handlers":{"/":{"Text":"hello"}}}}}
+        """), .conflict)
+    }
+
+    func testNoConflictWhenRootIsOurPort() {
+        XCTAssertEqual(serveState("""
         {"Web":{"mac.tail1234.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:8765"}}}}}
-        """
-        XCTAssertFalse(RemoteControlServer.serveConflict(from: Data(json.utf8), port: 8765))
+        """), .ready)
     }
 
-    func testNoServeConflictWhenNothingOn443() {
-        XCTAssertFalse(RemoteControlServer.serveConflict(from: Data("{}".utf8), port: 8765))
+    func testNoConflictWhenNothingIsOn443() {
+        XCTAssertEqual(serveState("{}"), .notServing)
     }
 
-    func testServeConflictWhenRootIsStaticHandler() {
-        let json = """
+    func testAStaticPathRootHandlerIsAConflict() {
+        XCTAssertEqual(serveState("""
         {"Web":{"mac.tail1234.ts.net:443":{"Handlers":{"/":{"Path":"/var/www/site"}}}}}
-        """
-        XCTAssertTrue(RemoteControlServer.serveConflict(from: Data(json.utf8), port: 8765))
+        """), .conflict)
     }
 
     func testParseTunnelHostFromCloudflaredOutput() {


### PR DESCRIPTION
Closes #92.

Two separate reasons the warning stayed up on a Mac where HTTPS was fully set up.

**The match was too literal.** Readiness required the substring `127.0.0.1:<port>` inside a `Proxy` value, and required the `Web` key to end in `:443`. Tailscale is under no obligation to spell it that way — `localhost`, an IPv6 loopback, a trailing slash, or a scheme Toki did not anticipate all describe the same serve and all read as absent. A handler on any path other than `/` was missed as well, so a Mac serving Toki alongside anything else looked unserved. The target is now parsed properly (scheme, host, port) and any spelling of this machine on any path counts.

**"Could not read the status" was reported as "serve is not running".** A `tailscale serve status` that failed, timed out, or returned something unparseable produced the same orange warning as a genuinely empty config — telling the user their HTTPS was off and offering to fix a setup that was already working. It is now its own state, the row says Toki could not check rather than that Tailscale is not serving, and since it is not evidence of anything it no longer drives auto-serve.

The two booleans (`ready`, `conflict`) that could disagree with each other are now one `ServeState` — `ready`, `conflict`, `notServing`, `unreadable(reason)` — so an impossible combination cannot be held.

## On the screenshot in #92

The state table in that comment is what this is built against: it ruled out the CLI-missing and conflict paths and left detection. Both causes above produce exactly what was photographed. What it cannot do is tell us **which** of the two it was, because they rendered identically — that ambiguity is itself fixed here, so if it recurs the row will now say which.

Still worth pasting the real `tailscale serve status --json` into #92: `serveState` is a pure function over that blob, and a genuine sample becomes a fixture that pins the parser to your Tailscale version rather than to my reading of its output shape.

## Tests

`RemoteControlServerTests` now covers the six spellings of a loopback target, our port found on a non-root path, handlers on ports other than 443 being ignored, a static (`Text`/`Path`) root handler counting as a conflict, and — the distinction that was missing — unreadable output never being reported as "not serving".

---
_Generated by [Claude Code](https://claude.ai/code/session_016hohPTY9DSjEDSiseYo3Tw)_