### PR TITLE
Release 2.7.0 (stable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.7.0 - 2026-08-20
 
 ### Added
 
@@ -16,11 +16,6 @@
 - **The companion app sees Antigravity and fx sessions.** Both now surface on the phone with their own logos and their conversation transcripts (fx's session events, Antigravity's brain log), and their terminals accept typed replies and keypresses like Claude, Codex, and OpenCode sessions do.
 - **Cursor is detected from its desktop app, not just the CLI.** The Cursor card now appears when Cursor.app is installed, so desktop-only users see it without the `cursor-agent` CLI on their PATH.
 - **Cursor shows real usage with a spend ring.** When you are signed into Cursor, the card reads your usage from cursor.com: spend this cycle against your plan's limit as a health ring, plus token counts and the cycle reset, alongside your plan tier. Since the desktop agent has no separate process, the card also reads local AI-edit and chat activity to show Active and sort by recency, and falls back to that when signed out.
-
-## 2.7.0 - 2026-08-19
-
-### Added
-
 - **Permissions are a checklist, not a series of surprises.** Every macOS permission Toki needs is one list, in onboarding and permanently under **Settings › Permissions**, each explained and read with a check that never prompts. Nothing is requested until you press its button.
 - **Allow all.** First run can request every permission at once, one dialog at a time with Accessibility last; refusing one only disables what it was for. The list includes starting Toki at login, and a refused permission offers System Settings instead of an **Allow** button macOS would ignore.
 - **Quota on your phone.** The companion app shows the account with least left, expanding to the full list on tap, from the same reading the Mac renders; a reading the Mac stopped refreshing says so.


### PR DESCRIPTION
Cuts **2.7.0 stable**, folding the final beta (`v2.7.0-beta.8`) into the release. This is the sum of everything across `beta.1` through `beta.8`, as one release.

## New providers

- **Antigravity (`agy`)** and **Vercel `fx`** join the roster: detected as running agents, each with a card and a live Agents-tab row. fx is a real usage card (today/week/month token spend from its local ledger, plus AI Gateway credits); Antigravity is agent-only.
- **Cursor** gets a real spend ring read from cursor.com (spend against your plan's limit, tokens, cycle reset), detected from the CLI or the desktop app, with a local-activity fallback when signed out and a configurable limit.

## Companion app

- **Quota on your phone**, showing the account with least left and expanding to the full list.
- **Transcripts and controls** for Claude, Codex, OpenCode, fx, and Antigravity sessions, with tool-call progress, tappable links, and multi-question / multi-select prompt answering.
- **Send an image** from your phone into a reply.
- **ChatGPT/Claude-style composer** that grows upward and floats over the chat, a **typing indicator that counts elapsed time**, and a **pairing code that counts down** to its rotation.
- The browser tab names the Mac and the chat; leaving a paired session asks first; sessions persist across a closed browser.

## Permissions and setup

- **Permissions are a checklist**, in onboarding and under Settings, each explained and read without surprise prompts, with an **Allow all** first-run flow (Accessibility last) and login-item control.
- Toki turns on **Tailscale HTTPS itself** (`tailscale serve` once per start), with clearer detection and actionable refusal messages.
- A **menu-bar glyph** shows while Remote Control is on.

## Fixes

- Companion sessions survive a closed browser and outlive a stray 403; the server rediscovers agents when the pipe goes quiet.
- Codex quota works with only the Codex app installed.
- An agent's transcript and name follow the live conversation across `/clear`, chat switches, and rollovers, assigned per project folder.
- A range of `tailscale serve` detection and HTTPS-enablement fixes.

## Release

- `v2.7.0-beta.8` is already tagged and publishing from the merge of the provider work. Merging this PR and tagging `v2.7.0` cuts the stable release.
- Reviewed by Codex and fx (GLM 5.2) across the provider work; all findings fixed.

Full detail in CHANGELOG.md under `2.7.0 - 2026-08-20`.
