### PR TITLE
Show token usage in the spend section, and fix its attribution, ordering, and rename bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,16 @@
 ### Added
 
 - **Sarvam Code sessions in Remote Control.** A running `sarvam-code` CLI now shows up on your phone like Claude, Codex, and OpenCode do: its transcript streams live, permission prompts surface as attention alerts, the model badge reads the session's current model, and the Model button opens its `/model` picker. Sarvam Code shares Codex's session format, so its sessions resolve from `~/.sarvam/sessions` (honoring `SARVAM_HOME`) through the same reader.
+- **Token counts sit beside the money in the spend view.** Every Today, Week, Month, and All Time block in Analytics now shows the tokens behind the figure, and each cost-tracked card carries today's count next to its spend, so a quiet bill reads as either a quiet day or a cheaper model rather than being ambiguous.
 
 ### Fixed
 
 - **Codex approval prompts show the real command.** A pending Codex approval on your phone now reads the actual command text, including unified-exec calls that carry it in `input` rather than `arguments`, instead of a blank summary. A running `wait` poll is also no longer mistaken for a pending approval, so the prompt only appears when Codex genuinely needs an answer.
+- **Auto-detected providers can be renamed.** Pi, OpenCode, fx, Sarvam Code, Cursor, and Antigravity are detected rather than configured, so there was no saved entry for a new name to land in and the card quietly reverted whatever you typed. The first rename now writes that entry, keeping the account's existing history and usage.
+- **The provider you are using ranks above the ones you are not.** Cost-tracked providers have no quota percentage to sort by, so they fell back to the fixed order Toki detects them in, and a running Sarvam Code sat below an idle Pi no matter what you did. A live session now breaks that tie, without letting it outrank quota headroom or lift an errored card up the list.
+- **OpenCode's token count no longer reads far too low.** It counted only input and output while Pi and fx also include cache reads and writes, and all three add into the same total, so OpenCode came in roughly 28x under: 9.6M tokens against 275.2M actual on a real database. Databases predating the cache columns still aggregate instead of blanking the panel.
+- **Token totals follow the currency each provider bills in.** They were pinned to the USD row, so an install billing in something else (Sarvam Code in INR, say) grew a phantom USD row reading `$0.00` for every period beside the real one. Each provider's tokens now land on its own currency row, and the four blocks in a row keep a matching height when only some periods have usage.
+- **Session Costs stays inside its panel.** The donut's legend wrapped onto several lines once eight or more sessions were running and overlapped both the chart and the list under it. That list already names every session with its logo, cost, and token count, so the legend is gone and the list scrolls within a fixed height rather than pushing the spend blocks and quota chart out of view. Sessions are ordered costliest first.
 
 ## 3.0.0 - 2026-08-23
 

--- a/Sources/Toki/API/FxUsageClient.swift
+++ b/Sources/Toki/API/FxUsageClient.swift
@@ -13,6 +13,10 @@ struct FxUsageClient {
         var weekCost = 0.0
         var monthCost = 0.0
         var allTimeCost = 0.0
+        var todayTokens = 0.0
+        var weekTokens = 0.0
+        var monthTokens = 0.0
+        var allTimeTokens = 0.0
         var requestCount = 0
         var lastActivityMs = 0.0
     }
@@ -103,7 +107,10 @@ struct FxUsageClient {
             if let id = fact.id, !seen.insert(id).inserted { return }
 
             let cost = number(fact.totalCost)
+            let tokens = number(fact.inputTokens) + number(fact.outputTokens)
+                + number(fact.cacheReadTokens) + number(fact.cacheWriteTokens)
             totals.allTimeCost += cost
+            totals.allTimeTokens += tokens
             totals.requestCount += 1
 
             guard let createdAtMs = fact.createdAtMs, createdAtMs > 0 else { return }
@@ -114,9 +121,16 @@ struct FxUsageClient {
                 totals.todayOutput += number(fact.outputTokens)
                 totals.todayCacheRead += number(fact.cacheReadTokens)
                 totals.todayCost += cost
+                totals.todayTokens += tokens
             }
-            if let week, date >= week.start, date < week.end { totals.weekCost += cost }
-            if let month, date >= month.start, date < month.end { totals.monthCost += cost }
+            if let week, date >= week.start, date < week.end {
+                totals.weekCost += cost
+                totals.weekTokens += tokens
+            }
+            if let month, date >= month.start, date < month.end {
+                totals.monthCost += cost
+                totals.monthTokens += tokens
+            }
         }
         return totals
     }

