### PR TITLE
Change model from Remote Control

### DIFF
--- a/Sources/Toki/Resources/toki_remote.py
+++ b/Sources/Toki/Resources/toki_remote.py
@@ -1034,6 +1034,118 @@ def opencode_attention(session_id):
     return {"kind": "permission", "prompt": f"Allow {tool}?" if tool else "OpenCode is waiting on you", "options": []}
 
 
+def _claude_model(j):
+    msg = j.get("message")
+    return msg.get("model") if isinstance(msg, dict) else None
+
+
+def _codex_model(j):
+    return (j.get("payload") or {}).get("model") if j.get("type") == "turn_context" else None
+
+
+def _fx_model(j):
+    """fx records the model on session_started and on each usage checkpoint, both under a `model`
+    key nested in the payload; walk the record for the last one so a mid-session switch is caught."""
+    if j.get("kind") not in ("session_started", "usage_checkpointed"):
+        return None
+    found, stack = None, [j.get("payload")]
+    while stack:
+        o = stack.pop()
+        if isinstance(o, dict):
+            for k, v in o.items():
+                if k == "model" and isinstance(v, str):
+                    found = v
+                elif isinstance(v, (dict, list)):
+                    stack.append(v)
+        elif isinstance(o, list):
+            stack.extend(o)
+    return found
+
+
+AGY_MODEL_RE = re.compile(r"gemini-[0-9]+(?:\.[0-9]+)*(?:-[a-z]+)*", re.I)
+
+
+def agy_model(session_path):
+    """Antigravity keeps the model only inside a metadata blob in its per-conversation db, so read
+    the newest gen_metadata row and pull the id out of it. Best-effort: None when it is not found."""
+    parts = session_path.split(os.sep)
+    try:
+        cid = parts[parts.index("brain") + 1]
+    except (ValueError, IndexError):
+        return None
+    db = os.path.join(HOME, ".gemini", "antigravity-cli", "conversations", cid + ".db")
+    if not os.path.exists(db):
+        return None
+    try:
+        con = sqlite3.connect(f"file:{db}?mode=ro", uri=True, timeout=1)
+        try:
+            row = con.execute("SELECT data FROM gen_metadata ORDER BY idx DESC LIMIT 1").fetchone()
+        finally:
+            con.close()
+    except sqlite3.Error:
+        return None
+    if not row or row[0] is None:
+        return None
+    blob = row[0] if isinstance(row[0], str) else row[0].decode("utf-8", "replace")
+    m = AGY_MODEL_RE.search(blob)
+    return m.group(0) if m else None
+
+
+def opencode_model(session_id):
+    rows = opencode_query("SELECT model FROM session WHERE id=?", (session_id,))
+    raw = rows[0][0] if rows and rows[0][0] else None
+    if not raw:
+        return None
+    # OpenCode stores the model as a JSON object ({"id","providerID","variant"}); show its id.
+    try:
+        obj = json.loads(raw)
+    except (ValueError, TypeError):
+        return raw
+    return obj.get("id") or obj.get("model") or raw if isinstance(obj, dict) else raw
+
+
+JSONL_MODEL_EXTRACTORS = {"claude": _claude_model, "codex": _codex_model, "fx": _fx_model}
+# path -> (offset, model): the model as of the bytes read so far, so each poll parses only what was
+# appended since the last one rather than re-reading a growing session in full.
+_model_stream = {}
+
+
+def jsonl_model(path, extract):
+    """The current model in a jsonl session, read incrementally. The model line can sit anywhere --
+    far behind the tail in a long session -- so a bounded tail scan would miss it, but re-reading the
+    whole file every poll would not; this keeps the last value and consumes only the new bytes."""
+    try:
+        size = os.path.getsize(path)
+    except OSError:
+        _model_stream.pop(path, None)
+        return None
+    prev = _model_stream.get(path)
+    # A shorter file than last time means the session was replaced; start over.
+    offset, model = prev if prev and prev[0] <= size else (0, None)
+    records, new_offset = jsonl_lines(path, offset)
+    for j in (records or []):
+        v = extract(j)
+        if v:
+            model = v
+    _model_stream[path] = (new_offset if records is not None else offset, model)
+    if len(_model_stream) > 128:
+        _model_stream.pop(next(iter(_model_stream)))
+    return model
+
+
+def model_of(agent):
+    """The model an agent is currently running, or None when it cannot be read for that provider."""
+    provider, session = agent.get("provider"), agent.get("session")
+    if not session:
+        return None
+    if provider == "antigravity":
+        return agy_model(session)
+    if provider == "opencode":
+        return opencode_model(session)
+    extract = JSONL_MODEL_EXTRACTORS.get(provider)
+    return jsonl_model(session, extract) if extract else None
+
+
 def opencode_tool_summary(tool, inp):
     if not isinstance(inp, dict):
         return ""
