### PR TITLE
Fail over to the Codex app's bundled CLI for usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **Codex quota works with only the Codex app installed.** Reading Codex usage needs the `codex` CLI, and until now that meant a separate Homebrew or npm install even though the desktop app already ships one. When nothing named `codex` is on your `PATH`, Toki now falls back to the copy inside `Codex.app`, so the app alone is enough. A `PATH` install still wins, since it can be newer than the version locked to the app; a broken one is named as the problem instead of being quietly skipped.
+
 ## 2.7.0 - 2026-08-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Fixed
-
-- **Codex quota works with only the Codex app installed.** Reading Codex usage needs the `codex` CLI, and until now that meant a separate Homebrew or npm install even though the desktop app already ships one. When nothing named `codex` is on your `PATH`, Toki now falls back to the copy inside `Codex.app`, so the app alone is enough. A `PATH` install still wins, since it can be newer than the version locked to the app; a broken one is named as the problem instead of being quietly skipped.
-
 ## 2.7.0 - 2026-08-11
 
 ### Added
@@ -31,6 +25,7 @@
 - **Toki no longer reports a working `tailscale serve` as missing.** Detection matched one spelling of the loopback at one path, so `localhost`, IPv6, or a shared serve all read as "not serving", and an unreadable status looked identical to an empty one. Those are now distinct answers.
 - **`tailscale serve` starts itself on the machines that most need it.** Auto-serve was gated on the Mac's `.ts.net` name, which serving does not require, so on a Mac whose Tailscale ships no usable CLI the gate closed and serve never ran. It now runs regardless, takes the name from serve's own config, and says when it deliberately declines.
 - **The permissions checklist reports what it actually checked.** A closed terminal made macOS refuse to answer about Automation and read as "not granted yet"; the Keychain row claimed success whenever the gate was open; **Send a test** logged a notification as delivered macOS may never have shown. Each now tells the truth and offers a way to retry.
+- **Codex quota works with only the Codex app installed.** Reading Codex usage needs the `codex` CLI, and until now that meant a separate Homebrew or npm install even though the desktop app already ships one. When nothing named `codex` is on your `PATH`, Toki now falls back to the copy inside `Codex.app`, so the app alone is enough. A `PATH` install still wins, since it can be newer than the version locked to the app; a broken one is named as the problem instead of being quietly skipped.
 - **An agent's transcript and name follow the conversation you are actually having.** Toki pinned an agent to the session file written at its launch, so once the conversation moved (via `/clear`, switching chats, or a rollover) the menu bar name and Remote Control transcript froze. Sessions are now assigned across a whole project folder at once, each agent owning the files created before the next one started, so no two agents share a file and a lone agent follows the live conversation.
 - The companion server stops trusting a snapshot forever: a reading older than 90 seconds means the pipe went quiet, and past that the server discovers agents itself.
 - **The button that turns on Tailscale HTTPS is reachable in the case that needs it.** It only appeared once `tailscale status` produced a DNS name, which the Mac App Store build cannot supply; it now appears for a hand-typed host too, and where no `tailscale` command exists Toki hands over the command to run.

