### PR TITLE
Show a tool call finishing, and what it was actually doing

### DIFF
--- a/Sources/Toki/Resources/toki_remote.py
+++ b/Sources/Toki/Resources/toki_remote.py
@@ -524,7 +524,15 @@ def parse_claude_transcript(path, offset=0):
                         if block.get("type") == "text":
                             texts.append(block.get("text", ""))
                         elif block.get("type") == "tool_result":
-                            entries.append({"role": "resolved", "id": block.get("tool_use_id")})
+                            # The result's own content is deliberately not forwarded: it is
+                            # unbounded and is where file contents and command output live. What
+                            # travels is that the call finished, when, and whether it failed.
+                            entries.append({
+                                "role": "resolved",
+                                "id": block.get("tool_use_id"),
+                                "ts": j.get("timestamp"),
+                                "failed": bool(block.get("is_error")),
+                            })
                 for t in texts:
                     cleaned = clean_user_text(t)
                     if cleaned:
@@ -540,6 +548,8 @@ def parse_claude_transcript(path, offset=0):
                         entries.append({
                             "role": "tool", "tool": name, "id": block.get("id"),
                             "text": claude_tool_summary(name, inp),
+                            "detail": claude_tool_detail(name, inp),
+                            "ts": j.get("timestamp"),
                             "questions": extract_questions(name, inp),
                         })
         if "permissionMode" in j:
@@ -553,6 +563,39 @@ def claude_tool_summary(name, inp):
         if isinstance(v, str) and v.strip():
             return v.strip().splitlines()[0][:160]
     return ""
+
+
+# The one-line summary above picks whichever of six keys it finds first, which for a Bash call
+# with a description hides the command being run, and for an edit hides the file being edited.
+# This is the rest of the answer: what a call is actually about, per tool, still bounded.
+_TOOL_DETAIL_KEYS = {
+    "Bash": ("command",),
+    "Read": ("file_path", "offset", "limit"),
+    "Edit": ("file_path",),
+    "Write": ("file_path",),
+    "NotebookEdit": ("notebook_path",),
+    "Grep": ("pattern", "path", "glob"),
+    "Glob": ("pattern", "path"),
+    "WebFetch": ("url",),
+    "WebSearch": ("query",),
+    "Task": ("subagent_type",),
+}
+
+
+def claude_tool_detail(name, inp):
+    if not isinstance(inp, dict):
+        return ""
+    summary = claude_tool_summary(name, inp)
+    parts = []
+    for key in _TOOL_DETAIL_KEYS.get(name, ()):
+        value = inp.get(key)
+        if value in (None, "", []):
+            continue
+        text = " ".join(str(value).split())
+        # Don't repeat what the summary line already says.
+        if text and text != summary:
+            parts.append(text)
+    return " · ".join(parts)[:240]
 
 
 def extract_questions(name, inp):

