### PR TITLE
Fix Tailscale serve/status warning caused by the GUI-wrapper CLI

### DIFF
--- a/Sources/Toki/Server/RemoteControlServer.swift
+++ b/Sources/Toki/Server/RemoteControlServer.swift
@@ -604,10 +604,18 @@ final class RemoteControlServer: ObservableObject {
         interfaceIPv4Addresses().first { isTailscaleAddress($0.ip) }?.ip
     }
 
+    nonisolated static func tailscaleJSONObject(from data: Data?) -> [String: Any]? {
+        guard let data, !data.isEmpty else { return nil }
+        if let object = try? JSONSerialization.jsonObject(with: data), let root = object as? [String: Any] {
+            return root
+        }
+        guard let brace = data.firstIndex(of: UInt8(ascii: "{")) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: data[brace...])) as? [String: Any]
+    }
+
     nonisolated static func tailscaleDNSName(from statusData: Data) -> String? {
         guard
-            let object = try? JSONSerialization.jsonObject(with: statusData),
-            let status = object as? [String: Any],
+            let status = tailscaleJSONObject(from: statusData),
             let selfNode = status["Self"] as? [String: Any],
             let rawName = selfNode["DNSName"] as? String
         else {
@@ -621,8 +629,7 @@ final class RemoteControlServer: ObservableObject {
 
     nonisolated static func rawSelfDNSName(from statusData: Data) -> String? {
         guard
-            let object = try? JSONSerialization.jsonObject(with: statusData),
-            let status = object as? [String: Any],
+            let status = tailscaleJSONObject(from: statusData),
             let selfNode = status["Self"] as? [String: Any]
         else {
             return nil
@@ -684,11 +691,11 @@ final class RemoteControlServer: ObservableObject {
     private nonisolated static func tailscaleExecutable() -> URL {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         let candidates = [
-            "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
             "/opt/homebrew/bin/tailscale",
             "/usr/local/bin/tailscale",
             "/usr/bin/tailscale",
-            "\(home)/.local/bin/tailscale"
+            "\(home)/.local/bin/tailscale",
+            "/Applications/Tailscale.app/Contents/MacOS/Tailscale"
         ]
         if let path = candidates.first(where: FileManager.default.isExecutableFile(atPath:)) {
             return URL(fileURLWithPath: path)
@@ -813,10 +820,7 @@ final class RemoteControlServer: ObservableObject {
     // right fix. "MagicDNS is off" is claimed only for a running node that really reports no name;
     // every other way of failing to read one says so instead of accusing a setting that may be on.
     nonisolated static func statusDiagnostic(from data: Data) -> String {
-        guard
-            let object = try? JSONSerialization.jsonObject(with: data),
-            let status = object as? [String: Any]
-        else {
+        guard let status = tailscaleJSONObject(from: data) else {
             return "Couldn't read Tailscale's status. Enter the host by hand."
         }
         if let backend = status["BackendState"] as? String, backend != "Running" {
@@ -1059,9 +1063,7 @@ final class RemoteControlServer: ObservableObject {
 
     /// The `.ts.net` host `tailscale serve` reports, used when `tailscale status` can't supply the name.
     nonisolated static func servedTailscaleHost(from data: Data?) -> String? {
-        guard let data,
-              let object = try? JSONSerialization.jsonObject(with: data),
-              let root = object as? [String: Any],
+        guard let root = tailscaleJSONObject(from: data),
               let web = root["Web"] as? [String: Any] else { return nil }
         for key in web.keys.sorted() {
             guard let colon = key.lastIndex(of: ":") else { continue }
@@ -1075,7 +1077,7 @@ final class RemoteControlServer: ObservableObject {
         guard let data else {
             return .unreadable("Toki couldn't read `tailscale serve status`.")
         }
-        guard let object = try? JSONSerialization.jsonObject(with: data), let root = object as? [String: Any] else {
+        guard let root = tailscaleJSONObject(from: data) else {
             return .unreadable("Tailscale's serve status wasn't readable.")
         }
         // Valid JSON with no Web map is a real "not serving", not a read failure.

--- a/Tests/TokiTests/RemoteControlServerTests.swift
+++ b/Tests/TokiTests/RemoteControlServerTests.swift
@@ -172,6 +172,43 @@ final class RemoteControlServerTests: XCTestCase {
         XCTAssertNil(RemoteControlServer.tailscaleDNSName(from: data))
     }
 
+    func testTailscaleDNSNameSurvivesAVersionSkewWarningPrefix() {
+        let data = Data("""
+        Warning: client version "1.98.5" != tailscaled server version "1.102.2"
+        {"Self":{"DNSName":"my-mac.example-tailnet.ts.net."}}
+        """.utf8)
+
+        XCTAssertEqual(
+            RemoteControlServer.tailscaleDNSName(from: data),
+            "my-mac.example-tailnet.ts.net"
+        )
+    }
+
+    func testStatusDiagnosticTreatsTheGUIWrapperErrorAsUnreadable() {
+        let data = Data("The Tailscale GUI failed to start: The operation couldn’t be completed. (Tailscale.CLIError error 3.)".utf8)
+
+        XCTAssertEqual(
+            RemoteControlServer.statusDiagnostic(from: data),
+            "Couldn't read Tailscale's status. Enter the host by hand."
+        )
+    }
+
+    func testServeStateSurvivesAVersionSkewWarningPrefix() {
+        let json = """
+        Warning: client version "1.98.5" != tailscaled server version "1.102.2"
+        {"Web":{"mac.tail1234.ts.net:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:8765"}}}}}
+        """
+        XCTAssertEqual(serveState(json), .ready)
+    }
+
+    func testServeStateReportsGUIWrapperErrorAsUnreadable() {
+        let data = Data("The Tailscale GUI failed to start: The operation couldn’t be completed. (Tailscale.CLIError error 3.)".utf8)
+
+        guard case .unreadable = RemoteControlServer.serveState(from: data, port: 8765) else {
+            return XCTFail("expected unreadable for non-JSON serve output")
+        }
+    }
+
     func testTailscaleConnectURLUsesHostedUIAndEncodesParameters() {
         let url = RemoteControlServer.makeConnectURL(
             companionAppMode: .hosted,


### PR DESCRIPTION
## The problem

On machines with the Tailscale **app** installed, the Remote Control settings showed:

> ⚠️ Tailscale's serve status wasn't readable. Serve may well be running - this is Toki failing to check, not Tailscale failing to serve.

(and the equivalent "Couldn't read Tailscale's status. Enter the host by hand.") even when Tailscale was connected and `tailscale serve` was actively fronting Toki's port.

## Root cause

`tailscaleExecutable()` resolved `tailscale` to `/Applications/Tailscale.app/Contents/MacOS/Tailscale` first. That binary is the GUI app, which also acts as a CLI **only when it can reach the running GUI**. Toki is a Finder-launched app, so it runs child processes with a bare environment. In that environment the wrapper cannot reach the GUI and prints to **stdout**, with **exit code 0**:

```
The Tailscale GUI failed to start: The operation couldn't be completed. (Tailscale.CLIError error 3.)
```

Because the exit code is 0, Toki treated that 105-byte string as the command's JSON output and failed to parse it. The diagnostic log confirmed it: repeated `no_dns_name ... raw=<absent>` entries whose detail is the JSON-parse-failure branch.

The reason it looks fine from a terminal is that an interactive shell inherits the full login environment the GUI wrapper needs; a Finder-launched app does not.

The standalone `tailscale` CLI (Homebrew / `/usr/local/bin` / `/usr/bin` / `~/.local/bin`) talks to `tailscaled` directly over its socket and returns valid JSON in that same bare environment.

## The fix

- **Prefer the standalone CLI** and try the `Tailscale.app` GUI wrapper only as a last resort, when no real CLI is installed.
- **Parse Tailscale JSON tolerantly**: a shared `tailscaleJSONObject(from:)` strips any non-JSON prefix (e.g. a version-skew `Warning: client version ...` line a CLI may print ahead of the object) before decoding, so a stray banner never reads back as an unreadable status. Genuinely non-JSON output (like the GUI-wrapper error) still degrades to the existing "unreadable / enter host by hand" path.

## Tests

Added coverage for a version-skew warning prefix (status and serve both still parse) and for the GUI-wrapper error string being reported as unreadable. Full suite: 57 passing.