### PR TITLE
Run tailscale serve without waiting to be told the Mac's name

### DIFF
--- a/Sources/Toki/Server/RemoteControlServer.swift
+++ b/Sources/Toki/Server/RemoteControlServer.swift
@@ -133,6 +133,9 @@ final class RemoteControlServer: ObservableObject {
     // Toki enables HTTPS once per running server rather than on every status poll, so a refusal
     // (not the operator, certificates off) is reported once instead of retried every 20 seconds.
     private var didAttemptAutoServe = false
+    /// Why Toki did not run `tailscale serve` itself. Without this the row said serve was not
+    /// running and offered a button, with no hint that Toki had already decided not to try.
+    @Published private(set) var autoServeSkipped: String?
     // Public HTTPS address from a Cloudflare quick tunnel, when Host is Cloudflare Tunnel.
     @Published private(set) var tunnelHost: String?
     @Published private(set) var isStartingTunnel = false
@@ -618,10 +621,13 @@ final class RemoteControlServer: ObservableObject {
                 let serve = Self.readTailscaleServe(port: checkPort)
                 return (name: status.name, diagnostic: status.diagnostic, cli: status.cliAvailable, serve: serve)
             }.value
-            tailscaleDNSName = result.name
             tailscaleStatusDiagnostic = result.diagnostic
             tailscaleCLIAvailable = result.cli
-            serveState = result.serve
+            serveState = result.serve.state
+            // `tailscale status` is not the only place this Mac's name appears. When it could not
+            // be read, serve's own configuration names the host it is serving, which is the same
+            // name the phone needs - so it is filled in rather than typed by hand.
+            tailscaleDNSName = result.name ?? result.serve.host
             enableTailscaleServeIfNeeded()
         }
     }