--- a/Sources/Toki/API/CodexUsageClient.swift
+++ b/Sources/Toki/API/CodexUsageClient.swift
@@ -7,7 +7,7 @@ struct CodexUsageClient {
 
     func snapshot() async throws -> AccountSnapshot {
         let credentials = try CodexCredentialReader.readCredentials(account: account)
-        let payload = try CodexAppServerClient.fetch(account: account)
+        let payload = try await CodexAppServerClient.fetch(account: account)
         let usage = CodexUsage(json: payload.usage ?? [:])
         let rateLimits = CodexRateLimits(json: payload.rateLimits ?? [:])
         guard usage.hasUsage || rateLimits.hasUsage else {
@@ -35,24 +35,49 @@ struct CodexUsageClient {
             progressRatio: rateLimits.progressRatio,
             resetCreditsAvailable: rateLimits.resetCreditsAvailable,
             metrics: rateLimits.metrics + usage.metrics,
-            accountInfo: CodexCredentialReader.accountInfo(from: credentials) + CodexAccountInfo.lines(from: payload.account),
+            accountInfo: CodexCredentialReader.accountInfo(from: credentials)
+                + CodexAccountInfo.lines(from: payload.account)
+                + Self.binaryInfoLines(payload.binarySource),
             primaryWindow: rateLimits.primaryWindow,
             secondaryWindow: rateLimits.secondaryWindow
         )
+    }
+
+    private static func binaryInfoLines(_ binary: CodexBinary?) -> [MetricLine] {
+        guard let binary else { return [] }
+        return [MetricLine(label: "Codex CLI", value: binary.displayName)]
     }
 }
 
 enum CodexAppServerClient {
     private static let path = agentCommandSearchPath
 
-    static func fetch(account: AccountConfig) throws -> CodexAppServerPayload {
-        let responses = try call(account: account, requests: [
+    // Resolve once per fetch/reset and thread the result through, so the optional account-info line
+    // can't disagree with the fetch if install state changes mid-refresh. Nothing usable found is a
+    // real error thrown before anything is spawned, naming both fixes.
+    private static func resolvedBinary() async throws -> CodexBinary {
+        guard let binary = try await CodexBinaryResolver.resolve() else {
+            throw LocalizedErrorMessage(CodexBinaryResolver.notFoundMessage)
+        }
+        DiagnosticLogger.shared.record(
+            .info,
+            component: "usage",
+            code: "codex_binary_source",
+            detail: "source=\(binary.sourceTag) executable=\(binary.executablePath)"
+        )
+        return binary
+    }
+
+    static func fetch(account: AccountConfig) async throws -> CodexAppServerPayload {
+        let binary = try await resolvedBinary()
+        let responses = try call(account: account, binary: binary, requests: [
             (id: 2, method: "account/usage/read", params: "null"),
             (id: 3, method: "account/rateLimits/read", params: "null"),
             (id: 4, method: "account/read", params: "{}")
         ])
 
         var payload = CodexAppServerPayload()
+        payload.binarySource = binary
         payload.usage = responses.results[2]
         payload.rateLimits = responses.results[3]
         payload.account = responses.results[4]
@@ -71,7 +96,8 @@ enum CodexAppServerClient {
         return payload
     }
 
-    static func consumeRateLimitResetCredit(account: AccountConfig, creditID: String?) throws -> String {
+    static func consumeRateLimitResetCredit(account: AccountConfig, creditID: String?) async throws -> String {
+        let binary = try await resolvedBinary()
         var params: [String: Any] = ["idempotencyKey": UUID().uuidString]
         if let creditID {
             params["creditId"] = creditID
@@ -79,7 +105,7 @@ enum CodexAppServerClient {
         let paramsData = try JSONSerialization.data(withJSONObject: params)
         let paramsString = String(data: paramsData, encoding: .utf8) ?? "{}"
 
-        let responses = try call(account: account, requests: [(id: 2, method: "account/rateLimitResetCredit/consume", params: paramsString)])
+        let responses = try call(account: account, binary: binary, requests: [(id: 2, method: "account/rateLimitResetCredit/consume", params: paramsString)])
         guard let result = responses.results[2] as? [String: Any], let outcome = result["outcome"] as? String else {
             throw LocalizedErrorMessage(responses.errors.first ?? "Codex did not confirm the reset")
         }
@@ -107,7 +133,7 @@ enum CodexAppServerClient {
     // therefore stay alive (via a trailing sleep) for at least as long as we intend to poll,
     // or app-server tears itself down mid-round-trip and every response after initialize goes
     // missing - the app-server process itself is still killed explicitly below once we're done.
-    private static func call(account: AccountConfig, requests: [(id: Int, method: String, params: String)]) throws -> (results: [Int: Any], errors: [String]) {
+    private static func call(account: AccountConfig, binary: CodexBinary, requests: [(id: Int, method: String, params: String)]) throws -> (results: [Int: Any], errors: [String]) {
         let initialize = #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"Toki","version":"\#(appVersion)"},"capabilities":{"experimentalApi":true}}}"#
         let initialized = #"{"jsonrpc":"2.0","method":"initialized","params":null}"#
         let requestLines = requests.map { #"{"jsonrpc":"2.0","id":\#($0.id),"method":"\#($0.method)","params":\#($0.params)}"# }
@@ -126,7 +152,7 @@ enum CodexAppServerClient {
         printf '%s\\n' '\(shellEscaped(initialized))'; \
         sleep 0.2; \
         printf '%s\\n' \(printfArgs); \
-        sleep 11 ) | CODEX_HOME='\(shellEscaped(codexHome))' PATH="\(path):$PATH" codex app-server --stdio > "$__toki_out" 2>&1 & \
+        sleep 11 ) | CODEX_HOME='\(shellEscaped(codexHome))' PATH="\(path):$PATH" '\(shellEscaped(binary.executablePath))' app-server --stdio > "$__toki_out" 2>&1 & \
         __toki_pid=$!; \
         for ((__toki_i = 1; __toki_i <= 100; __toki_i++)); do \
         sleep 0.1; \
@@ -166,11 +192,18 @@ enum CodexAppServerClient {
             }
         }
 
-        // No structured JSON-RPC error and no results usually means codex itself failed
-        // before speaking JSON-RPC (missing binary, permission error, crash) - surface a
-        // sanitized snippet instead of the raw line (which could contain paths or system info).
+        // No structured JSON-RPC error and no results usually means the selected codex itself
+        // failed before speaking JSON-RPC (permission error, crash, app-server won't start) -
+        // surface a sanitized snippet instead of the raw line (which could contain paths or system
+        // info), prefixed with which source was selected so a corrupt app-bundled binary is
+        // distinguishable from a broken PATH install.
         if errors.isEmpty, results.isEmpty, let firstUnparsed = unparsedLines.first {
-            errors.append(String(firstUnparsed.prefix(200)))
+            let source: String
+            switch binary {
+            case .pathInstall(let path): source = "Codex CLI at \(path)"
+            case .appBundle: source = "Codex.app's bundled CLI"
+            }
+            errors.append("\(source) failed: \(firstUnparsed.prefix(200))")
         }
 
         return (results, errors)

--- a/Sources/Toki/Agents/AgentSessionResolver.swift
+++ b/Sources/Toki/Agents/AgentSessionResolver.swift
@@ -716,7 +716,7 @@ struct HostApp: Hashable {
         HostApp(displayName: "VS Code Insiders", bundleID: "com.microsoft.VSCodeInsiders", matchers: ["code - insiders"]),
         HostApp(displayName: "VS Code", bundleID: "com.microsoft.VSCode", matchers: ["code helper", "visual studio code"]),
         HostApp(displayName: "Cursor", bundleID: "com.todesktop.230313mzl4w4u92", matchers: ["cursor"]),
-        HostApp(displayName: "ChatGPT", bundleID: "com.openai.codex", matchers: ["chatgpt"]),
+        HostApp(displayName: "ChatGPT", bundleID: codexAppBundleIdentifier, matchers: ["chatgpt"]),
         HostApp(displayName: "iTerm", bundleID: "com.googlecode.iterm2", matchers: ["iterm"]),
         HostApp(displayName: "WezTerm", bundleID: "com.github.wez.wezterm", matchers: ["wezterm"]),
         HostApp(displayName: "Alacritty", bundleID: "org.alacritty", matchers: ["alacritty"]),

--- a/Sources/Toki/Models/CodexModels.swift
+++ b/Sources/Toki/Models/CodexModels.swift
@@ -12,6 +12,7 @@ struct CodexAppServerPayload {
     var usage: Any?
     var rateLimits: Any?
     var account: Any?
+    var binarySource: CodexBinary?
 }
 
 struct CodexUsage {

--- a/Sources/Toki/Store/UsageStore+Accounts.swift
+++ b/Sources/Toki/Store/UsageStore+Accounts.swift
@@ -32,8 +32,12 @@ extension UsageStore {
         resettingAccountIDs.insert(accountID)
         Task {
             defer { resettingAccountIDs.remove(accountID) }
-            let result = await Task.detached {
-                Result { try CodexAppServerClient.consumeRateLimitResetCredit(account: account, creditID: nil) }
+            let result = await Task.detached { () -> Result<String, Error> in
+                do {
+                    return .success(try await CodexAppServerClient.consumeRateLimitResetCredit(account: account, creditID: nil))
+                } catch {
+                    return .failure(error)
+                }
             }.value
 
             switch result {

--- a/Sources/Toki/Utilities/CodexBinary.swift
+++ b/Sources/Toki/Utilities/CodexBinary.swift
@@ -1,0 +1,130 @@
+import AppKit
+import Foundation
+
+// The Codex desktop app registers under this bundle id, which also names the ChatGPT host in
+// AgentSessionResolver - one constant so the two spellings can't drift apart.
+let codexAppBundleIdentifier = "com.openai.codex"
+
+// Which install answered a usage fetch. Both cases carry resolve()'s chosen absolute path so the
+// exact binary that gets invoked is loggable and testable without a second lookup.
+enum CodexBinary: Equatable {
+    case pathInstall(String)
+    case appBundle(String)
+
+    var executablePath: String {
+        switch self {
+        case .pathInstall(let path), .appBundle(let path):
+            return path
+        }
+    }
+
+    // Short tag for the diagnostic log line.
+    var sourceTag: String {
+        switch self {
+        case .pathInstall: return "pathInstall"
+        case .appBundle: return "appBundle"
+        }
+    }
+
+    // The account-info card's "Codex CLI" value: the PATH executable that answered, or the app.
+    var displayName: String {
+        switch self {
+        case .pathInstall(let path): return path
+        case .appBundle: return "Codex.app"
+        }
+    }
+}
+
+enum CodexBinaryResolver {
+    // Named both installs so the not-found error is actionable and testable in one place.
+    static let notFoundMessage =
+        "Codex isn't installed where Toki can run it. Install the Codex CLI so `codex` is on your PATH, "
+        + "or install the Codex macOS app."
+
+    // The ladder, kept pure and injectable so a real `codex` on the test runner's PATH can't bleed
+    // into a test: a PATH probe result wins only when it is a single absolute path to a regular
+    // executable; otherwise the first app-bundle candidate holding one; nil when nothing usable
+    // exists. PATH precedence is intentional - a broken PATH install is reported, never bypassed.
+    static func resolve(
+        pathProbe: () throws -> String?,
+        candidates: [String],
+        isExecutable: (String) -> Bool
+    ) rethrows -> CodexBinary? {
+        if let probed = try pathProbe().flatMap(singleAbsolutePath), isExecutable(probed) {
+            return .pathInstall(probed)
+        }
+        for directory in candidates {
+            let candidate = (directory as NSString).appendingPathComponent("codex")
+            if isExecutable(candidate) {
+                return .appBundle(candidate)
+            }
+        }
+        return nil
+    }
+
+    // Production entry: probe through the same login shell and search path the launch uses, gather
+    // the app-bundle candidates (NSWorkspace on the main actor), then run the pure ladder - so the
+    // probe and the invocation can never disagree about what `codex` resolves to.
+    static func resolve() async throws -> CodexBinary? {
+        let candidates = await bundleCandidateDirectories()
+        return try resolve(
+            pathProbe: shellPathProbe,
+            candidates: candidates,
+            isExecutable: isRegularExecutable
+        )
+    }
+
+    // Exposed for tests: the external-executable probe against an explicit PATH expression.
+    // whence -p (not `command -v`): in zsh `command -v` can name an alias or function rather than a
+    // filesystem path; whence -p only ever names an external executable. `2>/dev/null || true` forces
+    // exit 0 with empty output when absent, since runShell throws on any non-zero exit - a throw here
+    // means the shell itself failed (login-profile error, timeout) and must surface, not be
+    // misclassified as "Codex not installed".
+    static func probeCodexOnPath(_ pathExpression: String) throws -> String? {
+        let output = try SecretResolver.runShell("PATH=\"\(pathExpression)\" whence -p codex 2>/dev/null || true")
+        let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    // A regular, executable file. Excludes directories (which are "executable" as searchable) and
+    // broken symlinks, but follows symlinks so a Homebrew/npm shim still resolves.
+    static func isRegularExecutable(_ path: String) -> Bool {
+        let fileManager = FileManager.default
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: path, isDirectory: &isDirectory), !isDirectory.boolValue else {
+            return false
+        }
+        return fileManager.isExecutableFile(atPath: path)
+    }
+
+    private static func shellPathProbe() throws -> String? {
+        try probeCodexOnPath("\(agentCommandSearchPath):$PATH")
+    }
+
+    private static func singleAbsolutePath(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("/"), !trimmed.contains("\n") else { return nil }
+        return trimmed
+    }
+
+    // /Contents/Resources of every registered Codex.app followed by the two standard install
+    // locations, deduplicated in order. Enumerating all registered URLs means one broken
+    // registration can't hide a valid copy. NSWorkspace is MainActor-isolated under strict
+    // concurrency, so only the lookup hops to the main actor and just its results cross back.
+    private static func bundleCandidateDirectories() async -> [String] {
+        let registered = await MainActor.run { registeredCodexResourceDirectories() }
+        let literals = [
+            "/Applications/Codex.app/Contents/Resources",
+            NSHomeDirectory() + "/Applications/Codex.app/Contents/Resources"
+        ]
+        var seen = Set<String>()
+        return (registered + literals).filter { seen.insert($0).inserted }
+    }
+
+    @MainActor
+    private static func registeredCodexResourceDirectories() -> [String] {
+        NSWorkspace.shared
+            .urlsForApplications(withBundleIdentifier: codexAppBundleIdentifier)
+            .map { $0.appendingPathComponent("Contents/Resources").path }
+    }
+}

--- a/Tests/TokiTests/CodexBinaryTests.swift
+++ b/Tests/TokiTests/CodexBinaryTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import XCTest
+@testable import Toki
+
+final class CodexBinaryTests: XCTestCase {
+    // MARK: - The ladder
+
+    // Injects a probe closure so a real `codex` on the runner's PATH can't bleed in - this is the
+    // regression guard against a future refactor letting the app's version-locked CLI shadow a
+    // newer PATH install.
+    func testPathInstallWinsWhenBothPresent() {
+        let binary = CodexBinaryResolver.resolve(
+            pathProbe: { "/usr/local/bin/codex" },
+            candidates: ["/Applications/Codex.app/Contents/Resources"],
+            isExecutable: { _ in true }
+        )
+        XCTAssertEqual(binary, .pathInstall("/usr/local/bin/codex"))
+    }
+
+    func testAppBundleUsedWhenCLIAbsent() {
+        let bundleDir = "/Applications/Codex.app/Contents/Resources"
+        let binary = CodexBinaryResolver.resolve(
+            pathProbe: { nil },
+            candidates: [bundleDir],
+            isExecutable: { $0 == bundleDir + "/codex" }
+        )
+        XCTAssertEqual(binary, .appBundle(bundleDir + "/codex"))
+    }
+
+    func testNilWhenNeitherPresent() {
+        let binary = CodexBinaryResolver.resolve(
+            pathProbe: { nil },
+            candidates: ["/Applications/Codex.app/Contents/Resources"],
+            isExecutable: { _ in false }
+        )
+        XCTAssertNil(binary)
+    }
+
+    // A probe result that isn't a single absolute path (an alias/function name, empty, multi-line)
+    // is rejected and the ladder falls through to the bundle.
+    func testNonAbsoluteProbeResultIsRejected() {
+        let bundleDir = "/Applications/Codex.app/Contents/Resources"
+        let binary = CodexBinaryResolver.resolve(
+            pathProbe: { "codex" },
+            candidates: [bundleDir],
+            isExecutable: { $0.hasPrefix("/Applications") }
+        )
+        XCTAssertEqual(binary, .appBundle(bundleDir + "/codex"))
+    }
+
+    // MARK: - Candidate filtering
+
+    func testRegularExecutableIsAccepted() throws {
+        let directory = try makeTemporaryDirectory()
+        let codex = directory.appendingPathComponent("codex")
+        try writeExecutable(at: codex)
+        XCTAssertTrue(CodexBinaryResolver.isRegularExecutable(codex.path))
+    }
+
+    func testNonExecutableFileIsRejected() throws {
+        let directory = try makeTemporaryDirectory()
+        let codex = directory.appendingPathComponent("codex")
+        try Data("not runnable".utf8).write(to: codex)
+        XCTAssertFalse(CodexBinaryResolver.isRegularExecutable(codex.path))
+    }
+
+    func testDirectoryIsRejected() throws {
+        let directory = try makeTemporaryDirectory()
+        let codex = directory.appendingPathComponent("codex")
+        try FileManager.default.createDirectory(at: codex, withIntermediateDirectories: false)
+        XCTAssertFalse(CodexBinaryResolver.isRegularExecutable(codex.path))
+    }
+
+    func testCandidateWithoutCodexIsSkipped() throws {
+        let withCodex = try makeTemporaryDirectory()
+        try writeExecutable(at: withCodex.appendingPathComponent("codex"))
+        let withoutCodex = try makeTemporaryDirectory()
+
+        let binary = CodexBinaryResolver.resolve(
+            pathProbe: { nil },
+            candidates: [withoutCodex.path, withCodex.path],
+            isExecutable: CodexBinaryResolver.isRegularExecutable
+        )
+        XCTAssertEqual(binary, .appBundle(withCodex.appendingPathComponent("codex").path))
+    }
+
+    // MARK: - Shell probe
+
+    // A fully controlled PATH (temp dir only, no inherited tail) so whence -p's answer is
+    // deterministic on any runner.
+    func testShellProbeFindsExecutableOnControlledPath() throws {
+        let directory = try makeTemporaryDirectory()
+        let codex = directory.appendingPathComponent("codex")
+        try writeExecutable(at: codex)
+
+        let probed = try CodexBinaryResolver.probeCodexOnPath(directory.path)
+        XCTAssertEqual(probed, codex.path)
+    }
+
+    func testShellProbeReturnsNilOnEmptyPath() throws {
+        let directory = try makeTemporaryDirectory()
+        XCTAssertNil(try CodexBinaryResolver.probeCodexOnPath(directory.path))
+    }
+
+    // MARK: - Helpers
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+
+    private func writeExecutable(at url: URL) throws {
+        try Data("#!/bin/sh\n".utf8).write(to: url)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+    }
+}

--- a/Tests/TokiTests/ShellNoiseAndDiagnosticsTests.swift
+++ b/Tests/TokiTests/ShellNoiseAndDiagnosticsTests.swift
@@ -173,6 +173,15 @@ final class ShellNoiseAndDiagnosticsTests: XCTestCase {
         }
     }
 
+    func testCodexNotFoundMessageNamesBothInstalls() {
+        let message = CodexBinaryResolver.notFoundMessage
+        XCTAssertTrue(message.contains("Codex CLI"), message)
+        XCTAssertTrue(message.contains("PATH"), message)
+        XCTAssertTrue(message.contains("Codex macOS app"), message)
+        // It must read as an actionable install hint, never a leaked raw shell line.
+        XCTAssertFalse(message.contains("app-server"), message)
+    }
+
     // MARK: - Diagnostic error detail
 
     func testNSErrorDetailCarriesDomainAndCode() {

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -38,6 +38,8 @@ Toki reads the auth file and asks the local Codex app-server for usage and rate 
 
 The app-server is launched through a login shell, which sources `.zprofile` but not `.zshrc`. Since the version managers most CLIs are installed through (nvm, fnm, volta, bun, pnpm, mise, asdf) set `PATH` from `.zshrc`, their bin directories are appended explicitly, so a `codex` installed that way is found rather than reported as `command not found`.
 
+When no `codex` is on `PATH` at all, Toki falls back to the copy bundled inside `Codex.app`, so the desktop app on its own is enough to read usage. A `PATH` install always takes precedence over the bundled copy, since the bundled CLI is version-locked to the app release and a Homebrew or npm install should keep winning. A broken `PATH` install is reported as such rather than silently bypassed.
+
 When OpenAI has banked a rate-limit reset credit, the expanded card shows a **Reset now** button (with a count when more than one is banked). It stays disabled until the current window is at least 80% used, so a credit is not spent while quota remains.
 
 ## Pi


### PR DESCRIPTION
## What

Toki reads Codex quota by running `codex app-server --stdio`. Today the binary is resolved only from the package-manager bin dirs on `PATH`, so a Mac with **only** the Codex desktop app installed has working auth (both the CLI and the app sign in to `~/.codex/auth.json`) but every usage refresh dies on a truncated `codex: command not found`.

This resolves the binary as an explicit ladder:

1. a `codex` on `PATH` (as today) wins
2. otherwise the copy bundled inside `Codex.app` (`Contents/Resources/codex`)
3. otherwise a not-found error that names **both** installs

The desktop app alone now works end to end. No new API, no new permissions, nothing new leaves the machine.

## How

- **`CodexBinary` / `CodexBinaryResolver`** (new, `Sources/Toki/Utilities/CodexBinary.swift`). The ladder, kept pure and injectable (`pathProbe` / `candidates` / `isExecutable` closures) so a real `codex` on a test runner's `PATH` can't bleed into the ordering tests.
  - PATH is probed with `whence -p codex 2>/dev/null || true` through the same login shell and `agentCommandSearchPath` the launch uses, so probe and invocation can never disagree. `whence -p` (not `command -v`) never names an alias/function; the `|| true` keeps absence at exit 0 so a genuine shell failure still surfaces instead of being misread as "not installed".
  - Candidates are validated as regular, executable files (follows symlinks, excludes directories/broken links).
  - NSWorkspace enumerates **all** registered Codex.app URLs (dedup'd) so one broken registration can't hide a valid copy; that lookup hops to the main actor under strict concurrency and only its results cross back.
- **Invocation** (`CodexUsageClient.swift`). The resolved absolute path is invoked in **both** cases, single-quoted the same way `CODEX_HOME` is, removing the probe/invocation race. The source + resolved path are logged once per refresh (`codex_binary_source`) and shown on the card as a `Codex CLI` line.
- **Failure taxonomy.** Nothing usable found throws a named error *before* spawning anything. A selected binary that fails at runtime keeps the existing sanitized snippet but is now prefixed with which source was selected, so a corrupt app-bundled CLI is distinguishable from a broken PATH install. A broken PATH install is never silently bypassed.
- `com.openai.codex` is hoisted to one shared constant (was duplicated in `AgentSessionResolver`).
- `detectCodex()` still gates on `auth.json`; the step-3 error is the actionable surface when the app is installed but no executable exists.

## Constraints held

- **PATH wins, always** - the bundled CLI is version-locked to the app release, so a Homebrew/npm install keeps winning and a broken PATH install is reported, not bypassed.
- `Contents/Resources/codex` is observed, not contracted - the regular-executable filter degrades a layout change to today's behaviour plus a clearer error, never a crash.
- No new permissions.

## Tests

- Ladder: CLI+app present -> PATH install; CLI absent + app present -> app bundle; neither -> nil; non-absolute (alias-shaped) probe result rejected.
- Shell `whence -p` probe against a fully controlled PATH (temp dir only): finds the temp binary; empty dir -> nil.
- Candidate filtering: regular executable accepted; non-executable / directory / missing rejected.
- Not-found message names both installs and leaks no raw shell line.

`swift build && swift test` (334 pass) and the stricter `swift build --build-tests -Xswiftc -strict-concurrency=complete` are both clean.

## Not covered here

Manual on-device checks (app-only refresh, both-present precedence via the diagnostic log, corrupt PATH install, reset-credit path through the bundled binary) still want a pass on a real Mac. The reset-credit check spends a real limited credit, so it needs sign-off before pressing it.
