### PR TITLE
Surface Antigravity ask_question prompts in Remote Control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- **Antigravity questions reach Remote Control.** When an Antigravity (`agy`) session asks a clarifying question (`ask_question`), the phone now shows each question with its options instead of a blank panel. Its attention parser only recognized approval-gated commands, so a pending question left the agent stuck with nothing to answer. Because Antigravity records an answer as each question's own text, tapping an option sends that option verbatim as your reply, and the composer stays open for a free-text answer.
 - **Antigravity permission prompts reach Remote Control.** A pending approval in an Antigravity (`agy`) session now surfaces on your phone the way Claude, Codex, and OpenCode prompts already do. Its attention was being read through OpenCode's path, which expects a session id rather than a transcript, so the prompt never appeared.
 
 ## 2.7.0 - 2026-08-20

--- a/Sources/Toki/Resources/toki_remote.py
+++ b/Sources/Toki/Resources/toki_remote.py
@@ -948,18 +948,21 @@ TRANSCRIPT_PARSERS = {
 # Read-only tools (view_file, grep_search, find_by_name) run without asking, so only these leave the
 # transcript resting on a proposal antigravity is blocked on.
 AGY_APPROVAL_TOOLS = ("run_command",)
+AGY_QUESTION_TOOL = "ask_question"
+AGY_BLOCKING_TOOLS = AGY_APPROVAL_TOOLS + (AGY_QUESTION_TOOL,)
 
 
 def agy_attention(path):
     """Antigravity writes the tool call it wants to run, then blocks for approval, so a pending
-    permission is the final record: a model proposal (PLANNER_RESPONSE) holding an approval-gated
-    call with nothing appended after it. Approving appends the command's result, moving the tail
-    past the call and clearing this.
+    permission is the final record: a model proposal (PLANNER_RESPONSE) holding a blocking call
+    with nothing appended after it. Answering appends the call's result, moving the tail past the
+    call and clearing this. A blocking call is either an approval-gated command or an ask_question
+    picker; the latter carries the questions to show instead of an approve/reject.
 
     This does not fire for an auto-approved command that is merely executing. The instant such a
     command starts, Antigravity appends a "running as a background task" record (verified against a
     live session), and then more planner output, so the tail is no longer a lone call. A trailing
-    approval-gated call therefore means the agent is waiting on the human, not running a command."""
+    blocking call therefore means the agent is waiting on the human, not running a command."""
     if not quiet_enough(path):
         return None
     records, _ = jsonl_lines(path, 0)
@@ -968,10 +971,13 @@ def agy_attention(path):
         return None
     calls = last.get("tool_calls") or []
     pending = next((c for c in reversed(calls)
-                    if isinstance(c, dict) and c.get("name") in AGY_APPROVAL_TOOLS), None)
+                    if isinstance(c, dict) and c.get("name") in AGY_BLOCKING_TOOLS), None)
     if not pending:
         return None
     args = pending.get("args") if isinstance(pending.get("args"), dict) else {}
+    if pending.get("name") == AGY_QUESTION_TOOL:
+        qs = normalize_questions(args.get("questions"), "is_multi_select")
+        return question_attention(qs) if qs else None
     label = (args.get("toolSummary") or args.get("toolAction")
              or args.get("CommandLine") or pending.get("name"))
     return {"kind": "permission", "prompt": f"Allow: {label}?", "options": []}

--- a/Sources/Toki/Resources/webui/app.js
+++ b/Sources/Toki/Resources/webui/app.js
@@ -679,7 +679,8 @@ function answerComplete(qs, sel) {
 }
 
 function renderQuestions() {
-  const { questions: qs, sel } = answer;
+  const { questions: qs, sel, provider } = answer;
+  const tapToSend = provider == "antigravity";
   let html = '<div class="ahead">Agent is asking</div>';
   qs.forEach((q, qi) => {
     if (q.header)
@@ -687,15 +688,15 @@ function renderQuestions() {
         (q.multi ? '<span class="qtag">select all that apply</span>' : "") + "</div>";
     html += '<div class="qq">' + md(q.question || "") + "</div>";
     (q.options || []).forEach((o, oi) => {
-      const on = sel[qi].has(oi);
-      html += `<button class="opt${on ? " on" : ""}" data-opt="${qi}:${oi}" ` +
-        `role="${q.multi ? "checkbox" : "radio"}" aria-checked="${on}">` +
-        `<span class="mark ${q.multi ? "box" : "radio"}" aria-hidden="true"></span>` +
+      const on = !tapToSend && sel[qi].has(oi);
+      html += `<button class="opt${on ? " on" : ""}" data-opt="${qi}:${oi}"` +
+        (tapToSend ? ">" : ` role="${q.multi ? "checkbox" : "radio"}" aria-checked="${on}">` +
+          `<span class="mark ${q.multi ? "box" : "radio"}" aria-hidden="true"></span>`) +
         `<span class="olab"><b>${esc(o.label)}</b>` +
         (o.description ? `<em>${esc(o.description)}</em>` : "") + "</span></button>";
     });
   });
-  if (!isQuickPick(qs)) {
+  if (!tapToSend && !isQuickPick(qs)) {
     // Both TUIs default or drop unanswered questions, so require every available choice.
     html += '<div class="decision-row one"><button class="decision approve" data-submit="1"' +
       (answerComplete(qs, sel) ? "" : " disabled") + ">Submit</button></div>";
@@ -703,10 +704,28 @@ function renderQuestions() {
   $("#alert").innerHTML = html;
 }
 
+async function sendOptionText(qi, oi) {
+  if (submitting) return;
+  const opt = (answer.questions[qi].options || [])[oi];
+  if (!opt) return;
+  const pending = answer;
+  submitting = true;
+  const ok = await send({ text: opt.label });
+  submitting = false;
+  if (answer !== pending) return;
+  if (ok) {
+    answer = null;
+    $("#alert").style.display = "none";
+  } else {
+    renderQuestions();
+  }
+}
+
 function toggleOption(spec) {
   // Freeze selection while its computed keystrokes are in flight.
   if (!answer || submitting) return;
   const [qi, oi] = spec.split(":").map(Number);
+  if (answer.provider == "antigravity") return void sendOptionText(qi, oi);
   const set = answer.sel[qi];
   if (answer.questions[qi].multi) {
     if (set.has(oi)) set.delete(oi);


### PR DESCRIPTION
## Problem

When an Antigravity (`agy`) session asks a clarifying question (`ask_question`), the Remote Control phone view showed a blank panel and the agent sat stuck with nothing to answer. `agy_attention` only recognized approval-gated commands (`run_command`) as blocking calls, so a pending `ask_question` returned `None`.

## Fix

- **Backend (`toki_remote.py`):** `ask_question` now counts as a blocking tool. When it is the pending call, its `questions` are normalized into the same picker payload Claude/OpenCode use (`options` are plain strings, the multi flag is `is_multi_select`) and returned via `question_attention`.
- **Frontend (`webui/app.js`):** Antigravity records an answer as each question's own text, and a selected option is stored as that option's exact label (verified against a real transcript: `A2: (Recommended) 3-second countdown…`). So for Antigravity, tapping an option sends its label verbatim as a text reply instead of a picker keystroke. Options render as plain tappable chips with no radio marks or dead Submit button; the composer stays open for a free-text answer.

## Verification

- `agy_attention` returns both questions with their options for a real pending `ask_question`.
- `run_command` approvals, read-only tools, empty-question, and already-answered cases all still resolve correctly (return the same as before).
- Python and JS syntax checks pass.

## Caveat

With a multi-question `ask_question`, each tap sends one option immediately. Clean for the common single-question case; the multi-question terminal submission path is worth a quick check on a live session before stable release.