### PR TITLE
Fix Antigravity permission prompts not reaching Remote Control

### DIFF
--- a/Sources/Toki/Resources/toki_remote.py
+++ b/Sources/Toki/Resources/toki_remote.py
@@ -945,6 +945,32 @@ TRANSCRIPT_PARSERS = {
 }
 
 
+# Read-only tools (view_file, grep_search, find_by_name) run without asking, so only these leave the
+# transcript resting on a proposal antigravity is blocked on.
+AGY_APPROVAL_TOOLS = ("run_command",)
+
+
+def agy_attention(path):
+    """Antigravity writes the tool call it wants to run, then blocks for approval, so a pending
+    permission is the final record carrying an approval-gated call with nothing appended after it.
+    Approving appends the command's result, moving the tail past the call and clearing this."""
+    if not quiet_enough(path):
+        return None
+    records, _ = jsonl_lines(path, 0)
+    last = records[-1] if records else None
+    if not isinstance(last, dict):
+        return None
+    calls = last.get("tool_calls") or []
+    pending = next((c for c in reversed(calls)
+                    if isinstance(c, dict) and c.get("name") in AGY_APPROVAL_TOOLS), None)
+    if not pending:
+        return None
+    args = pending.get("args") if isinstance(pending.get("args"), dict) else {}
+    label = (args.get("toolSummary") or args.get("toolAction")
+             or args.get("CommandLine") or pending.get("name"))
+    return {"kind": "permission", "prompt": f"Allow: {label}?", "options": []}
+
+
 def codex_attention(path):
     if not quiet_enough(path):
         return None
@@ -1950,8 +1976,12 @@ class Handler(BaseHTTPRequestHandler):
                         att = claude_attention(a["session"])
                     elif a["provider"] == "codex":
                         att = codex_attention(a["session"])
-                    else:
+                    elif a["provider"] == "antigravity":
+                        att = agy_attention(a["session"])
+                    elif a["provider"] == "opencode":
                         att = opencode_attention(a["session"])
+                    # fx has no attention parser yet; leave it None rather than misreading it
+                    # through opencode's, which expects a session id and not a transcript path.
                 result.append({
                     "pid": a["pid"], "tty": a["tty"], "cwd": a["cwd"],
                     "path": display_path(a["cwd"]),

--- a/Sources/Toki/Resources/toki_remote.py
+++ b/Sources/Toki/Resources/toki_remote.py
@@ -952,13 +952,19 @@ AGY_APPROVAL_TOOLS = ("run_command",)
 
 def agy_attention(path):
     """Antigravity writes the tool call it wants to run, then blocks for approval, so a pending
-    permission is the final record carrying an approval-gated call with nothing appended after it.
-    Approving appends the command's result, moving the tail past the call and clearing this."""
+    permission is the final record: a model proposal (PLANNER_RESPONSE) holding an approval-gated
+    call with nothing appended after it. Approving appends the command's result, moving the tail
+    past the call and clearing this.
+
+    This does not fire for an auto-approved command that is merely executing. The instant such a
+    command starts, Antigravity appends a "running as a background task" record (verified against a
+    live session), and then more planner output, so the tail is no longer a lone call. A trailing
+    approval-gated call therefore means the agent is waiting on the human, not running a command."""
     if not quiet_enough(path):
         return None
     records, _ = jsonl_lines(path, 0)
     last = records[-1] if records else None
-    if not isinstance(last, dict):
+    if not isinstance(last, dict) or last.get("type") != "PLANNER_RESPONSE":
         return None
     calls = last.get("tool_calls") or []
     pending = next((c for c in reversed(calls)


### PR DESCRIPTION
## The bug

Antigravity permission prompts never propagated to the phone. Neither did fx's.

## Root cause

The `/api/agents` attention dispatch only special-cased Claude and Codex; everything else fell through to `opencode_attention`:

```python
if provider == "claude": ...
elif provider == "codex": ...
else: att = opencode_attention(a["session"])
```

`opencode_attention` looks a session up in the OpenCode SQLite DB **by id**. Antigravity and fx pass a **transcript file path**, so the query always returned `None` and their prompts were silently dropped.

## The fix

Route `antigravity` to a new `agy_attention` and make the dispatch explicit. `opencode` keeps its own parser; `fx` has no attention parser yet, so it now stays `None` explicitly rather than misusing OpenCode's (no behaviour change for fx, just correctness).

### How `agy_attention` detects a pending prompt

Verified against a live Antigravity session blocked on a command approval. Antigravity writes the tool call it wants to run **before** it blocks, then waits:

- **Pending:** the final transcript record is a `PLANNER_RESPONSE` carrying a `run_command` tool call, with nothing appended after it, and the file goes quiet.
- **Resolved:** approving appends a `GENERIC` "command exited" result, which moves the tail past the call, so the signal clears itself.

So the parser flags a permission when the last record holds an approval-gated tool call (`run_command`; read-only tools like `view_file`/`grep_search` auto-run and never sit waiting), gated by the same `quiet_enough` guard the Claude and Codex parsers use.

## Testing

Live end-to-end against a real `agy` session and the standalone server:

1. Drove `agy` to a `Requesting permission for: uname -a` prompt in tmux.
2. `GET /api/agents` returned:
   ```json
   { "provider": "antigravity", "attention": { "kind": "permission", "prompt": "Allow: Run uname -a?" } }
   ```
3. An idle Antigravity process and a live fx session both correctly stayed `attention: null` (no false positives).
4. Confirmed at the transcript level that approving appends the result record and the tail moves past the call, so the prompt self-clears.
5. `python3 -m py_compile` passes.