--- a/Sources/Toki/API/OpenCodeUsageClient.swift
+++ b/Sources/Toki/API/OpenCodeUsageClient.swift
@@ -107,6 +107,7 @@ struct OpenCodeUsageClient {
         let weekStart = calendar.dateInterval(of: .weekOfYear, for: now).map { Int($0.start.timeIntervalSince1970) } ?? 0
         let monthStart = calendar.dateInterval(of: .month, for: now).map { Int($0.start.timeIntervalSince1970) } ?? 0
 
+        let tokens = tokenSumExpression(db: db)
         let row = try Self.staticQuery(
             db: db,
             sql: """
@@ -115,10 +116,10 @@ struct OpenCodeUsageClient {
             IFNULL(SUM(CASE WHEN time_updated/1000 >= \(weekStart) THEN cost END),0), \
             IFNULL(SUM(CASE WHEN time_updated/1000 >= \(monthStart) THEN cost END),0), \
             IFNULL(SUM(cost),0), \
-            IFNULL(SUM(CASE WHEN time_updated/1000 >= \(dayStart) THEN tokens_input + tokens_output END),0), \
-            IFNULL(SUM(CASE WHEN time_updated/1000 >= \(weekStart) THEN tokens_input + tokens_output END),0), \
-            IFNULL(SUM(CASE WHEN time_updated/1000 >= \(monthStart) THEN tokens_input + tokens_output END),0), \
-            IFNULL(SUM(tokens_input + tokens_output),0) FROM session;
+            IFNULL(SUM(CASE WHEN time_updated/1000 >= \(dayStart) THEN \(tokens) END),0), \
+            IFNULL(SUM(CASE WHEN time_updated/1000 >= \(weekStart) THEN \(tokens) END),0), \
+            IFNULL(SUM(CASE WHEN time_updated/1000 >= \(monthStart) THEN \(tokens) END),0), \
+            IFNULL(SUM(\(tokens)),0) FROM session;
             """
         )
 
@@ -132,6 +133,17 @@ struct OpenCodeUsageClient {
             monthTokens: row.value(6),
             allTimeTokens: row.value(7)
         )
+    }
+
+    static func tokenSumExpression(db: String) -> String {
+        let required = ["tokens_input", "tokens_output"]
+        let optional = ["tokens_cache_read", "tokens_cache_write"]
+        let present = Set(
+            ((try? sqliteOutput(db: db, sql: "PRAGMA table_info(session);")) ?? "")
+                .split(separator: "\n")
+                .compactMap { $0.split(separator: "|").dropFirst().first.map(String.init) }
+        )
+        return (required + optional.filter(present.contains)).joined(separator: " + ")
     }
 
     private static func staticQuery(db: String, sql: String) throws -> Row {

--- a/Sources/Toki/API/OpenCodeUsageClient.swift
+++ b/Sources/Toki/API/OpenCodeUsageClient.swift
@@ -10,6 +10,10 @@ struct OpenCodeUsageClient {
         var weekCost = 0.0
         var monthCost = 0.0
         var allTimeCost = 0.0
+        var todayTokens = 0.0
+        var weekTokens = 0.0
+        var monthTokens = 0.0
+        var allTimeTokens = 0.0
     }
 
     let account: AccountConfig
@@ -110,7 +114,11 @@ struct OpenCodeUsageClient {
             IFNULL(SUM(CASE WHEN time_updated/1000 >= \(dayStart) THEN cost END),0), \
             IFNULL(SUM(CASE WHEN time_updated/1000 >= \(weekStart) THEN cost END),0), \
             IFNULL(SUM(CASE WHEN time_updated/1000 >= \(monthStart) THEN cost END),0), \
-            IFNULL(SUM(cost),0) FROM session;
+            IFNULL(SUM(cost),0), \
+            IFNULL(SUM(CASE WHEN time_updated/1000 >= \(dayStart) THEN tokens_input + tokens_output END),0), \
+            IFNULL(SUM(CASE WHEN time_updated/1000 >= \(weekStart) THEN tokens_input + tokens_output END),0), \
+            IFNULL(SUM(CASE WHEN time_updated/1000 >= \(monthStart) THEN tokens_input + tokens_output END),0), \
+            IFNULL(SUM(tokens_input + tokens_output),0) FROM session;
             """
         )
 
@@ -118,7 +126,11 @@ struct OpenCodeUsageClient {
             todayCost: row.value(0),
             weekCost: row.value(1),
             monthCost: row.value(2),
-            allTimeCost: row.value(3)
+            allTimeCost: row.value(3),
+            todayTokens: row.value(4),
+            weekTokens: row.value(5),
+            monthTokens: row.value(6),
+            allTimeTokens: row.value(7)
         )
     }
 

--- a/Sources/Toki/API/PiUsageClient.swift
+++ b/Sources/Toki/API/PiUsageClient.swift
@@ -13,6 +13,10 @@ struct PiUsageClient {
         var weekCost = 0.0
         var monthCost = 0.0
         var allTimeCost = 0.0
+        var todayTokens = 0.0
+        var weekTokens = 0.0
+        var monthTokens = 0.0
+        var allTimeTokens = 0.0
         var sessionCount = 0
     }
 
@@ -152,6 +156,9 @@ struct PiUsageClient {
             for contribution in file.contributions {
                 guard seen.insert(contribution.dedupKey).inserted else { continue }
                 totals.allTimeCost += contribution.cost
+                let contributionTokens = contribution.input + contribution.output
+                    + contribution.cacheRead + contribution.cacheWrite
+                totals.allTimeTokens += contributionTokens
                 guard let date = contribution.date else { continue }
                 if date >= startOfDay, date < nextDay {
                     totals.todayInput += contribution.input
@@ -159,11 +166,18 @@ struct PiUsageClient {
                     totals.todayCacheRead += contribution.cacheRead
                     totals.todayCacheWrite += contribution.cacheWrite
                     totals.todayCost += contribution.cost
+                    totals.todayTokens += contributionTokens
                 }
                 // Half-open ranges, matching the day window above, so an instant on a week or
                 // month boundary lands in exactly one bucket rather than being double-counted.
-                if let week, date >= week.start, date < week.end { totals.weekCost += contribution.cost }
-                if let month, date >= month.start, date < month.end { totals.monthCost += contribution.cost }
+                if let week, date >= week.start, date < week.end {
+                    totals.weekCost += contribution.cost
+                    totals.weekTokens += contributionTokens
+                }
+                if let month, date >= month.start, date < month.end {
+                    totals.monthCost += contribution.cost
+                    totals.monthTokens += contributionTokens
+                }
             }
         }
         return totals

--- a/Sources/Toki/Store/UsageStore+Accounts.swift
+++ b/Sources/Toki/Store/UsageStore+Accounts.swift
@@ -117,6 +117,8 @@ extension UsageStore {
             config.accountLabels = labels
         } else if let index = config.accounts.firstIndex(where: { $0.id == snapshot.id }) {
             config.accounts[index].name = trimmed
+        } else if !config.accounts.contains(where: { $0.provider == snapshot.provider }) {
+            config.accounts.append(AccountConfig(id: snapshot.id, name: trimmed, provider: snapshot.provider))
         } else {
             return
         }

--- a/Sources/Toki/Utilities/BusinessLogic.swift
+++ b/Sources/Toki/Utilities/BusinessLogic.swift
@@ -24,6 +24,10 @@ func nextResetDate(for account: AccountConfig, state: AccountUsageState?) -> Dat
 // (tier 1, since there's at least a live signal), then agent-detection-only providers
 // sitting idle (tier 2). Everything else (error state, remaining ratio) only breaks
 // ties within a tier - it never lets an idle no-API card outrank a real quota card.
+//
+// A live session is the last tiebreak rather than the first: cost-tracked providers
+// (Pi, Sarvam Code, fx, OpenCode) have no quota headroom to rank by, so without it they
+// all tie and fall back to the order UsageFetcher happens to append them in.
 func sortedByAvailability(_ snapshots: [AccountSnapshot], activeProviders: Set<Provider> = []) -> [AccountSnapshot] {
     snapshots.enumerated()
         .sorted { lhs, rhs in
@@ -48,6 +52,12 @@ func sortedByAvailability(_ snapshots: [AccountSnapshot], activeProviders: Set<P
 
             if let leftRemaining, let rightRemaining, leftRemaining != rightRemaining {
                 return leftRemaining > rightRemaining
+            }
+
+            let leftActive = activeProviders.contains(left.provider)
+            let rightActive = activeProviders.contains(right.provider)
+            if leftActive != rightActive {
+                return leftActive
             }
 
             return lhs.offset < rhs.offset

--- a/Sources/Toki/Utilities/BusinessLogic.swift
+++ b/Sources/Toki/Utilities/BusinessLogic.swift
@@ -24,10 +24,6 @@ func nextResetDate(for account: AccountConfig, state: AccountUsageState?) -> Dat
 // (tier 1, since there's at least a live signal), then agent-detection-only providers
 // sitting idle (tier 2). Everything else (error state, remaining ratio) only breaks
 // ties within a tier - it never lets an idle no-API card outrank a real quota card.
-//
-// A live session is the last tiebreak rather than the first: cost-tracked providers
-// (Pi, Sarvam Code, fx, OpenCode) have no quota headroom to rank by, so without it they
-// all tie and fall back to the order UsageFetcher happens to append them in.
 func sortedByAvailability(_ snapshots: [AccountSnapshot], activeProviders: Set<Provider> = []) -> [AccountSnapshot] {
     snapshots.enumerated()
         .sorted { lhs, rhs in

--- a/Sources/Toki/Views/SpendAnalyticsPanel.swift
+++ b/Sources/Toki/Views/SpendAnalyticsPanel.swift
@@ -107,14 +107,17 @@ struct SpendAnalyticsPanel: View {
 
             if isLoadingLocalTotals && hasLocalCostProvider {
                 HStack(spacing: 4) {
-                    spendBlock(label: "Today", money: .usd(0))
-                    spendBlock(label: "Week", money: .usd(0))
-                    spendBlock(label: "Month", money: .usd(0))
-                    spendBlock(label: "All Time", money: .usd(0))
+                    spendBlock(label: "Today", money: .usd(0), tokens: 0)
+                    spendBlock(label: "Week", money: .usd(0), tokens: 0)
+                    spendBlock(label: "Month", money: .usd(0), tokens: 0)
+                    spendBlock(label: "All Time", money: .usd(0), tokens: 0)
                 }
                 .redacted(reason: .placeholder)
             } else {
                 ForEach(localSpendRows, id: \.currencyCode) { row in
+                    // Either every block in a row carries a token line or none does, so the
+                    // four surfaces stay the same height when only some periods have usage.
+                    let tokens = row.allTimeTokens > 0
                     VStack(alignment: .leading, spacing: 4) {
                         if localSpendRows.count > 1 {
                             Text(row.currencyCode)
@@ -122,10 +125,10 @@ struct SpendAnalyticsPanel: View {
                                 .foregroundStyle(.tertiary)
                         }
                         HStack(spacing: 4) {
-                            spendBlock(label: "Today", money: Money(amount: row.today, currencyCode: row.currencyCode), tokens: row.todayTokens)
-                            spendBlock(label: "Week", money: Money(amount: row.week, currencyCode: row.currencyCode), tokens: row.weekTokens)
-                            spendBlock(label: "Month", money: Money(amount: row.month, currencyCode: row.currencyCode), tokens: row.monthTokens)
-                            spendBlock(label: "All Time", money: Money(amount: row.allTime, currencyCode: row.currencyCode), tokens: row.allTimeTokens)
+                            spendBlock(label: "Today", money: Money(amount: row.today, currencyCode: row.currencyCode), tokens: tokens ? row.todayTokens : nil)
+                            spendBlock(label: "Week", money: Money(amount: row.week, currencyCode: row.currencyCode), tokens: tokens ? row.weekTokens : nil)
+                            spendBlock(label: "Month", money: Money(amount: row.month, currencyCode: row.currencyCode), tokens: tokens ? row.monthTokens : nil)
+                            spendBlock(label: "All Time", money: Money(amount: row.allTime, currencyCode: row.currencyCode), tokens: tokens ? row.allTimeTokens : nil)
                         }
                     }
                 }
@@ -148,14 +151,16 @@ struct SpendAnalyticsPanel: View {
         }
     }
 
-    private func spendBlock(label: String, money: Money, tokens: Double = 0) -> some View {
+    private func spendBlock(label: String, money: Money, tokens: Double?) -> some View {
         VStack(spacing: 4) {
             Text(formatMoney(money))
                 .font(.system(size: 11, weight: .semibold, design: .monospaced))
-            if tokens > 0 {
-                Text(formatCompact(tokens))
-                    .font(.system(size: 9, weight: .medium, design: .monospaced))
+            if let tokens {
+                Text("\(formatCompact(tokens)) tokens")
+                    .font(.system(size: 9))
                     .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
             }
             Text(label)
                 .font(.system(size: 9))
@@ -268,11 +273,20 @@ struct SpendAnalyticsPanel: View {
     }
 
     private func sessionCostGroups(_ agents: [ActiveAgent]) -> [(currencyCode: String, agents: [ActiveAgent])] {
-        Dictionary(grouping: agents.filter { $0.sessionUsage?.cost != nil }) {
-            $0.sessionUsage?.currencyCode ?? "USD"
+        let billed = agents.filter { $0.sessionUsage?.cost != nil }
+        let grouped: [String: [ActiveAgent]] = Dictionary(grouping: billed) { agent in
+            agent.sessionUsage?.currencyCode ?? "USD"
         }
-        .map { (currencyCode: $0.key, agents: $0.value) }
-        .sorted { $0.currencyCode < $1.currencyCode }
+        // Costliest first, so the capped session list leads with the sessions worth seeing.
+        return grouped
+            .map { key, value -> (currencyCode: String, agents: [ActiveAgent]) in
+                (currencyCode: key, agents: value.sorted { cost(of: $0) > cost(of: $1) })
+            }
+            .sorted { $0.currencyCode < $1.currencyCode }
+    }
+
+    private func cost(of agent: ActiveAgent) -> Double {
+        agent.sessionUsage?.cost ?? 0
     }
 
     // MARK: - Quota (%)
@@ -514,14 +528,12 @@ struct SpendAnalyticsPanel: View {
         }
     }
 
-    private struct LocalSpendRow {
+    struct LocalSpendRow: Equatable {
         let currencyCode: String
         var today = 0.0
         var week = 0.0
         var month = 0.0
         var allTime = 0.0
-        // Token totals are currency-agnostic, so they are tracked on the USD row only and
-        // displayed alongside the cost in each spend block.
         var todayTokens = 0.0
         var weekTokens = 0.0
         var monthTokens = 0.0
@@ -529,59 +541,73 @@ struct SpendAnalyticsPanel: View {
     }
 
     private var localSpendRows: [LocalSpendRow] {
+        Self.spendRows(pi: piTotals, openCode: openCodeTotals, fx: fxTotals, sarvam: sarvamCodeTotals)
+    }
+
+    /// Per-currency spend rows, with each provider's token counts attributed to the currency
+    /// that provider actually bills in.
+    ///
+    /// nonisolated + static so the currency attribution can be tested without a rendered view,
+    /// matching `agentID(at:in:agents:)` above.
+    nonisolated static func spendRows(
+        pi: PiUsageClient.Totals?,
+        openCode: OpenCodeUsageClient.Totals?,
+        fx: FxUsageClient.Totals?,
+        sarvam: SarvamCodeUsageClient.Totals?
+    ) -> [LocalSpendRow] {
         var rows: [String: LocalSpendRow] = [:]
         func add(_ amount: Double, currency: String, keyPath: WritableKeyPath<LocalSpendRow, Double>) {
             var row = rows[currency] ?? LocalSpendRow(currencyCode: currency)
             row[keyPath: keyPath] += amount
             rows[currency] = row
         }
-        func addTokens(_ tokens: Double, keyPath: WritableKeyPath<LocalSpendRow, Double>) {
-            var row = rows["USD"] ?? LocalSpendRow(currencyCode: "USD")
-            row[keyPath: keyPath] += tokens
-            rows["USD"] = row
+        func addUSD(costs: (Double, Double, Double, Double), tokens: (Double, Double, Double, Double)) {
+            add(costs.0, currency: "USD", keyPath: \.today)
+            add(costs.1, currency: "USD", keyPath: \.week)
+            add(costs.2, currency: "USD", keyPath: \.month)
+            add(costs.3, currency: "USD", keyPath: \.allTime)
+            add(tokens.0, currency: "USD", keyPath: \.todayTokens)
+            add(tokens.1, currency: "USD", keyPath: \.weekTokens)
+            add(tokens.2, currency: "USD", keyPath: \.monthTokens)
+            add(tokens.3, currency: "USD", keyPath: \.allTimeTokens)
         }
-        var usdSources: [(Double, Double, Double, Double)] = []
-        if let piTotals {
-            usdSources.append((piTotals.todayCost, piTotals.weekCost, piTotals.monthCost, piTotals.allTimeCost))
-            addTokens(piTotals.todayTokens, keyPath: \.todayTokens)
-            addTokens(piTotals.weekTokens, keyPath: \.weekTokens)
-            addTokens(piTotals.monthTokens, keyPath: \.monthTokens)
-            addTokens(piTotals.allTimeTokens, keyPath: \.allTimeTokens)
+
+        if let pi {
+            addUSD(
+                costs: (pi.todayCost, pi.weekCost, pi.monthCost, pi.allTimeCost),
+                tokens: (pi.todayTokens, pi.weekTokens, pi.monthTokens, pi.allTimeTokens)
+            )
         }
-        if let openCodeTotals {
-            usdSources.append((openCodeTotals.todayCost, openCodeTotals.weekCost, openCodeTotals.monthCost, openCodeTotals.allTimeCost))
-            addTokens(openCodeTotals.todayTokens, keyPath: \.todayTokens)
-            addTokens(openCodeTotals.weekTokens, keyPath: \.weekTokens)
-            addTokens(openCodeTotals.monthTokens, keyPath: \.monthTokens)
-            addTokens(openCodeTotals.allTimeTokens, keyPath: \.allTimeTokens)
+        if let openCode {
+            addUSD(
+                costs: (openCode.todayCost, openCode.weekCost, openCode.monthCost, openCode.allTimeCost),
+                tokens: (openCode.todayTokens, openCode.weekTokens, openCode.monthTokens, openCode.allTimeTokens)
+            )
         }
-        if let fxTotals {
-            usdSources.append((fxTotals.todayCost, fxTotals.weekCost, fxTotals.monthCost, fxTotals.allTimeCost))
-            addTokens(fxTotals.todayTokens, keyPath: \.todayTokens)
-            addTokens(fxTotals.weekTokens, keyPath: \.weekTokens)
-            addTokens(fxTotals.monthTokens, keyPath: \.monthTokens)
-            addTokens(fxTotals.allTimeTokens, keyPath: \.allTimeTokens)
+        if let fx {
+            addUSD(
+                costs: (fx.todayCost, fx.weekCost, fx.monthCost, fx.allTimeCost),
+                tokens: (fx.todayTokens, fx.weekTokens, fx.monthTokens, fx.allTimeTokens)
+            )
         }
-        for source in usdSources {
-            add(source.0, currency: "USD", keyPath: \.today)
-            add(source.1, currency: "USD", keyPath: \.week)
-            add(source.2, currency: "USD", keyPath: \.month)
-            add(source.3, currency: "USD", keyPath: \.allTime)
-        }
-        if let sarvamCodeTotals {
-            for money in sarvamCodeTotals.todayCosts.sortedMoney { add(money.amount, currency: money.currencyCode, keyPath: \.today) }
-            for money in sarvamCodeTotals.weekCosts.sortedMoney { add(money.amount, currency: money.currencyCode, keyPath: \.week) }
-            for money in sarvamCodeTotals.monthCosts.sortedMoney { add(money.amount, currency: money.currencyCode, keyPath: \.month) }
-            for money in sarvamCodeTotals.allTimeCosts.sortedMoney { add(money.amount, currency: money.currencyCode, keyPath: \.allTime) }
-            addTokens(Double(sarvamCodeTotals.todayTokens), keyPath: \.todayTokens)
-            addTokens(Double(sarvamCodeTotals.weekTokens), keyPath: \.weekTokens)
-            addTokens(Double(sarvamCodeTotals.monthTokens), keyPath: \.monthTokens)
-            addTokens(Double(sarvamCodeTotals.allTimeTokens), keyPath: \.allTimeTokens)
-            if sarvamCodeTotals.allTimeCosts.isEmpty, rows["USD"] == nil {
-                rows["USD"] = LocalSpendRow(currencyCode: "USD")
-            }
+        if let sarvam {
+            for money in sarvam.todayCosts.sortedMoney { add(money.amount, currency: money.currencyCode, keyPath: \.today) }
+            for money in sarvam.weekCosts.sortedMoney { add(money.amount, currency: money.currencyCode, keyPath: \.week) }
+            for money in sarvam.monthCosts.sortedMoney { add(money.amount, currency: money.currencyCode, keyPath: \.month) }
+            for money in sarvam.allTimeCosts.sortedMoney { add(money.amount, currency: money.currencyCode, keyPath: \.allTime) }
+            let base = dominantCurrency(sarvam.allTimeCosts) ?? "USD"
+            add(Double(sarvam.todayTokens), currency: dominantCurrency(sarvam.todayCosts) ?? base, keyPath: \.todayTokens)
+            add(Double(sarvam.weekTokens), currency: dominantCurrency(sarvam.weekCosts) ?? base, keyPath: \.weekTokens)
+            add(Double(sarvam.monthTokens), currency: dominantCurrency(sarvam.monthCosts) ?? base, keyPath: \.monthTokens)
+            add(Double(sarvam.allTimeTokens), currency: base, keyPath: \.allTimeTokens)
         }
         return rows.values.sorted { $0.currencyCode < $1.currencyCode }
+    }
+
+    /// The currency carrying the most spend, or nil when nothing has been billed yet.
+    /// Ties resolve to the alphabetically first code, so the choice is stable across refreshes.
+    nonisolated private static func dominantCurrency(_ totals: MoneyTotals) -> String? {
+        totals.sortedMoney.max { $0.amount < $1.amount }?.currencyCode
     }
 }
 

--- a/Sources/Toki/Views/SpendAnalyticsPanel.swift
+++ b/Sources/Toki/Views/SpendAnalyticsPanel.swift
@@ -75,7 +75,6 @@ struct SpendAnalyticsPanel: View {
             Text("Spend")
                 .font(.system(size: 11, weight: .semibold))
 
-            // Cost-based provider cards (Pi, OpenCode, fx, Sarvam Code)
             let costProviders = store.snapshots.filter { !$0.isError && $0.remainingRatio == nil && $0.menuBarValue != nil }
             if !costProviders.isEmpty {
                 ForEach(costProviders) { snap in
@@ -115,8 +114,6 @@ struct SpendAnalyticsPanel: View {
                 .redacted(reason: .placeholder)
             } else {
                 ForEach(localSpendRows, id: \.currencyCode) { row in
-                    // Either every block in a row carries a token line or none does, so the
-                    // four surfaces stay the same height when only some periods have usage.
                     let tokens = row.allTimeTokens > 0
                     VStack(alignment: .leading, spacing: 4) {
                         if localSpendRows.count > 1 {
@@ -192,9 +189,6 @@ struct SpendAnalyticsPanel: View {
                 }
             }
         }
-        // The agent list below the chart already serves as a legend (provider logo, title,
-        // cost, token count), so the chart's built-in legend is redundant. With 8+ sessions
-        // it wrapped to multiple lines and overlapped the chart and the list below it.
         .chartLegend(.hidden)
         .frame(height: 110)
         .chartOverlay { _ in
@@ -241,8 +235,6 @@ struct SpendAnalyticsPanel: View {
         .frame(height: 14)
         .padding(.horizontal, 4)
 
-        // Cap the session list so many agents scroll internally instead of pushing the
-        // whole panel down and crowding out the spend blocks and quota chart below it.
         ScrollView(.vertical) {
             VStack(spacing: 0) {
                 ForEach(agents) { agent in
@@ -277,7 +269,6 @@ struct SpendAnalyticsPanel: View {
         let grouped: [String: [ActiveAgent]] = Dictionary(grouping: billed) { agent in
             agent.sessionUsage?.currencyCode ?? "USD"
         }
-        // Costliest first, so the capped session list leads with the sessions worth seeing.
         return grouped
             .map { key, value -> (currencyCode: String, agents: [ActiveAgent]) in
                 (currencyCode: key, agents: value.sorted { cost(of: $0) > cost(of: $1) })
@@ -517,7 +508,6 @@ struct SpendAnalyticsPanel: View {
         store.snapshots.contains { $0.provider == .pi || $0.provider == .openCode || $0.provider == .sarvamCode || $0.provider == .fx }
     }
 
-    /// Today's token count for a provider, resolved from the locally-aggregated totals.
     private func todayTokens(for provider: Provider) -> Double? {
         switch provider {
         case .pi: return piTotals?.todayTokens
@@ -544,11 +534,6 @@ struct SpendAnalyticsPanel: View {
         Self.spendRows(pi: piTotals, openCode: openCodeTotals, fx: fxTotals, sarvam: sarvamCodeTotals)
     }
 
-    /// Per-currency spend rows, with each provider's token counts attributed to the currency
-    /// that provider actually bills in.
-    ///
-    /// nonisolated + static so the currency attribution can be tested without a rendered view,
-    /// matching `agentID(at:in:agents:)` above.
     nonisolated static func spendRows(
         pi: PiUsageClient.Totals?,
         openCode: OpenCodeUsageClient.Totals?,
@@ -604,8 +589,6 @@ struct SpendAnalyticsPanel: View {
         return rows.values.sorted { $0.currencyCode < $1.currencyCode }
     }
 
-    /// The currency carrying the most spend, or nil when nothing has been billed yet.
-    /// Ties resolve to the alphabetically first code, so the choice is stable across refreshes.
     nonisolated private static func dominantCurrency(_ totals: MoneyTotals) -> String? {
         totals.sortedMoney.max { $0.amount < $1.amount }?.currencyCode
     }

--- a/Sources/Toki/Views/SpendAnalyticsPanel.swift
+++ b/Sources/Toki/Views/SpendAnalyticsPanel.swift
@@ -6,6 +6,7 @@ struct SpendAnalyticsPanel: View {
     @State private var piTotals: PiUsageClient.Totals?
     @State private var openCodeTotals: OpenCodeUsageClient.Totals?
     @State private var sarvamCodeTotals: SarvamCodeUsageClient.Totals?
+    @State private var fxTotals: FxUsageClient.Totals?
     @State private var isLoadingLocalTotals = true
     @State private var selectedRange: TimeRange = .day
     @State private var selectedAgentID: Int32?
@@ -116,10 +117,10 @@ struct SpendAnalyticsPanel: View {
                                 .foregroundStyle(.tertiary)
                         }
                         HStack(spacing: 4) {
-                            spendBlock(label: "Today", money: Money(amount: row.today, currencyCode: row.currencyCode))
-                            spendBlock(label: "Week", money: Money(amount: row.week, currencyCode: row.currencyCode))
-                            spendBlock(label: "Month", money: Money(amount: row.month, currencyCode: row.currencyCode))
-                            spendBlock(label: "All Time", money: Money(amount: row.allTime, currencyCode: row.currencyCode))
+                            spendBlock(label: "Today", money: Money(amount: row.today, currencyCode: row.currencyCode), tokens: row.todayTokens)
+                            spendBlock(label: "Week", money: Money(amount: row.week, currencyCode: row.currencyCode), tokens: row.weekTokens)
+                            spendBlock(label: "Month", money: Money(amount: row.month, currencyCode: row.currencyCode), tokens: row.monthTokens)
+                            spendBlock(label: "All Time", money: Money(amount: row.allTime, currencyCode: row.currencyCode), tokens: row.allTimeTokens)
                         }
                     }
                 }
@@ -136,16 +137,21 @@ struct SpendAnalyticsPanel: View {
                 }
             }
 
-            if !isLoadingLocalTotals && costProviders.isEmpty && piTotals == nil && openCodeTotals == nil && sarvamCodeTotals == nil && costAgents.isEmpty {
+            if !isLoadingLocalTotals && costProviders.isEmpty && piTotals == nil && openCodeTotals == nil && sarvamCodeTotals == nil && fxTotals == nil && costAgents.isEmpty {
                 emptyState(icon: "dollarsign.circle", text: "No spend data yet")
             }
         }
     }
 
-    private func spendBlock(label: String, money: Money) -> some View {
+    private func spendBlock(label: String, money: Money, tokens: Double = 0) -> some View {
         VStack(spacing: 4) {
             Text(formatMoney(money))
                 .font(.system(size: 11, weight: .semibold, design: .monospaced))
+            if tokens > 0 {
+                Text(formatCompact(tokens))
+                    .font(.system(size: 9, weight: .medium, design: .monospaced))
+                    .foregroundStyle(.secondary)
+            }
             Text(label)
                 .font(.system(size: 9))
                 .foregroundStyle(.tertiary)
@@ -176,8 +182,11 @@ struct SpendAnalyticsPanel: View {
                 }
             }
         }
-        .chartLegend(position: .bottom, spacing: 8)
-        .frame(height: 160)
+        // The agent list below the chart already serves as a legend (provider logo, title,
+        // cost, token count), so the chart's built-in legend is redundant. With 8+ sessions
+        // it wrapped to multiple lines and overlapped the chart and the list below it.
+        .chartLegend(.hidden)
+        .frame(height: 140)
         .chartOverlay { _ in
             GeometryReader { geometry in
                 Rectangle()
@@ -472,10 +481,13 @@ struct SpendAnalyticsPanel: View {
         if store.snapshots.contains(where: { $0.provider == .sarvamCode }) {
             sarvamCodeTotals = try? SarvamCodeUsageClient.aggregate()
         }
+        if store.snapshots.contains(where: { $0.provider == .fx }) {
+            fxTotals = try? FxUsageClient.aggregate()
+        }
     }
 
     private var hasLocalCostProvider: Bool {
-        store.snapshots.contains { $0.provider == .pi || $0.provider == .openCode || $0.provider == .sarvamCode }
+        store.snapshots.contains { $0.provider == .pi || $0.provider == .openCode || $0.provider == .sarvamCode || $0.provider == .fx }
     }
 
     private struct LocalSpendRow {
@@ -484,6 +496,12 @@ struct SpendAnalyticsPanel: View {
         var week = 0.0
         var month = 0.0
         var allTime = 0.0
+        // Token totals are currency-agnostic, so they are tracked on the USD row only and
+        // displayed alongside the cost in each spend block.
+        var todayTokens = 0.0
+        var weekTokens = 0.0
+        var monthTokens = 0.0
+        var allTimeTokens = 0.0
     }
 
     private var localSpendRows: [LocalSpendRow] {
@@ -493,12 +511,32 @@ struct SpendAnalyticsPanel: View {
             row[keyPath: keyPath] += amount
             rows[currency] = row
         }
+        func addTokens(_ tokens: Double, keyPath: WritableKeyPath<LocalSpendRow, Double>) {
+            var row = rows["USD"] ?? LocalSpendRow(currencyCode: "USD")
+            row[keyPath: keyPath] += tokens
+            rows["USD"] = row
+        }
         var usdSources: [(Double, Double, Double, Double)] = []
         if let piTotals {
             usdSources.append((piTotals.todayCost, piTotals.weekCost, piTotals.monthCost, piTotals.allTimeCost))
+            addTokens(piTotals.todayTokens, keyPath: \.todayTokens)
+            addTokens(piTotals.weekTokens, keyPath: \.weekTokens)
+            addTokens(piTotals.monthTokens, keyPath: \.monthTokens)
+            addTokens(piTotals.allTimeTokens, keyPath: \.allTimeTokens)
         }
         if let openCodeTotals {
             usdSources.append((openCodeTotals.todayCost, openCodeTotals.weekCost, openCodeTotals.monthCost, openCodeTotals.allTimeCost))
+            addTokens(openCodeTotals.todayTokens, keyPath: \.todayTokens)
+            addTokens(openCodeTotals.weekTokens, keyPath: \.weekTokens)
+            addTokens(openCodeTotals.monthTokens, keyPath: \.monthTokens)
+            addTokens(openCodeTotals.allTimeTokens, keyPath: \.allTimeTokens)
+        }
+        if let fxTotals {
+            usdSources.append((fxTotals.todayCost, fxTotals.weekCost, fxTotals.monthCost, fxTotals.allTimeCost))
+            addTokens(fxTotals.todayTokens, keyPath: \.todayTokens)
+            addTokens(fxTotals.weekTokens, keyPath: \.weekTokens)
+            addTokens(fxTotals.monthTokens, keyPath: \.monthTokens)
+            addTokens(fxTotals.allTimeTokens, keyPath: \.allTimeTokens)
         }
         for source in usdSources {
             add(source.0, currency: "USD", keyPath: \.today)
@@ -511,6 +549,10 @@ struct SpendAnalyticsPanel: View {
             for money in sarvamCodeTotals.weekCosts.sortedMoney { add(money.amount, currency: money.currencyCode, keyPath: \.week) }
             for money in sarvamCodeTotals.monthCosts.sortedMoney { add(money.amount, currency: money.currencyCode, keyPath: \.month) }
             for money in sarvamCodeTotals.allTimeCosts.sortedMoney { add(money.amount, currency: money.currencyCode, keyPath: \.allTime) }
+            addTokens(Double(sarvamCodeTotals.todayTokens), keyPath: \.todayTokens)
+            addTokens(Double(sarvamCodeTotals.weekTokens), keyPath: \.weekTokens)
+            addTokens(Double(sarvamCodeTotals.monthTokens), keyPath: \.monthTokens)
+            addTokens(Double(sarvamCodeTotals.allTimeTokens), keyPath: \.allTimeTokens)
             if sarvamCodeTotals.allTimeCosts.isEmpty, rows["USD"] == nil {
                 rows["USD"] = LocalSpendRow(currencyCode: "USD")
             }

--- a/Sources/Toki/Views/SpendAnalyticsPanel.swift
+++ b/Sources/Toki/Views/SpendAnalyticsPanel.swift
@@ -75,7 +75,7 @@ struct SpendAnalyticsPanel: View {
             Text("Spend")
                 .font(.system(size: 11, weight: .semibold))
 
-            // Cost-based provider cards (Pi, OpenCode)
+            // Cost-based provider cards (Pi, OpenCode, fx, Sarvam Code)
             let costProviders = store.snapshots.filter { !$0.isError && $0.remainingRatio == nil && $0.menuBarValue != nil }
             if !costProviders.isEmpty {
                 ForEach(costProviders) { snap in
@@ -89,6 +89,11 @@ struct SpendAnalyticsPanel: View {
                                 .foregroundStyle(.tertiary)
                         }
                         Spacer()
+                        if let todayTokens = todayTokens(for: snap.provider), todayTokens > 0 {
+                            Text("\(formatCompact(todayTokens)) tokens")
+                                .font(.system(size: 9))
+                                .foregroundStyle(.tertiary)
+                        }
                         if let bar = snap.menuBarValue {
                             Text(bar)
                                 .font(.system(size: 11, weight: .semibold, design: .monospaced))
@@ -186,7 +191,7 @@ struct SpendAnalyticsPanel: View {
         // cost, token count), so the chart's built-in legend is redundant. With 8+ sessions
         // it wrapped to multiple lines and overlapped the chart and the list below it.
         .chartLegend(.hidden)
-        .frame(height: 140)
+        .frame(height: 110)
         .chartOverlay { _ in
             GeometryReader { geometry in
                 Rectangle()
@@ -231,27 +236,35 @@ struct SpendAnalyticsPanel: View {
         .frame(height: 14)
         .padding(.horizontal, 4)
 
-        ForEach(agents) { agent in
-            HStack(spacing: 8) {
-                ProviderLogo(provider: agent.provider, size: 16)
-                Text(agent.title)
-                    .font(.system(size: 11, weight: .medium))
-                    .lineLimit(1)
-                Spacer()
-                if let usage = agent.sessionUsage, let cost = usage.cost {
-                    Text(formatMoney(Money(amount: cost, currencyCode: usage.currencyCode)))
-                        .font(.system(size: 11, weight: .semibold, design: .monospaced))
-                    Text("\(formatCompact(Double(usage.tokensInput + usage.tokensOutput))) tokens")
-                        .font(.system(size: 10))
-                        .foregroundStyle(.tertiary)
+        // Cap the session list so many agents scroll internally instead of pushing the
+        // whole panel down and crowding out the spend blocks and quota chart below it.
+        ScrollView(.vertical) {
+            VStack(spacing: 0) {
+                ForEach(agents) { agent in
+                    HStack(spacing: 8) {
+                        ProviderLogo(provider: agent.provider, size: 16)
+                        Text(agent.title)
+                            .font(.system(size: 11, weight: .medium))
+                            .lineLimit(1)
+                        Spacer()
+                        if let usage = agent.sessionUsage, let cost = usage.cost {
+                            Text(formatMoney(Money(amount: cost, currencyCode: usage.currencyCode)))
+                                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                            Text("\(formatCompact(Double(usage.tokensInput + usage.tokensOutput))) tokens")
+                                .font(.system(size: 10))
+                                .foregroundStyle(.tertiary)
+                        }
+                    }
+                    .padding(8)
+                    .contentSurface()
+                    .onHover { isHovered in
+                        selectedAgentID = isHovered ? agent.id : nil
+                    }
                 }
             }
-            .padding(8)
-            .contentSurface()
-            .onHover { isHovered in
-                selectedAgentID = isHovered ? agent.id : nil
-            }
         }
+        .scrollIndicators(.hidden)
+        .frame(maxHeight: 220)
     }
 
     private func sessionCostGroups(_ agents: [ActiveAgent]) -> [(currencyCode: String, agents: [ActiveAgent])] {
@@ -488,6 +501,17 @@ struct SpendAnalyticsPanel: View {
 
     private var hasLocalCostProvider: Bool {
         store.snapshots.contains { $0.provider == .pi || $0.provider == .openCode || $0.provider == .sarvamCode || $0.provider == .fx }
+    }
+
+    /// Today's token count for a provider, resolved from the locally-aggregated totals.
+    private func todayTokens(for provider: Provider) -> Double? {
+        switch provider {
+        case .pi: return piTotals?.todayTokens
+        case .openCode: return openCodeTotals?.todayTokens
+        case .fx: return fxTotals?.todayTokens
+        case .sarvamCode: return sarvamCodeTotals.map { Double($0.todayTokens) }
+        default: return nil
+        }
     }
 
     private struct LocalSpendRow {

--- a/Tests/TokiTests/AccountRenameTests.swift
+++ b/Tests/TokiTests/AccountRenameTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+@testable import Toki
+
+@MainActor
+final class AccountRenameTests: XCTestCase {
+    nonisolated(unsafe) private var directory: URL!
+
+    override func setUpWithError() throws {
+        directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("toki-rename-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        setenv("TOKI_CONFIG", directory.appendingPathComponent("config.json").path, 1)
+        setenv("TOKI_STATE", directory.appendingPathComponent("state.json").path, 1)
+    }
+
+    override func tearDownWithError() throws {
+        unsetenv("TOKI_CONFIG")
+        unsetenv("TOKI_STATE")
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    private func snapshot(id: String, name: String, provider: Provider) -> AccountSnapshot {
+        AccountSnapshot(
+            id: id,
+            name: name,
+            provider: provider,
+            primary: "",
+            subtitle: "",
+            remainingRatio: nil,
+            metrics: []
+        )
+    }
+
+    private func store(accounts: [AccountConfig], snapshots: [AccountSnapshot]) throws -> UsageStore {
+        let config = AppConfig(refreshMinutes: nil, accountLabels: nil, accounts: accounts, aiInstructions: nil)
+        try ConfigLoader.save(config)
+        let store = UsageStore()
+        store.config = config
+        store.snapshots = snapshots
+        return store
+    }
+
+    func testRenamingAnAutoDetectedProviderPersistsIt() throws {
+        let sarvam = snapshot(id: "sarvam-code-auto", name: "Sarvam Code", provider: .sarvamCode)
+        let store = try store(
+            accounts: [AccountConfig(id: "claude-code", name: "Claude Code", provider: .claudeCode)],
+            snapshots: [sarvam]
+        )
+
+        store.renameAccount(snapshot: sarvam, alias: "Sarvam")
+
+        let saved = try ConfigLoader.load()
+        let entry = saved.accounts.first { $0.provider == .sarvamCode }
+        XCTAssertEqual(entry?.name, "Sarvam")
+        XCTAssertEqual(entry?.id, "sarvam-code-auto", "reusing the id keeps history keyed to it")
+        XCTAssertEqual(store.snapshots.first?.name, "Sarvam")
+        XCTAssertNil(store.configError)
+    }
+
+    func testRenamingTheSameProviderTwiceUpdatesInsteadOfDuplicating() throws {
+        let sarvam = snapshot(id: "sarvam-code-auto", name: "Sarvam Code", provider: .sarvamCode)
+        let store = try store(accounts: [], snapshots: [sarvam])
+
+        store.renameAccount(snapshot: sarvam, alias: "Sarvam")
+        store.renameAccount(snapshot: store.snapshots[0], alias: "Sarvam AI")
+
+        let saved = try ConfigLoader.load()
+        XCTAssertEqual(saved.accounts.filter { $0.provider == .sarvamCode }.count, 1)
+        XCTAssertEqual(saved.accounts.first { $0.provider == .sarvamCode }?.name, "Sarvam AI")
+    }
+
+    func testRenamingAConfiguredAccountStillUpdatesInPlace() throws {
+        let sarvam = snapshot(id: "sarvam-code-auto", name: "Sarvam Code", provider: .sarvamCode)
+        let store = try store(
+            accounts: [AccountConfig(id: "sarvam-code-auto", name: "Sarvam Code", provider: .sarvamCode)],
+            snapshots: [sarvam]
+        )
+
+        store.renameAccount(snapshot: sarvam, alias: "Sarvam AI")
+
+        let saved = try ConfigLoader.load()
+        XCTAssertEqual(saved.accounts.count, 1)
+        XCTAssertEqual(saved.accounts[0].name, "Sarvam AI")
+    }
+
+    func testAClaudeSnapshotWithoutAnEmailDoesNotAppendAStrayAccount() throws {
+        let claude = snapshot(id: "claude-1-unknown", name: "Claude", provider: .claudeCode)
+        let store = try store(
+            accounts: [AccountConfig(id: "claude-code", name: "Claude Code", provider: .claudeCode)],
+            snapshots: [claude]
+        )
+
+        store.renameAccount(snapshot: claude, alias: "Personal")
+
+        let saved = try ConfigLoader.load()
+        XCTAssertEqual(saved.accounts.count, 1)
+        XCTAssertEqual(saved.accounts[0].id, "claude-code")
+    }
+}

--- a/Tests/TokiTests/FxUsageClientTests.swift
+++ b/Tests/TokiTests/FxUsageClientTests.swift
@@ -7,10 +7,18 @@ final class FxUsageClientTests: XCTestCase {
         Int(ISO8601DateFormatter().date(from: iso)!.timeIntervalSince1970 * 1000)
     }
 
-    private func generation(id: String, at iso: String, cost: Double, input: Int = 0, output: Int = 0) -> String {
+    private func generation(
+        id: String,
+        at iso: String,
+        cost: Double,
+        input: Int = 0,
+        output: Int = 0,
+        cacheRead: Int = 0,
+        cacheWrite: Int = 0
+    ) -> String {
         "{\"schema_version\":1,\"kind\":\"generation\",\"fact\":{\"id\":\"\(id)\",\"created_at_ms\":\(ms(iso)),"
-            + "\"model\":\"m\",\"input_tokens\":\(input),\"output_tokens\":\(output),\"cache_read_tokens\":0,"
-            + "\"cache_write_tokens\":0,\"reasoning_tokens\":0,\"total_cost\":\(cost)}}"
+            + "\"model\":\"m\",\"input_tokens\":\(input),\"output_tokens\":\(output),\"cache_read_tokens\":\(cacheRead),"
+            + "\"cache_write_tokens\":\(cacheWrite),\"reasoning_tokens\":0,\"total_cost\":\(cost)}}"
     }
 
     func testAggregateBucketsDedupesAndToleratesNoise() throws {
@@ -19,11 +27,11 @@ final class FxUsageClientTests: XCTestCase {
         // now = 2026-08-19 (Wed). Sunday-based week is 2026-08-16..08-22; August is the month.
         let jsonl = [
             "{\"schema_version\":1,\"kind\":\"coverage\",\"started_at_ms\":\(ms("2026-08-01T00:00:00Z"))}",
-            generation(id: "today", at: "2026-08-19T09:00:00Z", cost: 0.10, input: 100, output: 10),
+            generation(id: "today", at: "2026-08-19T09:00:00Z", cost: 0.10, input: 100, output: 10, cacheRead: 1_000, cacheWrite: 50),
             generation(id: "today", at: "2026-08-19T10:00:00Z", cost: 0.99, input: 999, output: 99),  // dup id
-            generation(id: "week", at: "2026-08-18T09:00:00Z", cost: 0.20),
-            generation(id: "month", at: "2026-08-03T09:00:00Z", cost: 0.30),
-            generation(id: "last-month", at: "2026-07-20T09:00:00Z", cost: 0.40),
+            generation(id: "week", at: "2026-08-18T09:00:00Z", cost: 0.20, input: 20, output: 2),
+            generation(id: "month", at: "2026-08-03T09:00:00Z", cost: 0.30, input: 30, output: 3),
+            generation(id: "last-month", at: "2026-07-20T09:00:00Z", cost: 0.40, input: 40, output: 4),
             generation(id: "negative", at: "2026-08-19T11:00:00Z", cost: -5),
             "{ not valid json"
         ].joined(separator: "\n")
@@ -42,6 +50,31 @@ final class FxUsageClientTests: XCTestCase {
         XCTAssertEqual(totals.monthCost, 0.60, accuracy: 0.000_001)  // today + week + month
         XCTAssertEqual(totals.allTimeCost, 1.00, accuracy: 0.000_001) // negative ignored
         XCTAssertEqual(totals.requestCount, 5)                        // unique generation facts
+    }
+
+    func testAggregateBucketsTokensIncludingCacheAndSkipsDuplicates() throws {
+        let root = try temporaryDirectory()
+        let file = (root as NSString).appendingPathComponent("usage.jsonl")
+        let jsonl = [
+            generation(id: "today", at: "2026-08-19T09:00:00Z", cost: 0.10, input: 100, output: 10, cacheRead: 1_000, cacheWrite: 50),
+            generation(id: "today", at: "2026-08-19T10:00:00Z", cost: 0.99, input: 999, output: 99),  // dup id
+            generation(id: "week", at: "2026-08-18T09:00:00Z", cost: 0.20, input: 20, output: 2),
+            generation(id: "month", at: "2026-08-03T09:00:00Z", cost: 0.30, input: 30, output: 3),
+            generation(id: "last-month", at: "2026-07-20T09:00:00Z", cost: 0.40, input: 40, output: 4)
+        ].joined(separator: "\n")
+        try jsonl.write(toFile: file, atomically: true, encoding: .utf8)
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let now = ISO8601DateFormatter().date(from: "2026-08-19T18:00:00Z")!
+
+        let totals = try FxUsageClient.aggregate(path: file, now: now, calendar: calendar)
+
+        XCTAssertEqual(totals.todayTokens, 1_160)     // 100 + 10 + 1000 + 50, dup not counted
+        XCTAssertEqual(totals.weekTokens, 1_182)      // today + 22
+        XCTAssertEqual(totals.monthTokens, 1_215)     // today + week + 33
+        XCTAssertEqual(totals.allTimeTokens, 1_259)   // + last month's 44
+        XCTAssertEqual(totals.todayCacheRead, 1_000)
     }
 
     func testMissingLedgerThrowsWithoutExposingPath() throws {

--- a/Tests/TokiTests/ProviderOrderingTests.swift
+++ b/Tests/TokiTests/ProviderOrderingTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+@testable import Toki
+
+final class ProviderOrderingTests: XCTestCase {
+    private func snapshot(
+        _ id: String,
+        provider: Provider,
+        remaining: Double? = nil,
+        isError: Bool = false,
+        agentOnly: Bool = false
+    ) -> AccountSnapshot {
+        AccountSnapshot(
+            id: id,
+            name: id,
+            provider: provider,
+            primary: "",
+            subtitle: "",
+            remainingRatio: remaining,
+            metrics: [],
+            isError: isError,
+            isAgentDetectionOnly: agentOnly
+        )
+    }
+
+    private func order(_ snapshots: [AccountSnapshot], active: Set<Provider> = []) -> [String] {
+        sortedByAvailability(snapshots, activeProviders: active).map(\.id)
+    }
+
+    func testRunningCostProviderOutranksIdleOneRegardlessOfDetectionOrder() {
+        let snapshots = [
+            snapshot("opencode", provider: .openCode),
+            snapshot("pi", provider: .pi),
+            snapshot("fx", provider: .fx),
+            snapshot("sarvam", provider: .sarvamCode)
+        ]
+
+        XCTAssertEqual(order(snapshots), ["opencode", "pi", "fx", "sarvam"])
+        XCTAssertEqual(order(snapshots, active: [.sarvamCode]), ["sarvam", "opencode", "pi", "fx"])
+    }
+
+    func testCostProvidersKeepDetectionOrderWhenSeveralAreRunning() {
+        let snapshots = [
+            snapshot("pi", provider: .pi),
+            snapshot("sarvam", provider: .sarvamCode),
+            snapshot("fx", provider: .fx)
+        ]
+
+        XCTAssertEqual(order(snapshots, active: [.pi, .sarvamCode]), ["pi", "sarvam", "fx"])
+    }
+
+    func testALiveSessionNeverOutranksQuotaHeadroom() {
+        let snapshots = [
+            snapshot("claude", provider: .claudeCode, remaining: 0.9),
+            snapshot("codex", provider: .codex, remaining: 0.4),
+            snapshot("sarvam", provider: .sarvamCode)
+        ]
+
+        XCTAssertEqual(order(snapshots, active: [.sarvamCode]), ["claude", "codex", "sarvam"])
+    }
+
+    func testAgentOnlyProvidersStillRankBelowRealUsageData() {
+        let snapshots = [
+            snapshot("grok", provider: .grok, agentOnly: true),
+            snapshot("pi", provider: .pi)
+        ]
+
+        XCTAssertEqual(order(snapshots, active: [.grok]), ["pi", "grok"])
+    }
+
+    func testErroredProviderSinksBelowAHealthyOneEvenWhenRunning() {
+        let snapshots = [
+            snapshot("sarvam", provider: .sarvamCode, isError: true),
+            snapshot("pi", provider: .pi)
+        ]
+
+        XCTAssertEqual(order(snapshots, active: [.sarvamCode]), ["pi", "sarvam"])
+    }
+}

--- a/Tests/TokiTests/SpendAnalyticsRowTests.swift
+++ b/Tests/TokiTests/SpendAnalyticsRowTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+@testable import Toki
+
+final class SpendAnalyticsRowTests: XCTestCase {
+    private func money(_ pairs: [(Double, String)]) -> MoneyTotals {
+        var totals = MoneyTotals()
+        for (amount, currency) in pairs {
+            totals.add(Money(amount: amount, currencyCode: currency), includingZero: true)
+        }
+        return totals
+    }
+
+    private func sarvam(
+        costs: [(Double, String)],
+        today: Int = 0,
+        week: Int = 0,
+        month: Int = 0,
+        allTime: Int = 0
+    ) -> SarvamCodeUsageClient.Totals {
+        var totals = SarvamCodeUsageClient.Totals()
+        totals.todayCosts = money(costs)
+        totals.weekCosts = money(costs)
+        totals.monthCosts = money(costs)
+        totals.allTimeCosts = money(costs)
+        totals.todayTokens = today
+        totals.weekTokens = week
+        totals.monthTokens = month
+        totals.allTimeTokens = allTime
+        return totals
+    }
+
+    private func rows(
+        pi: PiUsageClient.Totals? = nil,
+        openCode: OpenCodeUsageClient.Totals? = nil,
+        fx: FxUsageClient.Totals? = nil,
+        sarvam: SarvamCodeUsageClient.Totals? = nil
+    ) -> [SpendAnalyticsPanel.LocalSpendRow] {
+        SpendAnalyticsPanel.spendRows(pi: pi, openCode: openCode, fx: fx, sarvam: sarvam)
+    }
+
+    func testNonUSDProviderDoesNotGetAPhantomUSDRow() {
+        let result = rows(sarvam: sarvam(costs: [(120, "INR")], today: 5_000, week: 9_000, month: 9_000, allTime: 9_000))
+
+        XCTAssertEqual(result.map(\.currencyCode), ["INR"])
+        XCTAssertEqual(result[0].allTime, 120, accuracy: 0.000_001)
+        XCTAssertEqual(result[0].todayTokens, 5_000)
+        XCTAssertEqual(result[0].allTimeTokens, 9_000)
+    }
+
+    func testUSDProvidersShareOneRowAndSumCostsAndTokens() {
+        var pi = PiUsageClient.Totals()
+        pi.todayCost = 1
+        pi.allTimeCost = 4
+        pi.todayTokens = 100
+        pi.allTimeTokens = 400
+
+        var openCode = OpenCodeUsageClient.Totals()
+        openCode.todayCost = 2
+        openCode.allTimeCost = 5
+        openCode.todayTokens = 200
+        openCode.allTimeTokens = 500
+
+        var fx = FxUsageClient.Totals()
+        fx.todayCost = 3
+        fx.allTimeCost = 6
+        fx.todayTokens = 300
+        fx.allTimeTokens = 600
+
+        let result = rows(pi: pi, openCode: openCode, fx: fx)
+
+        XCTAssertEqual(result.map(\.currencyCode), ["USD"])
+        XCTAssertEqual(result[0].today, 6, accuracy: 0.000_001)
+        XCTAssertEqual(result[0].allTime, 15, accuracy: 0.000_001)
+        XCTAssertEqual(result[0].todayTokens, 600)
+        XCTAssertEqual(result[0].allTimeTokens, 1_500)
+    }
+
+    func testMixedCurrenciesKeepEachProvidersTokensOnItsOwnRow() {
+        var pi = PiUsageClient.Totals()
+        pi.todayCost = 2
+        pi.allTimeCost = 2
+        pi.todayTokens = 700
+        pi.allTimeTokens = 700
+
+        let result = rows(pi: pi, sarvam: sarvam(costs: [(50, "INR")], today: 300, allTime: 300))
+
+        XCTAssertEqual(result.map(\.currencyCode), ["INR", "USD"])
+        XCTAssertEqual(result[0].todayTokens, 300)
+        XCTAssertEqual(result[0].allTimeTokens, 300)
+        XCTAssertEqual(result[1].todayTokens, 700)
+        XCTAssertEqual(result[1].allTimeTokens, 700)
+    }
+
+    func testProviderWithoutAnyCostStillShowsAUSDRow() {
+        let result = rows(sarvam: sarvam(costs: [], today: 1_200, allTime: 1_200))
+
+        XCTAssertEqual(result.map(\.currencyCode), ["USD"])
+        XCTAssertEqual(result[0].allTime, 0, accuracy: 0.000_001)
+        XCTAssertEqual(result[0].todayTokens, 1_200)
+    }
+
+    func testPeriodWithoutCostFallsBackToTheAllTimeCurrency() {
+        var totals = sarvam(costs: [(75, "INR")], today: 400, allTime: 400)
+        totals.todayCosts = MoneyTotals()
+
+        let result = rows(sarvam: totals)
+
+        XCTAssertEqual(result.map(\.currencyCode), ["INR"])
+        XCTAssertEqual(result[0].todayTokens, 400)
+    }
+
+    func testNoProvidersProduceNoRows() {
+        XCTAssertTrue(rows().isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

Shows token usage alongside spend in the Analytics tab, and fixes the bugs that surfaced while building it: two in how those tokens are counted and attributed, one in how providers are ordered, and one that made renaming an auto-detected provider silently impossible.

## Token usage in the spend section

OpenCode, Pi, fx, and Sarvam Code all report token counts locally, but the spend blocks showed only money. Each provider's `Totals` gained `todayTokens`/`weekTokens`/`monthTokens`/`allTimeTokens`, threaded through `LocalSpendRow` into `spendBlock`, which renders the compact count under the amount. Cost provider cards also carry today's count next to their spend.

fx was missing from the spend section's provider detection and loading path entirely, so it is wired in alongside Pi, OpenCode, and Sarvam Code.

## Token counts were attributed to the wrong currency

Tokens were added to the `"USD"` row unconditionally. For an install billing in another currency, the costs landed on the real row (INR, say) while the tokens force-created a USD row holding no cost, so the panel rendered a phantom `USD` section reading `$0.00` for all four periods beside the real one, and tripped the `localSpendRows.count > 1` multi-currency labels.

Each provider's tokens now land on the currency row its costs land on. Sarvam Code is the only genuinely multi-currency source, so it attributes to the currency carrying the most spend in that period, falling back to its all-time dominant currency and then to USD. That fallback also subsumes the old `allTimeCosts.isEmpty` special case, which existed to keep an empty USD row for a Sarvam install with no cost data.

The aggregation moved out of the view into `SpendAnalyticsPanel.spendRows`, a `nonisolated static` matching the existing `agentID(at:in:agents:)`, so the attribution is testable without rendering.

## OpenCode undercounted tokens by roughly 28x

It summed `tokens_input + tokens_output` while fx and Pi both include cache reads and writes, and all three add into the same USD figure. On a real database that is 9.6M reported against 275.2M actual, because cache reads dominate.

`tokens_cache_read` and `tokens_cache_write` are now included, but probed from `PRAGMA table_info(session)` rather than assumed. Naming them directly would throw on an `opencode.db` predating those columns, and since `aggregate()` is called through `try?`, that failure would blank the entire spend panel rather than degrade the token figure. `tokens_reasoning` is deliberately left out, since providers generally already count it inside output.

## A running cost provider ranked below an idle one

`sortedByAvailability` consults `activeProviders` only inside `availabilityTier`, which separates tiers 1 and 2, and those apply solely to agent-detection-only providers. Everything reporting real usage lands in tier 0, and cost-tracked providers then tie through the error and remaining-ratio comparisons because none of them has quota headroom to rank by. They fell through to the stable index fallback, which is the order `accountsIncludingAutoDetected` appends in: OpenCode, Pi, Cursor, Antigravity, fx, Sarvam Code.

So Sarvam Code sat at the bottom of the Spend section while actively running, and nothing could change that. A live session is now the last tiebreak before the index fallback, which lifts a running cost provider above its idle peers without letting it outrank quota headroom, lift an errored card, or let an agent-only card outrank real usage data.

## Auto-detected providers could not be renamed

`renameAccount` looked the snapshot up in `config.accounts` and returned when it was absent. Pi, OpenCode, fx, Sarvam Code, Cursor, and Antigravity are synthesised by `accountsIncludingAutoDetected` and deliberately never persisted, so none had an entry to find. The card still offered the pencil, accepted the typed name, and reverted it with no error.

The first rename now materialises the config entry, reusing the snapshot id so history keyed to it carries over and `accountsIncludingAutoDetected` stops synthesising a duplicate. It fires only when no account of that provider is configured, so a Claude snapshot whose email could not be read still falls through instead of appending a stray entry beside the real `claude-code` account.

## Layout

The donut's built-in legend wrapped to several lines past eight sessions and overlapped both the chart and the list below it. The list already serves as a richer legend, carrying provider logo, title, cost, and token count, so the legend is hidden and the chart height drops from 160 to 110. The session list is bounded in a `ScrollView` so it no longer pushes the spend blocks and quota chart out of view, and each group is sorted costliest first so the capped view leads with what matters.

The token line previously rendered only when that period had usage, so a row where today was idle but the week was not produced four surfaces of unequal height in one `HStack`. A row now shows the line in every block or in none, and the count is labelled `tokens` so it cannot be misread as a second currency amount.

## Verification

- `swift build` clean
- `swift test`: 363 pass, including 16 new ones covering currency attribution, fx token bucketing with cache and dedup, provider ordering (the first tests `sortedByAvailability` has had), and renaming across configured, auto-detected, and repeat-rename paths
- `scripts/build-app.sh` builds and the app runs