@@ -2031,10 +2143,13 @@ class Handler(BaseHTTPRequestHandler):
                     "provider": a["provider"],
                     "title": a.get("title") or chat_title(a["provider"], a["session"], a["cwd"]),
                     "attention": att,
+                    "model": model_of(a),
                     "writable": agent_is_writable(a),
                     "machine": machine_name(),
                     # Lets newer hosted UIs hide uploads when connected to an older server.
                     "uploads": True,
+                    # Signals /api/screen support so older servers do not expose model control.
+                    "screen": True,
                 })
             self._json(result)
         elif url.path == "/api/screen":

--- a/Sources/Toki/Resources/toki_remote.py
+++ b/Sources/Toki/Resources/toki_remote.py
@@ -1294,6 +1294,76 @@ def focus_terminal_tab(tty):
         error "tty not found"''')
 
 
+def osascript_out(source):
+    return shell(["/usr/bin/osascript", "-e", source], timeout=6)
+
+
+def iterm_read(tty):
+    dev = tty if tty.startswith("/dev/") else f"/dev/{tty}"
+    return osascript_out(f'''
+        if application id "com.googlecode.iterm2" is running then
+          tell application id "com.googlecode.iterm2"
+            repeat with w in windows
+              repeat with t in tabs of w
+                repeat with s in sessions of t
+                  if tty of s is "{dev}" then
+                    return text of s
+                  end if
+                end repeat
+              end repeat
+            end repeat
+          end tell
+        end if
+        error "tty not found"''')
+
+
+def terminal_read(tty):
+    dev = tty if tty.startswith("/dev/") else f"/dev/{tty}"
+    return osascript_out(f'''
+        if application id "com.apple.Terminal" is running then
+          tell application id "com.apple.Terminal"
+            repeat with w in windows
+              repeat with t in tabs of w
+                if tty of t is "{dev}" then
+                  return contents of t
+                end if
+              end repeat
+            end repeat
+          end tell
+        end if
+        error "tty not found"''')
+
+
+def trim_screen(text):
+    """The tail of a captured screen, bounded by lines and bytes. Trailing blank lines a pane pads
+    itself with are dropped so the picker sits at the bottom of the mirror."""
+    text = text.replace("\r\n", "\n").replace("\r", "\n").rstrip("\n")
+    lines = text.split("\n")
+    if len(lines) > MAX_SCREEN_LINES:
+        lines = lines[-MAX_SCREEN_LINES:]
+    out = "\n".join(lines)
+    if len(out) > MAX_SCREEN_CHARS:
+        out = out[-MAX_SCREEN_CHARS:]
+    return out
+
+
+def capture_screen(tty, route=None):
+    """The visible terminal text for an agent's tty, or None when no route can read it. Mirrors an
+    interactive picker (e.g. /model) on the phone through the same three routes send_input writes to:
+    tmux, iTerm, then Terminal. tmux and both apps report only the visible region, not scrollback."""
+    if not safe_tty(tty):
+        return None
+    tmux, pane = route if route is not None else tmux_pane_for_tty(tty)
+    if pane:
+        out = shell([tmux, "capture-pane", "-p", "-t", pane])
+        return trim_screen(out) if out is not None else None
+    for reader in (iterm_read, terminal_read):
+        out = reader(tty)
+        if out is not None:
+            return trim_screen(out)
+    return None
+
+
 def send_input(tty, text=None, key=None, raw=False, route=None):
     """Deliver input to the agent's terminal. Returns (ok, how).
 
@@ -1537,6 +1607,9 @@ PAIRING_MAX_FAILURES = 5
 MAX_BODY_BYTES = 256 * 1024
 # Bound terminal injection independently of the general request-body cap.
 MAX_SEND_CHARS = 8_000
+# The mirrored picker only needs the tail of what is on screen; keep the payload small.
+MAX_SCREEN_LINES = 80
+MAX_SCREEN_CHARS = 8_000
 # Base64 adds roughly 33%, so the upload-body cap exceeds the decoded-image cap.
 MAX_IMAGE_BYTES = 12 * 1024 * 1024
 MAX_UPLOAD_BODY_BYTES = 17 * 1024 * 1024
@@ -1964,6 +2037,17 @@ class Handler(BaseHTTPRequestHandler):
                     "uploads": True,
                 })
             self._json(result)
+        elif url.path == "/api/screen":
+            pid = int_param(q, "pid")
+            agent = next((a for a in discover_agents() if a["pid"] == pid), None)
+            if not agent:
+                return self._json({"error": "agent gone"}, 410)
+            if not agent_is_writable(agent):
+                return self._json({"error": "This non-terminal session has no screen to read."}, 422)
+            text = capture_screen(agent["tty"])
+            if text is None:
+                return self._json({"ok": False, "error": "no route to tty (not tmux/iTerm/Terminal?)"})
+            self._json({"ok": True, "text": text})
         elif url.path == "/api/usage":
             self._json(current_usage())
         elif url.path == "/api/transcript":

--- a/Sources/Toki/Resources/webui/app.js
+++ b/Sources/Toki/Resources/webui/app.js
@@ -401,11 +401,19 @@ function providerLogo(p) {
   return '<svg class="plogo" viewBox="0 0 24 24" fill="#888"><circle cx="12" cy="12" r="8"/></svg>';
 }
 
+// Trim a model id to the part worth glancing at on a phone: drop a provider path prefix
+// (anthropic/\u2026, zai/\u2026) and the redundant "claude-" vendor tag.
+function shortModel(m) {
+  return String(m).split("/").pop().replace(/^claude-/, "");
+}
+
 function agentRow(a) {
   const path = dispPath(a.path);
+  const model = a.model ? '<span class="tm">' + esc(shortModel(a.model)) + "</span>" : "";
+  const dot = a.attention ? '<span class="dot">\u25cf</span>' : "";
   return providerLogo(a.provider) +
     '<span class="t">' +
-    '<span class="tl">' + (a.attention ? '<span class="dot">\u25cf</span> ' : "") + dispTitle(a.title) + "</span>" +
+    '<span class="tl">' + dot + '<span class="ttl">' + dispTitle(a.title) + "</span>" + model + "</span>" +
     (path ? '<span class="tp">' + path + "</span>" : "") +
     "</span>";
 }
@@ -462,7 +470,8 @@ function updateComposer(agent) {
   $("#readonly").style.display = agent && !writable ? "block" : "none";
   // Hosted UI versions can be newer than the server; gate uploads on its capability flag.
   $("#attach").hidden = !(agent && agent.uploads);
-  $("#model").hidden = !(writable && agent && MODEL_COMMANDS[agent.provider]);
+  // agent.screen gates the button off for older servers that lack /api/screen to mirror the picker.
+  $("#model").hidden = !(writable && agent && agent.screen && MODEL_COMMANDS[agent.provider]);
   if (!writable || (modelMirror && (!agent || modelMirror.pid != agent.pid))) closeModelMirror();
   document.querySelectorAll("footer button,footer input,footer textarea").forEach(el => el.disabled = !enabled);
   $("#msg").placeholder = writable ? "Reply to the agent\u2026" : (agent ? "Read-only session" : "No active session");
@@ -508,9 +517,13 @@ const MODEL_COMMANDS = {
 // While mirroring, hold the agent whose picker is open and the poll that repaints it.
 let modelMirror = null;
 
+// One capture in flight at a time: a slow AppleScript reader can take seconds, so the next poll is
+// scheduled only after this one settles rather than on a fixed interval that would stack requests.
 async function refreshModelMirror() {
   const pid = modelMirror && modelMirror.pid;
-  if (!pid) return;
+  if (!pid || modelMirror.inflight) return;
+  clearTimeout(modelMirror.timer);  // a manual refresh takes over any scheduled poll, never stacks
+  modelMirror.inflight = true;
   const pre = $("#modelscreen");
   try {
     const r = await api("/api/screen?pid=" + pid);
@@ -519,6 +532,11 @@ async function refreshModelMirror() {
     else pre.textContent = r.error ? "Can’t read this terminal: " + r.error : "No picker on screen.";
   } catch (e) {
     if (modelMirror && modelMirror.pid == pid) pre.textContent = "Couldn’t read the screen: " + e.message;
+  } finally {
+    if (modelMirror && modelMirror.pid == pid) {
+      modelMirror.inflight = false;
+      modelMirror.timer = setTimeout(refreshModelMirror, 700);
+    }
   }
 }
 
@@ -528,16 +546,15 @@ function openModelMirror(agent) {
   closeModelMirror();
   // Fire the CLI's own model command, then mirror the picker it opens on the terminal.
   send({ text: cmd });
-  modelMirror = { pid: agent.pid };
+  modelMirror = { pid: agent.pid, inflight: false };
   $("#modelmirror").hidden = false;
   $("#modelscreen").textContent = "Opening " + cmd + "…";
-  modelMirror.timer = setInterval(refreshModelMirror, 700);
-  setTimeout(refreshModelMirror, 450);
+  modelMirror.timer = setTimeout(refreshModelMirror, 450);
 }
 
 function closeModelMirror() {
   if (!modelMirror) return;
-  clearInterval(modelMirror.timer);
+  clearTimeout(modelMirror.timer);
   modelMirror = null;
   $("#modelmirror").hidden = true;
 }

--- a/Sources/Toki/Resources/webui/app.js
+++ b/Sources/Toki/Resources/webui/app.js
@@ -462,6 +462,8 @@ function updateComposer(agent) {
   $("#readonly").style.display = agent && !writable ? "block" : "none";
   // Hosted UI versions can be newer than the server; gate uploads on its capability flag.
   $("#attach").hidden = !(agent && agent.uploads);
+  $("#model").hidden = !(writable && agent && MODEL_COMMANDS[agent.provider]);
+  if (!writable || (modelMirror && (!agent || modelMirror.pid != agent.pid))) closeModelMirror();
   document.querySelectorAll("footer button,footer input,footer textarea").forEach(el => el.disabled = !enabled);
   $("#msg").placeholder = writable ? "Reply to the agent\u2026" : (agent ? "Read-only session" : "No active session");
 }
@@ -491,6 +493,53 @@ function clearContext() {
   send({ text: "/clear" }).then(ok => {
     if (ok) resetTranscript();
   });
+}
+
+// The slash command that opens each writable provider's model picker. Toki mirrors the picker the
+// command draws; selection is driven with the arrow/Enter footer, so no per-provider parsing.
+const MODEL_COMMANDS = {
+  claude: "/model",
+  codex: "/model",
+  opencode: "/models",
+  fx: "/model",
+  antigravity: "/model",
+};
+
+// While mirroring, hold the agent whose picker is open and the poll that repaints it.
+let modelMirror = null;
+
+async function refreshModelMirror() {
+  const pid = modelMirror && modelMirror.pid;
+  if (!pid) return;
+  const pre = $("#modelscreen");
+  try {
+    const r = await api("/api/screen?pid=" + pid);
+    if (!modelMirror || modelMirror.pid != pid) return;
+    if (r.ok && r.text) pre.textContent = r.text;
+    else pre.textContent = r.error ? "Can’t read this terminal: " + r.error : "No picker on screen.";
+  } catch (e) {
+    if (modelMirror && modelMirror.pid == pid) pre.textContent = "Couldn’t read the screen: " + e.message;
+  }
+}
+
+function openModelMirror(agent) {
+  const cmd = agent && MODEL_COMMANDS[agent.provider];
+  if (!cmd) return;
+  closeModelMirror();
+  // Fire the CLI's own model command, then mirror the picker it opens on the terminal.
+  send({ text: cmd });
+  modelMirror = { pid: agent.pid };
+  $("#modelmirror").hidden = false;
+  $("#modelscreen").textContent = "Opening " + cmd + "…";
+  modelMirror.timer = setInterval(refreshModelMirror, 700);
+  setTimeout(refreshModelMirror, 450);
+}
+
+function closeModelMirror() {
+  if (!modelMirror) return;
+  clearInterval(modelMirror.timer);
+  modelMirror = null;
+  $("#modelmirror").hidden = true;
 }
 
 let notifiedAttention = {};
@@ -1098,7 +1147,7 @@ document.addEventListener("pointerdown", e => {
 document.addEventListener("click", async e => {
   const b = e.target.closest("button");
   if (!b) return;
-  if (uploading && (b.id == "send" || b.id == "clear" ||
+  if (uploading && (b.id == "send" || b.id == "clear" || b.id == "model" ||
       b.dataset.key || b.dataset.opt || b.dataset.submit || b.dataset.text)) return;
   if (b.id == "send") {
     submitComposer();
@@ -1108,15 +1157,21 @@ document.addEventListener("click", async e => {
     clearPendingImage();
   } else if (b.id == "clear") {
     clearContext();
+  } else if (b.id == "model") {
+    openModelMirror(agents.find(a => a.pid == current));
+  } else if (b.id == "modelclose") {
+    closeModelMirror();
   } else if (b.dataset.key) {
     $("#alert").style.display = "none";
     await send({ key: b.dataset.key });
+    if (modelMirror) refreshModelMirror();
   } else if (b.dataset.opt) {
     toggleOption(b.dataset.opt);
   } else if (b.dataset.submit) {
     submitAnswer();
   } else if (b.dataset.text) {
     await send({ text: b.dataset.text, raw: true });
+    if (modelMirror) refreshModelMirror();
   }
 });
 

--- a/Sources/Toki/Resources/webui/index.html
+++ b/Sources/Toki/Resources/webui/index.html
@@ -50,6 +50,10 @@
 <div id="alert"></div><div id="readonly" role="status">Read-only session — this agent is not running in a terminal, so you can follow its progress but cannot send replies.</div><div id="log"></div>
 <button id="tolatest" type="button" hidden aria-label="Jump to latest">&#8595; New messages</button>
 <footer>
+  <div id="modelmirror" hidden>
+    <div class="mm-head"><span>Model picker: choose with the keys below</span><button id="modelclose" type="button">Done</button></div>
+    <pre id="modelscreen" aria-live="polite"></pre>
+  </div>
   <div class="keys" aria-label="Terminal controls">
     <button data-key="up" aria-label="Up arrow"><span>&#8593;</span><small>Up</small></button>
     <button data-key="down" aria-label="Down arrow"><span>&#8595;</span><small>Down</small></button>
@@ -62,7 +66,7 @@
   </div>
   <div id="attachpreview" hidden></div>
   <input id="fileinput" type="file" accept="image/*" hidden>
-  <div class="composer"><button id="attach" type="button" aria-label="Attach an image" title="Attach an image"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="m21 15-5-5L5 21"/></svg></button><textarea id="msg" rows="1" placeholder="Reply to the agent&#8230;" aria-describedby="composerhint"></textarea>
+  <div class="composer"><button id="attach" type="button" aria-label="Attach an image" title="Attach an image"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="m21 15-5-5L5 21"/></svg></button><button id="model" type="button" hidden aria-label="Change the agent&#8217;s model" title="Change model"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 7h9M17 7h3M4 17h3M11 17h9"/><circle cx="15.5" cy="7" r="2.2"/><circle cx="7.5" cy="17" r="2.2"/></svg></button><textarea id="msg" rows="1" placeholder="Reply to the agent&#8230;" aria-describedby="composerhint"></textarea>
   <button id="clear" type="button" aria-label="Clear the agent&#8217;s context" title="Clear the agent&#8217;s context (/clear)"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18M8 6V4.5A1.5 1.5 0 0 1 9.5 3h5A1.5 1.5 0 0 1 16 4.5V6M18.5 6l-.8 13.1a2 2 0 0 1-2 1.9H8.3a2 2 0 0 1-2-1.9L5.5 6"/></svg></button>
   <button id="send" aria-label="Send reply" aria-keyshortcuts="Meta+Enter Control+Enter" title="Send reply"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3.4 20.4 21 12 3.4 3.6l-.1 6.5L15 12 3.3 13.9Z"/></svg></button></div>
   <div class="composer-hint" id="composerhint">Return adds a line <span aria-hidden="true">&middot;</span> &#8984;/Ctrl + Return sends</div>

--- a/Sources/Toki/Resources/webui/styles.css
+++ b/Sources/Toki/Resources/webui/styles.css
@@ -124,8 +124,12 @@ body.privacy .eye-off{display:inline}
        background:var(--surface-2);color:var(--text);border:1px solid var(--line);font-size:15px;text-align:left}
 #dd .t{flex:1;min-width:0;display:flex;flex-direction:column;gap:1px;
        overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-#dd .tl,#dd .tp{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+#dd .tl{display:flex;align-items:center;gap:6px;min-width:0}
+#dd .ttl,#dd .tp{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 #dd .tp{color:var(--text-3);font-size:11px;font-family:ui-monospace,monospace}
+#dd .tm{flex:none;padding:1px 6px;border-radius:6px;background:var(--surface-1);
+        border:1px solid var(--line);color:var(--text-3);font-size:10px;
+        font-family:ui-monospace,monospace;white-space:nowrap}
 #dd .caret{color:var(--text-3);flex:none}
 #dd .dot{color:var(--danger)}
 #ddlist{display:none;position:absolute;left:0;right:0;top:calc(100% + 6px);z-index:5;

--- a/Sources/Toki/Resources/webui/styles.css
+++ b/Sources/Toki/Resources/webui/styles.css
@@ -261,6 +261,21 @@ input{flex:1;padding:11px;border-radius:var(--r-sm);background:var(--surface-2);
 #attach{background:var(--surface-2);border-color:var(--line-strong);color:var(--text-2);
         box-shadow:0 1px 0 #ffffff0d inset}
 #attach svg{fill:none;stroke:currentColor}
+#model{background:var(--surface-2);border-color:var(--line-strong);color:var(--text-2);
+       box-shadow:0 1px 0 #ffffff0d inset}
+#model[hidden]{display:none}
+#model svg{fill:none;stroke:currentColor;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}
+#modelmirror{margin-bottom:8px;border:1px solid var(--line-strong);border-radius:var(--r);
+             background:var(--surface-2);overflow:hidden}
+#modelmirror[hidden]{display:none}
+.mm-head{display:flex;align-items:center;justify-content:space-between;gap:8px;
+         padding:6px 10px;font-size:11px;color:var(--text-2);border-bottom:1px solid var(--line)}
+.mm-head button{width:auto;min-width:0;height:auto;flex:none;padding:3px 12px;border-radius:8px;
+                background:var(--surface);border:1px solid var(--line-strong);color:var(--text);
+                box-shadow:none;font:600 12px/1 -apple-system,system-ui,sans-serif}
+#modelscreen{margin:0;padding:8px 10px;max-height:220px;overflow:auto;
+             font:11px/1.35 ui-monospace,SFMono-Regular,Menlo,monospace;color:var(--text);
+             white-space:pre;-webkit-overflow-scrolling:touch}
 #attachpreview{position:relative;display:inline-block;margin-bottom:8px}
 #attachpreview[hidden]{display:none}
 #attachpreview img{max-height:96px;max-width:100%;display:block;border-radius:var(--r);

--- a/docs/remote-control.md
+++ b/docs/remote-control.md
@@ -167,6 +167,10 @@ The mirror reads the visible terminal through the same routes replies are typed 
 and Terminal. An agent in a terminal Toki cannot read that way still opens its picker on the Mac,
 but the phone shows nothing to steer by, so the mirror reports it has no route.
 
+Each agent also shows the model it is currently running as a small badge next to its name, read
+from the provider's own session (Antigravity's is best-effort, and a few session kinds such as a
+one-off review run record no model, so the badge is simply omitted there).
+
 ### The first connection can be blocked by the macOS firewall
 
 macOS prompts once to allow incoming connections for `python3`. If you dismissed that prompt, the

--- a/docs/remote-control.md
+++ b/docs/remote-control.md
@@ -1,7 +1,7 @@
 # Remote Control
 
 Remote Control lets you watch your running agents from your phone and reply to them: approve a
-permission prompt, answer a question, send a message, clear a session. Toki starts a small HTTP
+permission prompt, answer a question, send a message, clear a session, change the model. Toki starts a small HTTP
 server on this Mac, your phone opens a web app, and the two talk directly. Nothing goes through a
 cloud service, and no transcript leaves your machine.
 
@@ -155,6 +155,17 @@ Agents without a terminal — Codex desktop, VS Code extensions, anything not at
 show up but cannot be replied to. There is no keyboard to type into. They are grouped under
 **Read-only** at the bottom of the picker, so the agent that is actually waiting on you is the one
 selected by default.
+
+### Changing an agent's model
+
+The **Model** button in the composer opens the running CLI's own model picker (`/model` for
+Claude, Codex, fx, and Antigravity; `/models` for OpenCode) and then mirrors that picker on the
+phone so you can see the options and the highlighted row. You drive the selection with the same
+**↑ ↓ Tab Enter** controls used to answer any other picker, and **Done** closes the mirror.
+
+The mirror reads the visible terminal through the same routes replies are typed into: tmux, iTerm,
+and Terminal. An agent in a terminal Toki cannot read that way still opens its picker on the Mac,
+but the phone shows nothing to steer by, so the mirror reports it has no route.
 
 ### The first connection can be blocked by the macOS firewall
 


### PR DESCRIPTION
## What

Adds a **Model** button to the Remote Control composer that lets you change the model of a running CLI agent from your phone, for every writable provider (Claude, Codex, OpenCode, fx, Antigravity).

## How

Rather than a static per-provider model registry (which drifts as vendors add models) or blind arrow navigation, this mirrors the CLI's own picker:

1. Tapping **Model** sends the provider's model command (`/model`, or `/models` for OpenCode), which opens that CLI's native picker in the terminal.
2. A new `GET /api/screen?pid=` endpoint captures the visible terminal and the phone shows it live, polling while the mirror is open.
3. You select with the existing **↑ ↓ Tab Enter** footer controls; **Done** closes the mirror.

Screen capture reuses the exact routes replies already travel over, each with a read counterpart:

- tmux → `tmux capture-pane -p`
- iTerm → `text of session`
- Terminal → `contents of tab`

All report only the visible region (not scrollback), trimmed to the last 80 lines / 8000 chars. No per-provider picker parsing, so nothing breaks when a CLI restyles its picker.

## Scope and limits

- The mirror only works where there is a route: tmux, iTerm, or Terminal. Other terminals still open the picker on the Mac but the phone reports it has no route to read.
- Read-only (non-terminal) sessions have no screen and are rejected with 422.
- `fx` and `antigravity` default to `/model`. Both are single-file compiled binaries, so their in-TUI slash command could not be verified without launching them; if either differs it is a one-line change in `MODEL_COMMANDS` (app.js) plus the docs table.

## Testing

- `python3 -m py_compile` and `node --check` pass.
- `capture_screen` verified end-to-end against a live tmux pane (returns the pane text) and returns `None` safely for an unsafe/unroutable tty.
- `trim_screen` verified for CRLF normalization, trailing-blank trimming, and the line cap.

## Files

- `toki_remote.py` — capture helpers (`osascript_out`, `iterm_read`, `terminal_read`, `trim_screen`, `capture_screen`) and the `/api/screen` endpoint.
- `webui/app.js` — `MODEL_COMMANDS`, the mirror open/close/poll logic, and composer wiring.
- `webui/index.html`, `webui/styles.css` — the Model button and mirror panel.
- `docs/remote-control.md` — new "Changing an agent's model" section.