### PR TITLE
Make the links in a companion app message tappable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **A first run lists everything Toki will ever ask for, and can ask for it all at once.** **Allow all** requests them one dialog at a time, Accessibility last; refusing one only turns off what it was for. The list survives connecting an account and includes starting Toki at login. Afterwards rows appear only when they apply to your Mac, and a permission you refused offers System Settings instead of an **Allow** button macOS would ignore.
 - **Quota on your phone.** The companion app shows a strip with the account that has least left, expanding to the full list on tap. It is the same reading the Mac renders, so the two cannot disagree, and a reading the Mac stopped refreshing says so.
 - **Tool calls in the companion app show that they finished.** Calls now show as in flight, then succeeded or failed, with how long they took and a second line saying what the call is actually doing. Tool output stays on the Mac.
+- **A link in the companion app is a link you can tap.** Agents print URLs far more often than they write Markdown links, and until now a bare one was text you had to retype on a phone. Every message linkifies them: the agent's replies, the question in an approval prompt, the messages you send, and the target of a tool call. Links open in a new tab, only `http` and `https` are ever linked, and a URL inside code or a code block is still left as text. The full stop that ends the sentence stays out of the link, and so does a closing bracket the URL never opened.
 
 ### Changed
 

--- a/Sources/Toki/Resources/webui/app.js
+++ b/Sources/Toki/Resources/webui/app.js
@@ -151,6 +151,12 @@ function dispPath(p) {
   return privacyMode ? maskText(p) : esc(p);
 }
 
+// For the text of a tool row, which is often the URL the call is fetching. Masking still wins:
+// a masked row has nothing left worth linking.
+function dispLinked(t) {
+  return privacyMode ? maskText(t) : linkify(t);
+}
+
 // The session token rides in the Authorization header rather than the query string, so it stays
 // out of the phone's history and out of the request line any proxy in front of the Mac writes to
 // its log -- Cloudflare's, on the tunnel path.
@@ -419,6 +425,9 @@ function esc(s) {
 }
 
 const md = renderMarkdown;
+// Escapes and links in one step, for the messages that are not Markdown. Every caller assigns the
+// result to innerHTML, so nothing may reach it that has not been through here or esc().
+const linkify = renderMarkdown.linkify;
 
 const LOGOS = {
   claude: '<svg class="plogo" viewBox="0 0 100 100" fill="#d97757"><path d="m19.6 66.5 19.7-11 .3-1-.3-.5h-1l-3.3-.2-11.2-.3L14 53l-9.5-.5-2.4-.5L0 49l.2-1.5 2-1.3 2.9.2 6.3.5 9.5.6 6.9.4L38 49.1h1.6l.2-.7-.5-.4-.4-.4L29 41l-10.6-7-5.6-4.1-3-2-1.5-2-.6-4.2 2.7-3 3.7.3.9.2 3.7 2.9 8 6.1L37 36l1.5 1.2.6-.4.1-.3-.7-1.1L33 25l-6-10.4-2.7-4.3-.7-2.6c-.3-1-.4-2-.4-3l3-4.2L28 0l4.2.6L33.8 2l2.6 6 4.1 9.3L47 29.9l2 3.8 1 3.4.3 1h.7v-.5l.5-7.2 1-8.7 1-11.2.3-3.2 1.6-3.8 3-2L61 2.6l2 2.9-.3 1.8-1.1 7.7L59 27.1l-1.5 8.2h.9l1-1.1 4.1-5.4 6.9-8.6 3-3.5L77 13l2.3-1.8h4.3l3.1 4.7-1.4 4.9-4.4 5.6-3.7 4.7-5.3 7.1-3.2 5.7.3.4h.7l12-2.6 6.4-1.1 7.6-1.3 3.5 1.6.4 1.6-1.4 3.4-8.2 2-9.6 2-14.3 3.3-.2.1.2.3 6.4.6 2.8.2h6.8l12.6 1 3.3 2 1.9 2.7-.3 2-5.1 2.6-6.8-1.6-16-3.8-5.4-1.3h-.8v.4l4.6 4.5 8.3 7.5L89 80.1l.5 2.4-1.3 2-1.4-.2-9.2-7-3.6-3-8-6.8h-.5v.7l1.8 2.7 9.8 14.7.5 4.5-.7 1.4-2.6 1-2.7-.6-5.8-8-6-9-4.7-8.2-.5.4-2.9 30.2-1.3 1.5-3 1.2-2.5-2-1.4-3 1.4-6.2 1.6-8 1.3-6.4 1.2-7.9.7-2.6v-.2H49L43 72l-9 12.3-7.2 7.6-1.7.7-3-1.5.3-2.8L24 86l10-12.8 6-7.9 4-4.6-.1-.5h-.3L17.2 77.4l-4.7.6-2-2 .2-3 1-1 8-5.5Z"/></svg>',
@@ -616,7 +625,9 @@ let pendingEcho = null;
 function addEcho(text) {
   const d = document.createElement("div");
   d.className = "m user pending";
-  d.textContent = text;
+  // Linked here as well as when the transcript echoes it back, so a message does not change
+  // appearance under you the moment the agent confirms it.
+  d.innerHTML = linkify(text);
   $("#log").appendChild(d);
   pendingEcho = { node: d, text: text.trim() };
 }
@@ -685,10 +696,10 @@ function shortDuration(ms) {
 
 function toolRow(e) {
   const detail = e.detail && e.detail != e.text
-    ? '<span class="tool-detail">' + dispTitle(e.detail) + "</span>"
+    ? '<span class="tool-detail">' + dispLinked(e.detail) + "</span>"
     : "";
   return '<span class="tool-state" aria-hidden="true"></span>&#128295; <b>' + esc(e.tool) + "</b> " +
-    dispTitle(e.text || "") + detail;
+    dispLinked(e.text || "") + detail;
 }
 
 // The result carries no output, only that the call ended, when, and whether it failed: enough to
@@ -763,7 +774,9 @@ async function refreshLog() {
       }
     }
     else if (e.role == "assistant") d.innerHTML = md(e.text);
-    else d.textContent = e.text;
+    // Your own messages stay verbatim -- no Markdown, and the bubble's pre-wrap keeps the line
+    // breaks -- but a URL in one is as worth tapping as a URL in a reply.
+    else d.innerHTML = linkify(e.text);
     $("#log").appendChild(d);
     added++;
   }