@@ -631,9 +637,20 @@ final class RemoteControlServer: ObservableObject {
     // showing a warning and a button. A handler already serving :443 is left alone - replacing
     // someone else's service is a decision, and the UI asks for it explicitly.
     private func enableTailscaleServeIfNeeded() {
-        guard !didAttemptAutoServe, isRunning, tailscaleServeReady == false, !tailscaleServeConflict,
-              tailscaleCLIAvailable == true, hasUsableTailscaleHost,
-              hostMode == .tailscale || companionAppMode == .hosted else { return }
+        guard isRunning, hostMode == .tailscale || companionAppMode == .hosted else { return }
+        guard !didAttemptAutoServe else { return }
+        // Nothing to do, or nothing that can be decided yet.
+        guard tailscaleServeReady == false else { return }
+        // Deliberate refusals, each of which the row explains on its own.
+        if tailscaleServeConflict {
+            autoServeSkipped = "Something else already serves HTTPS on 443, so Toki left it alone."
+            return
+        }
+        if tailscaleCLIAvailable != true {
+            autoServeSkipped = "Toki has no tailscale command to run."
+            return
+        }
+        autoServeSkipped = nil
         didAttemptAutoServe = true
         enableTailscaleServe()
     }
@@ -792,12 +809,12 @@ final class RemoteControlServer: ObservableObject {
         return "Tailscale reports this Mac as \(name), which isn't a .ts.net name. Enter the host by hand."
     }
 
-    private nonisolated static func readTailscaleServe(port: Int) -> ServeState {
+    private nonisolated static func readTailscaleServe(port: Int) -> (state: ServeState, host: String?) {
         let run = runTailscale(["serve", "status", "--json"])
         guard run.foundCLI else {
-            return .unreadable("Toki couldn't run the tailscale command to check HTTPS.")
+            return (.unreadable("Toki couldn't run the tailscale command to check HTTPS."), nil)
         }
-        return serveState(from: run.data, port: port)
+        return (serveState(from: run.data, port: port), servedTailscaleHost(from: run.data))
     }
 
     // Why `tailscale serve` refused, in words, plus the one command that clears it where there is
@@ -1018,6 +1035,22 @@ final class RemoteControlServer: ObservableObject {
     nonisolated static func servedPort(fromWebKey key: String) -> Int? {
         guard let colon = key.lastIndex(of: ":") else { return nil }
         return Int(key[key.index(after: colon)...])
+    }
+
+    /// The `.ts.net` name `tailscale serve` says it is serving. When `tailscale status` cannot be
+    /// read - the Mac App Store build ships no usable CLI - this is a second source for the one
+    /// piece of information the connect link needs, and it is already on screen in serve's output.
+    nonisolated static func servedTailscaleHost(from data: Data?) -> String? {
+        guard let data,
+              let object = try? JSONSerialization.jsonObject(with: data),
+              let root = object as? [String: Any],
+              let web = root["Web"] as? [String: Any] else { return nil }
+        for key in web.keys.sorted() {
+            guard let colon = key.lastIndex(of: ":") else { continue }
+            let host = String(key[..<colon])
+            if isTailscaleDNSHost(host) { return host }
+        }
+        return nil
     }
 
     nonisolated static func serveState(from data: Data?, port: Int) -> ServeState {

--- a/Sources/Toki/Views/SettingsPanel.swift
+++ b/Sources/Toki/Views/SettingsPanel.swift
@@ -852,6 +852,15 @@ struct SettingsPanel: View {
                     }
                 }
 
+                // Toki decided not to run serve itself. Saying so beats a warning that reads as
+                // though nothing has happened yet.
+                if remoteServer.serveSetupFailure == nil, let skipped = remoteServer.autoServeSkipped {
+                    Text(skipped)
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
                 if let failure = remoteServer.serveSetupFailure {
                     VStack(alignment: .leading, spacing: 5) {
                         Text(failure.message)

--- a/Tests/TokiTests/RemoteControlServerTests.swift
+++ b/Tests/TokiTests/RemoteControlServerTests.swift
@@ -437,6 +437,26 @@ final class RemoteControlServerTests: XCTestCase {
         """), .conflict)
     }
 
+    // When `tailscale status` cannot be read, serve's own config still names the Mac - the same
+    // name the connect link needs, which was being typed in by hand instead.
+    func testTheServedHostIsLearnedFromServeStatus() {
+        let json = """
+        {"Web":{"mac.tail1234.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:8765"}}}}}
+        """
+        XCTAssertEqual(
+            RemoteControlServer.servedTailscaleHost(from: Data(json.utf8)),
+            "mac.tail1234.ts.net"
+        )
+    }
+
+    func testAServedHostThatIsNotATailnetNameIsIgnored() {
+        let json = """
+        {"Web":{"attacker.example.com:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:8765"}}}}}
+        """
+        XCTAssertNil(RemoteControlServer.servedTailscaleHost(from: Data(json.utf8)))
+        XCTAssertNil(RemoteControlServer.servedTailscaleHost(from: nil))
+    }
+
     func testParseTunnelHostFromCloudflaredOutput() {
         let text = """
         2026-07-29T10:00:00Z INF +----------------------------------------------------+


### PR DESCRIPTION
Closes #93. Builds on #99, which fixed the detection this gate reads.

**Auto-serve was gated on something it does not need.** It required a usable `.ts.net` host before running, but serving does not need one — `tailscale serve --bg http://127.0.0.1:<port>` works whatever the Mac is called. The name is only needed for the connect *link*. So on exactly the machines where `tailscale status` cannot be read — the Mac App Store build ships no usable CLI — the gate closed and serve silently never ran. That is the case that most needs to run itself.

**It also said nothing when it declined.** A conflict on 443 and a missing CLI are both deliberate refusals, and both left a row reading "`tailscale serve` isn't running" with an Enable button, as though Toki had not already decided. Each now says which it was.

**The name it was waiting for is in the output it already reads.** `tailscale serve status --json` is keyed by `<host>:<port>`, so where `status` cannot supply a `.ts.net` name, serve's own configuration can — and it is filled in rather than typed by hand. It goes through the same tailnet-name check as the detected name, so a host that is not a `.ts.net` name is refused rather than trusted as an API origin.

Between this and #99, the two halves of what you reported should now both be addressed: detection no longer misreads a working serve, and where serve genuinely is not running Toki starts it without needing the host name first.

## Tests

`servedTailscaleHost` gets cases for learning the host from a serve config and for refusing a non-tailnet name (and nil input). The auto-serve gate itself is `@MainActor` state on a singleton driven by shelling out to `tailscale`, so it is exercised by the checks around it rather than directly — the parsing it depends on is covered.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hohPTY9DSjEDSiseYo3Tw)_