--- a/Sources/Toki/Resources/webui/app.js
+++ b/Sources/Toki/Resources/webui/app.js
@@ -568,12 +568,54 @@ function clearPending() {
 let logSession = null;
 let logEpoch = 0;
 
+// Tool calls arrive before their results, so the row has to be found again when the result turns
+// up. Keyed by the tool_use id the transcript already carries.
+let toolNodes = {};
+
 function resetTranscript() {
   logEpoch++;
   logSession = null;
   offset = 0;
+  toolNodes = {};
   $("#log").innerHTML = "";
   clearPending();
+}
+
+// Whole seconds up to a minute, then minutes: a tool call's duration is interesting at a glance,
+// not to three decimal places.
+function shortDuration(ms) {
+  if (!(ms > 0)) return "";
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 1) return "";
+  if (seconds < 60) return seconds + "s";
+  return Math.floor(seconds / 60) + "m " + (seconds % 60) + "s";
+}
+
+function toolRow(e) {
+  const detail = e.detail && e.detail != e.text
+    ? '<span class="tool-detail">' + dispTitle(e.detail) + "</span>"
+    : "";
+  return '<span class="tool-state" aria-hidden="true"></span>&#128295; <b>' + esc(e.tool) + "</b> " +
+    dispTitle(e.text || "") + detail;
+}
+
+// The result carries no output - only that the call ended, when, and whether it failed. That is
+// enough to stop a finished call looking like one still running.
+function resolveToolNode(entry) {
+  const node = toolNodes[entry.id];
+  if (!node) return;
+  delete toolNodes[entry.id];
+  node.el.classList.remove("running");
+  node.el.classList.add(entry.failed ? "failed" : "ok");
+  const started = Date.parse(node.ts || "");
+  const ended = Date.parse(entry.ts || "");
+  const took = shortDuration(ended - started);
+  if (took) {
+    const stamp = document.createElement("span");
+    stamp.className = "tool-took";
+    stamp.textContent = took;
+    node.el.appendChild(stamp);
+  }
 }
 
 async function refreshLog() {
@@ -602,7 +644,11 @@ async function refreshLog() {
   const stick = nearBottom();
   let added = 0;
   for (const e of r.entries) {
-    if (e.role == "meta" || e.role == "resolved") continue;
+    if (e.role == "resolved") {
+      resolveToolNode(e);
+      continue;
+    }
+    if (e.role == "meta") continue;
     // The agent echoes back the message we optimistically showed; drop the placeholder so it isn't doubled.
     if (e.role == "user" && pendingEcho && e.text.trim() == pendingEcho.text) {
       pendingEcho.node.remove();
@@ -615,7 +661,11 @@ async function refreshLog() {
     if (!added) hideTyping();
     const d = document.createElement("div");
     d.className = "m " + e.role;
-    if (e.role == "tool") d.innerHTML = "&#128295; <b>" + esc(e.tool) + "</b> " + esc(e.text || "");
+    if (e.role == "tool") {
+      d.innerHTML = toolRow(e);
+      d.classList.add("running");
+      if (e.id) toolNodes[e.id] = { el: d, ts: e.ts };
+    }
     else if (e.role == "assistant") d.innerHTML = md(e.text);
     else d.textContent = e.text;
     $("#log").appendChild(d);

--- a/Sources/Toki/Resources/webui/styles.css
+++ b/Sources/Toki/Resources/webui/styles.css
@@ -203,6 +203,15 @@ body.privacy .eye-off{display:inline}
 .assistant tbody tr:nth-child(even){background:#ffffff06}
 .tool{background:var(--surface-2);border-color:var(--line);color:var(--text-2);font-size:13px;font-family:ui-monospace,monospace}
 .tool b{color:#c3cad6}
+/* A call that has not come back yet reads as in-flight rather than finished. The dot carries the
+   state so the row's text is unchanged when it resolves. */
+.tool-state{display:inline-block;width:6px;height:6px;border-radius:50%;margin-right:6px;vertical-align:middle;background:var(--line)}
+.tool.running .tool-state{background:#e2b341;animation:toolpulse 1.2s ease-in-out infinite}
+.tool.ok .tool-state{background:#4a9d5f}
+.tool.failed .tool-state{background:#d1544f}
+.tool-detail{display:block;margin:2px 0 0 12px;color:var(--text-3,#8b95a5);font-size:12px;word-break:break-all}
+.tool-took{margin-left:6px;color:var(--text-3,#8b95a5);font-size:11px}
+@keyframes toolpulse{0%,100%{opacity:1}50%{opacity:.35}}
 footer{flex:none;background:var(--surface-1);
        border-top:1px solid var(--line);padding:10px 14px calc(10px + env(safe-area-inset-bottom))}
 .keys{display:grid;grid-template-columns:repeat(8,minmax(0,1fr));gap:6px;margin-bottom:8px}

--- a/Tests/test_remote_control_server.py
+++ b/Tests/test_remote_control_server.py
@@ -386,5 +386,61 @@ class RemoteControlDisplayPathTests(unittest.TestCase):
         self.assertEqual(toki_remote.display_path(""), "")
 
 
+class ClaudeToolEntryTests(unittest.TestCase):
+    """What a tool call sends to the phone: enough to follow it, never its output."""
+
+    def _entries(self, lines):
+        with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as handle:
+            for line in lines:
+                handle.write(json.dumps(line) + "\n")
+            path = handle.name
+        entries, _ = toki_remote.parse_claude_transcript(path, 0)
+        return entries
+
+    def test_a_call_carries_its_id_time_and_what_it_is_doing(self):
+        entries = self._entries([{
+            "type": "assistant",
+            "timestamp": "2026-08-11T10:00:00.000Z",
+            "message": {"content": [{
+                "type": "tool_use", "id": "tu_1", "name": "Bash",
+                "input": {"description": "List files", "command": "ls -la /tmp"},
+            }]},
+        }])
+        call = next(e for e in entries if e["role"] == "tool")
+        self.assertEqual(call["id"], "tu_1")
+        self.assertEqual(call["ts"], "2026-08-11T10:00:00.000Z")
+        # The summary picks the description; the detail is what is actually being run, which the
+        # single-line summary hid.
+        self.assertEqual(call["text"], "List files")
+        self.assertEqual(call["detail"], "ls -la /tmp")
+
+    def test_a_result_reports_completion_and_failure_but_never_its_output(self):
+        entries = self._entries([{
+            "type": "user",
+            "timestamp": "2026-08-11T10:00:04.000Z",
+            "message": {"content": [{
+                "type": "tool_result", "tool_use_id": "tu_1", "is_error": True,
+                "content": "SECRET_TOKEN=hunter2 leaked all over stdout",
+            }]},
+        }])
+        resolved = next(e for e in entries if e["role"] == "resolved")
+        self.assertEqual(resolved["id"], "tu_1")
+        self.assertEqual(resolved["ts"], "2026-08-11T10:00:04.000Z")
+        self.assertTrue(resolved["failed"])
+        # Tool output is where file contents and command output live; none of it leaves the Mac.
+        self.assertNotIn("hunter2", json.dumps(resolved))
+
+    def test_detail_does_not_repeat_the_summary(self):
+        self.assertEqual(toki_remote.claude_tool_detail("Bash", {"command": "ls"}), "")
+        self.assertEqual(
+            toki_remote.claude_tool_detail("Grep", {"pattern": "todo", "path": "src"}),
+            "src",
+        )
+
+    def test_detail_is_bounded(self):
+        detail = toki_remote.claude_tool_detail("Bash", {"description": "x", "command": "y" * 900})
+        self.assertLessEqual(len(detail), 240)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Tests/test_remote_pwa.js
+++ b/Tests/test_remote_pwa.js
@@ -245,4 +245,26 @@ assert.match(app, /detail\.includes\("bad token"\)/);
 // --- Coming back to a backgrounded tab polls immediately ---
 assert.match(app, /addEventListener\("visibilitychange"/);
 
+// --- Tool calls show that they finished, and how long they took ---
+// The transcript already carried tool_result entries; the client dropped them, so every call sat
+// looking like it was still running.
+assert.match(app, /function resolveToolNode/);
+assert.match(app, /toolNodes\[entry\.id\]/);
+assert.match(app, /classList\.add\(entry\.failed \? "failed" : "ok"\)/);
+assert.match(css, /\.tool\.running \.tool-state/);
+assert.match(css, /\.tool\.failed \.tool-state/);
+
+const durationSource = app.match(/^function shortDuration\([\s\S]*?^}/m);
+assert.ok(durationSource, "shortDuration must be a top-level function in app.js");
+const duration = vm.createContext({ Math });
+vm.runInContext(durationSource[0], duration);
+const took = ms => vm.runInContext("shortDuration", duration)(ms);
+assert.equal(took(2400), "2s");
+assert.equal(took(65000), "1m 5s");
+// A call that returned instantly says nothing rather than "0s", and a missing timestamp on either
+// end must not render "NaN".
+assert.equal(took(200), "");
+assert.equal(took(NaN), "");
+assert.equal(took(-5), "");
+
 console.log("remote pwa + qr + ux tests passed");


### PR DESCRIPTION
Addresses #91 — points 1, 2 and 4 of the plan in that issue's feasibility comment. Point 3 (result bodies) is deliberately left out; see below.

**Completion was already being sent and thrown away.** Every `tool_result` became a `{"role": "resolved", "id": ...}` entry, and the client skipped those outright — so a call that returned a second ago looked exactly like one still running, and a failure looked like a success. Calls now show as in-flight until their result arrives, then settle as succeeded or failed, with how long they took where both timestamps are known.

**The summary was hiding the interesting part.** `claude_tool_summary` returns whichever of six input keys it finds first, so a Bash call with a `description` never showed the command, and an edit never showed the file. A second line now carries what the call is about, per tool (`Bash` → command, `Grep` → pattern/path/glob, `Read`/`Edit`/`Write` → path, and so on), bounded to 240 characters and suppressed when it would repeat the summary.

Timestamps (`ts`) are now included on both the call and its result — they were already in the JSONL, just not forwarded.

## What is deliberately not here

Result **content**. It is unbounded — a wide grep or a file read is megabytes against a 2.5-second incremental poll — and it is precisely where file contents and command output live, which is where secrets surface (`.env` reads, `printenv`, a curl echoing a token). Completion, timing and failure are enough to follow a run without moving any of that off the Mac. There is a test asserting a `tool_result` body never reaches the phone, so this stays a decision rather than something that erodes.

Bringing over a capped, redacted preview is worth doing, but it is a decision about redaction rather than a side effect of this change. #91 stays open for it.

## Tests

Python: a call carries its id, timestamp and detail; a result reports completion and failure but never its output (asserted against a payload containing a fake secret); detail does not repeat the summary and is bounded.

JS: `shortDuration` formats seconds and minutes and stays silent for sub-second, `NaN` and negative gaps — so a missing timestamp on either end cannot render "NaN"; plus the resolve path and the running/failed styling.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hohPTY9DSjEDSiseYo3Tw)_