@@ -856,8 +869,11 @@ document.addEventListener("click", async e => {
 });
 
 $("#log").addEventListener("click", e => {
+  // A link inside a failed message opens the link; tapping the bubble around it retries the send.
+  if (e.target.closest("a")) return;
   const f = e.target.closest(".m.user.failed");
   if (!f) return;
+  // textContent, not the linked markup: a retry has to send what was typed, not what it renders as.
   const text = f.textContent;
   f.remove();
   feedback("tap");

--- a/Sources/Toki/Resources/webui/markdown.js
+++ b/Sources/Toki/Resources/webui/markdown.js
@@ -80,9 +80,15 @@
     // separately would let the bare-URL pass find the href the written one had just produced and
     // nest a second anchor inside the first.
     text = text.replace(
-      new RegExp("\\[([^\\]]+)\\]\\((https?:[^)\\s]+)\\)|" + BARE_URL.source, "gu"),
+      new RegExp("\\[([^\\]]+)\\]\\(([^)\\s]*)\\)|" + BARE_URL.source, "gu"),
       function(match, label, href) {
-        return href ? anchor(href, label) : linkURL(match);
+        // A written link is matched whatever its destination, but only followed when that
+        // destination is one this renderer will open. The rest -- a relative path, an anchor, a
+        // mailto -- stays the plain text it has always been. Matching only the http ones here
+        // would drop the others through to the bare-URL branch, which would then find a URL in
+        // the label and swallow the "](destination)" after it into the href.
+        if (label !== undefined) return /^https?:/.test(href) ? anchor(href, label) : match;
+        return linkURL(match);
       }
     );
     return text.replace(/\u0001C(\d+)\u0001/g, function(_, index) {

--- a/Sources/Toki/Resources/webui/markdown.js
+++ b/Sources/Toki/Resources/webui/markdown.js
@@ -12,6 +12,62 @@
       .replace(/'/g, "&#39;");
   }
 
+  function anchor(href, label) {
+    return '<a href="' + href + '" target="_blank" rel="noopener noreferrer">' + label + "</a>";
+  }
+
+  function countChar(value, char) {
+    let total = 0;
+    for (let index = 0; index < value.length; index++) {
+      if (value[index] === char) total++;
+    }
+    return total;
+  }
+
+  // Where a bare URL actually ends. What surrounds it is prose, so a trailing full stop or comma
+  // belongs to the sentence, and a closing bracket belongs to the URL only if the URL opened it.
+  // Escaping has already run by this point, so a delimiter that wrapped the URL arrives as an
+  // entity -- &gt; from <url>, &quot; from "url" -- and has to come off whole, while the semicolon
+  // ending an &amp; inside a query string has to stay on.
+  function urlEnd(url) {
+    let end = url.length;
+    while (end > 0) {
+      const head = url.slice(0, end);
+      const wrapper = head.match(/&(?:gt|quot|#39);$/);
+      if (wrapper) {
+        end -= wrapper[0].length;
+        continue;
+      }
+      const last = head[end - 1];
+      if (last === ";" && /&(?:#\d+|[a-zA-Z]+);$/.test(head)) break;
+      if (".,;:!?".indexOf(last) >= 0) {
+        end--;
+        continue;
+      }
+      if (last === ")" && countChar(head, "(") < countChar(head, ")")) {
+        end--;
+        continue;
+      }
+      break;
+    }
+    return end;
+  }
+
+  // A bare URL runs to whitespace, to a "<" (escaping has already run, so a raw one can only be
+  // markup this renderer produced), or to a control character, which no URL contains and which is
+  // what a stashed code span is left behind as.
+  const BARE_URL = /https?:\/\/[^\s<\p{Cc}]+/gu;
+
+  // A bare URL, linked from wherever it ends up: the prose an agent writes, a line of a table, the
+  // question in an approval prompt. Only http(s) is matched, so no anchor this produces can carry
+  // a javascript: or data: target, and the URL has already been escaped by the time it lands in
+  // the href.
+  function linkURL(match) {
+    const url = match.slice(0, urlEnd(match));
+    if (!/^https?:\/\/[^\s<]/.test(url)) return match;
+    return anchor(url, url) + match.slice(url.length);
+  }
+
   function inlineMarkdown(value) {
     const codes = [];
     let text = value.replace(/`([^`\n]+)`/g, function(_, code) {
@@ -20,9 +76,14 @@
     });
     text = text.replace(/\*\*([^*]+)\*\*/g, "<b>$1</b>");
     text = text.replace(/(^|[^*])\*([^*\n]+)\*(?!\*)/g, "$1<i>$2</i>");
+    // Written links and bare ones in a single pass, the written form first: matching them
+    // separately would let the bare-URL pass find the href the written one had just produced and
+    // nest a second anchor inside the first.
     text = text.replace(
-      /\[([^\]]+)\]\((https?:[^)\s]+)\)/g,
-      '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>'
+      new RegExp("\\[([^\\]]+)\\]\\((https?:[^)\\s]+)\\)|" + BARE_URL.source, "gu"),
+      function(match, label, href) {
+        return href ? anchor(href, label) : linkURL(match);
+      }
     );
     return text.replace(/\u0001C(\d+)\u0001/g, function(_, index) {
       return "<code>" + codes[Number(index)] + "</code>";
@@ -99,7 +160,7 @@
     };
   }
 
-  return function renderMarkdown(source) {
+  function renderMarkdown(source) {
     let text = escapeHTML(source);
     const fences = [];
     text = text.replace(/```[a-zA-Z0-9_-]*\n([\s\S]*?)```/g, function(_, code) {
@@ -137,5 +198,16 @@
       index++;
     }
     return output.join("");
+  }
+
+  // The same links for text that is not Markdown: a message you typed, the target of a tool call.
+  // Nothing else in the string is interpreted, so a reply of "**not bold**" still reads as it was
+  // typed, and the escape runs first so this is safe on anything.
+  renderMarkdown.linkify = function(source) {
+    return escapeHTML(source == null ? "" : source).replace(BARE_URL, function(match) {
+      return linkURL(match);
+    });
   };
+
+  return renderMarkdown;
 });

--- a/Sources/Toki/Resources/webui/styles.css
+++ b/Sources/Toki/Resources/webui/styles.css
@@ -156,6 +156,10 @@ body.privacy .eye-off{display:inline}
 #alert .qq p{margin:5px 0}
 #alert .qq code{background:#0006;padding:1px 5px;border-radius:5px;
                 font-family:ui-monospace,monospace;font-size:13px}
+/* The panel is saturated blue when it asks and saturated red when it wants approval, so a link in
+   the question is set in white rather than a colour that only works against one of them. */
+#alert .qq a{color:#fff;text-decoration:underline;text-underline-offset:2px;
+             overflow-wrap:anywhere}
 #alert .qq:not(:first-of-type){margin-top:14px;padding-top:12px;border-top:1px solid #ffffff1a}
 #readonly{display:none;margin:10px 14px;padding:11px 12px;border-radius:var(--r);
           background:var(--warn-surface);border:1px solid var(--warn-line);color:#e2cc8c;font-size:13px}
@@ -173,6 +177,13 @@ body.privacy .eye-off{display:inline}
 #log{flex:1;min-height:0;overflow-y:auto;-webkit-overflow-scrolling:touch;padding:8px 14px}
 .m{margin:8px 0;padding:10px 13px;border-radius:var(--r-lg);max-width:88%;border:1px solid transparent;
    word-break:break-word;overflow-wrap:anywhere}
+/* A link has to look like one before it is tapped, in every kind of message: colour alone is not
+   enough against these surfaces, and a bare URL wraps mid-string on a phone. */
+.m a{color:var(--accent-2);text-decoration:underline;text-underline-offset:2px;
+     overflow-wrap:anywhere}
+.m a:active{opacity:.7}
+/* Blue on the green bubble is the one place the accent fights its background. */
+.user a{color:#9adcb4}
 .user{background:var(--user-surface);border-color:var(--user-line);margin-left:auto;
       border-bottom-right-radius:var(--tail);white-space:pre-wrap}
 .m.pending{opacity:.55}
@@ -191,7 +202,6 @@ body.privacy .eye-off{display:inline}
 .assistant code{background:#0f1118;padding:1px 5px;border-radius:5px;
                 font-family:ui-monospace,monospace;font-size:13px}
 .assistant p{margin:5px 0}
-.assistant a{color:var(--accent-2)}
 .assistant .table-wrap{max-width:100%;margin:8px 0;overflow-x:auto;
                        border:1px solid var(--line);border-radius:var(--r-sm)}
 .assistant table{width:100%;min-width:max-content;border-collapse:collapse;font-size:13px}

--- a/Tests/test_markdown.js
+++ b/Tests/test_markdown.js
@@ -23,4 +23,65 @@ assert.match(escaped, /<td style="text-align:left">a \| b<\/td>/);
 assert.doesNotMatch(escaped, /<script>/);
 assert.match(escaped, /&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
 
-console.log("markdown table tests passed");
+// A bare URL is linked, and the sentence it sits in keeps its punctuation.
+const bare = renderMarkdown("See https://github.com/aashutoshrathi/toki for the source.");
+assert.match(
+  bare,
+  /<a href="https:\/\/github\.com\/aashutoshrathi\/toki" target="_blank" rel="noopener noreferrer">https:\/\/github\.com\/aashutoshrathi\/toki<\/a> for the source\./
+);
+
+const trailing = renderMarkdown("Open https://toki.aashutosh.dev/docs, then https://example.com.");
+assert.match(trailing, /<a href="https:\/\/toki\.aashutosh\.dev\/docs"[^>]*>https:\/\/toki\.aashutosh\.dev\/docs<\/a>, then/);
+assert.match(trailing, /<a href="https:\/\/example\.com"[^>]*>https:\/\/example\.com<\/a>\.<\/p>/);
+
+// A bracket closes the URL only when the URL opened it.
+const brackets = renderMarkdown("(see https://example.com/a) and https://en.wikipedia.org/wiki/Foo_(bar)");
+assert.match(brackets, /href="https:\/\/example\.com\/a"/);
+assert.match(brackets, /<\/a>\) and/);
+assert.match(brackets, /href="https:\/\/en\.wikipedia\.org\/wiki\/Foo_\(bar\)"/);
+
+// A written link is left alone rather than linked twice, and its text is not a URL to hunt for.
+const written = renderMarkdown("[the repo](https://github.com/aashutoshrathi/toki) and nothing else");
+assert.equal(written.match(/<a /g).length, 1);
+assert.match(written, /<a href="https:\/\/github\.com\/aashutoshrathi\/toki"[^>]*>the repo<\/a>/);
+assert.doesNotMatch(renderMarkdown("[https://a.example](https://b.example)"), /<a[^>]*><a /);
+
+// Escaping runs first, so an "&" in a query string survives into the href, while the "<>" or
+// quotes that wrapped a URL are not swallowed by it.
+const query = renderMarkdown("https://example.com/s?a=1&b=2 done");
+assert.match(query, /href="https:\/\/example\.com\/s\?a=1&amp;b=2"/);
+assert.match(query, /<\/a> done<\/p>/);
+const wrapped = renderMarkdown("<https://example.com/x> and \"https://example.com/y\"");
+assert.match(wrapped, /href="https:\/\/example\.com\/x"/);
+assert.match(wrapped, /<\/a>&gt; and/);
+assert.match(wrapped, /href="https:\/\/example\.com\/y"/);
+assert.match(wrapped, /<\/a>&quot;<\/p>/);
+
+// Code keeps its URLs as text: a fenced block and an inline span are both left unlinked.
+assert.doesNotMatch(renderMarkdown("```\ncurl https://example.com\n```"), /<a /);
+assert.doesNotMatch(renderMarkdown("run `curl https://example.com` now"), /<a /);
+
+// Nothing but http(s) is linked, so a scheme that would run script cannot become a target.
+assert.doesNotMatch(renderMarkdown("javascript:alert(1) and data:text/html,x"), /<a /);
+assert.doesNotMatch(renderMarkdown("[x](javascript:alert(1))"), /<a /);
+
+// Links inside a table cell work the same way.
+const cellLink = renderMarkdown([
+  "| Name | Where |",
+  "| --- | --- |",
+  "| Toki | https://toki.aashutosh.dev |"
+].join("\n"));
+assert.match(cellLink, /<td style="text-align:left"><a href="https:\/\/toki\.aashutosh\.dev"/);
+
+// linkify: plain text, links only, with everything else left exactly as typed.
+assert.equal(
+  renderMarkdown.linkify("ship https://example.com/a?x=1&y=2 now"),
+  'ship <a href="https://example.com/a?x=1&amp;y=2" target="_blank" rel="noopener noreferrer">' +
+    "https://example.com/a?x=1&amp;y=2</a> now"
+);
+assert.equal(renderMarkdown.linkify("**not bold** and `not code`"), "**not bold** and `not code`");
+assert.equal(renderMarkdown.linkify(""), "");
+assert.doesNotMatch(renderMarkdown.linkify("<script>alert(1)</script>"), /<script>/);
+assert.doesNotMatch(renderMarkdown.linkify("javascript:alert(1)"), /<a /);
+
+console.log("markdown table and link tests passed");

--- a/Tests/test_markdown.js
+++ b/Tests/test_markdown.js
@@ -46,6 +46,16 @@ assert.equal(written.match(/<a /g).length, 1);
 assert.match(written, /<a href="https:\/\/github\.com\/aashutoshrathi\/toki"[^>]*>the repo<\/a>/);
 assert.doesNotMatch(renderMarkdown("[https://a.example](https://b.example)"), /<a[^>]*><a /);
 
+// A written link this renderer will not open stays plain text, label and all. The bare-URL pass
+// must not reach a URL sitting in that label and swallow the "](destination)" after it.
+for (const inert of [
+  "[https://toki.aashutosh.dev](/docs/setup)",
+  "[https://toki.aashutosh.dev](#anchor)",
+  "[see https://a.example](mailto:someone@example.com)",
+]) {
+  assert.doesNotMatch(renderMarkdown(inert), /<a /, inert + " should not link");
+}
+
 // Escaping runs first, so an "&" in a query string survives into the href, while the "<>" or
 // quotes that wrapped a URL are not swallowed by it.
 const query = renderMarkdown("https://example.com/s?a=1&b=2 done");

--- a/Tests/test_remote_ux.js
+++ b/Tests/test_remote_ux.js
@@ -64,6 +64,20 @@ assert.match(app, /if\s*\(ok\)\s*resetTranscript\(\)/);
 assert.match(app, /const epoch = logEpoch/);
 assert.match(app, /if\s*\(epoch\s*!=\s*logEpoch\)\s*return/);
 assert.match(app, /r\.session\s*!==\s*logSession/);
+// Every kind of message links its URLs: the agent's reply through the Markdown renderer, your own
+// messages and the tool rows through linkify, which escapes as it goes.
+assert.match(app, /const linkify = renderMarkdown\.linkify/);
+assert.match(app, /d\.innerHTML = linkify\(e\.text\)/);
+assert.match(app, /d\.innerHTML = linkify\(text\)/);
+assert.match(app, /function dispLinked/);
+assert.match(app, /dispLinked\(e\.text \|\| ""\)/);
+assert.match(app, /dispLinked\(e\.detail\)/);
+// Tapping a link inside a message that failed to send opens the link instead of retrying the send.
+assert.match(app, /if\s*\(e\.target\.closest\("a"\)\)\s*return/);
+assert.match(css, /\.m a\{/);
+assert.match(css, /\.user a\{/);
+assert.match(css, /#alert \.qq a\{/);
+
 // Restyled question banner (header label + badge/label option layout) and film grain.
 assert.match(app, /class="ahead"/);
 assert.match(app, /<b>\$\{i\s*\+\s*1\}<\/b><span>\$\{esc\(o\)\}<\/span>/);


### PR DESCRIPTION
Third beta of 2.7.0.

Agents print bare URLs far more often than they write Markdown links, and the companion app's renderer only ever linked the written `[label](url)` form. The common case — an agent handing you a PR link, a preview URL, a docs page — arrived on the phone as text you had to retype by hand.

## What changed

Bare `http(s)` URLs are now linked wherever a message is rendered:

| Where | How |
| :--- | :--- |
| The agent's replies | the Markdown renderer, alongside written links |
| The question in an approval prompt | same renderer, already used there |
| The messages you send | a plain-text linkifier `markdown.js` now exports |
| The target of a tool call | same linkifier, behind the privacy mask |

Written and bare links are matched in a single pass, the written form first. Matching them separately would let the bare-URL scan find the `href` the written one had just produced and nest a second anchor inside the first. Code spans and fenced blocks are stashed before the scan, so `` `curl https://example.com` `` still renders as text.

### Where a bare URL ends

The fiddly part, since a URL sits in prose:

- trailing sentence punctuation (`.`, `,`, `:`, `;`, `!`, `?`) stays out of the link
- a closing bracket comes off unless the URL opened it, so `https://en.wikipedia.org/wiki/Foo_(bar)` survives intact while `(see https://example.com/a)` does not swallow the bracket
- escaping runs first, so a delimiter that wrapped the URL arrives as an entity — `&gt;` from `<url>`, `&quot;` from `"url"` — and is removed whole, while the semicolon ending an `&amp;` inside a query string stays on

### Safety

Only `http` and `https` are matched, so no anchor this produces can carry a `javascript:` or `data:` target. Every string is escaped before it is scanned, so the URL that lands in the `href` is already escaped and cannot break out of the attribute. Links keep the `target="_blank" rel="noopener noreferrer"` the written form already used, and the server's `Referrer-Policy: no-referrer` means following one tells the destination nothing.

### Interaction and styling

Tapping a link inside a message that failed to send now opens the link; tapping the bubble around it still retries the send.

Links are underlined rather than distinguished by colour alone, and wrap mid-string so a long URL cannot push a bubble off a phone screen. The user bubble uses a green link colour, since the accent blue fights that green background, and a link in the approval panel is set in white because that panel is saturated blue when it asks and saturated red when it wants approval.

## Tests

`Tests/test_markdown.js` covers the linking rules directly: bare URLs, trailing punctuation, brackets, written links not being double-linked, query-string escaping, wrapped URLs, code spans and fences staying plain, non-http schemes being ignored, links in table cells, and the `linkify` export leaving everything but URLs verbatim. `Tests/test_remote_ux.js` asserts the app wiring and the new styles.

Rendered at 390px in Chromium against the real `styles.css` and `markdown.js` to check contrast on all four surfaces (approval panel, user bubble, assistant bubble, tool row) and confirm every anchor carries the right `href`, `target`, and `rel`.

```
$ for t in Tests/test_*.js; do node "$t"; done
markdown table and link tests passed
...
remote mobile UX tests passed

$ python3 -m unittest discover -s Tests -p 'test_*.py'
Ran 58 tests in 0.007s
OK
```
