### PR TITLE
Cut release notes to one line per change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,10 +86,11 @@ jobs:
             PRERELEASE_FLAG="--prerelease"
           fi
           # A tagged release reads its notes from the matching CHANGELOG.md section, so the
-          # release page carries the curated entries rather than a raw commit list. Prerelease
-          # tags have no section of their own and fall back to the generated notes.
+          # release page carries the curated entries rather than a raw commit list. --summary
+          # keeps it to one line per change; the full text stays in CHANGELOG.md and in the
+          # app's What's New. Prerelease tags have no section and fall back to generated notes.
           NOTES_FILE="$RUNNER_TEMP/release-notes.md"
-          if bash scripts/release-notes.sh "${GITHUB_REF_NAME}" > "$NOTES_FILE"; then
+          if bash scripts/release-notes.sh --summary "${GITHUB_REF_NAME}" > "$NOTES_FILE"; then
             NOTES_FLAGS=(--notes-file "$NOTES_FILE")
           else
             NOTES_FLAGS=(--generate-notes)

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # Prints CHANGELOG.md's section for a release tag, for `gh release create --notes-file`.
+# With --summary, each entry is cut back to its headline, so the release page reads as one
+# line per change while CHANGELOG.md keeps the full text.
 # Exits 1 when the changelog has no section for that version, which is the normal case for a
 # prerelease tag - the caller falls back to --generate-notes there.
 set -euo pipefail
@@ -7,9 +9,17 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CHANGELOG="$ROOT_DIR/CHANGELOG.md"
 
-TAG="${1:-}"
+SUMMARY=false
+TAG=""
+for arg in "$@"; do
+  case "$arg" in
+    --summary) SUMMARY=true ;;
+    *) TAG="$arg" ;;
+  esac
+done
+
 if [[ -z "$TAG" ]]; then
-  echo "usage: release-notes.sh <tag>" >&2
+  echo "usage: release-notes.sh [--summary] <tag>" >&2
   exit 2
 fi
 
@@ -29,6 +39,10 @@ NOTES=$(printf '%s\n' "$NOTES" | sed -e '/./,$!d' | awk 'BEGIN{blank=0} /^$/{bla
 if [[ -z "$NOTES" ]]; then
   echo "No CHANGELOG.md section for $VERSION" >&2
   exit 1
+fi
+
+if [[ "$SUMMARY" == true ]]; then
+  NOTES=$(printf '%s\n' "$NOTES" | sed -E 's/^- (\*\*[^*]+\*\*).*/- \1/')
 fi
 
 printf '%s\n' "$NOTES"


### PR DESCRIPTION
## Summary

The 3.0.0 release page carried every changelog entry in full: seventeen paragraphs to scroll before you can tell what shipped. That detail already lives in `CHANGELOG.md` and in the app's What's New, both of which read the same source.

`release-notes.sh --summary` reduces each entry to its bold headline, keeping the version heading and the Added/Fixed grouping, so the page still covers every change at one line each. The workflow passes the flag; without it the script behaves exactly as before.

## Before and after

```
- **Sarvam Code joins usage tracking.** Toki auto-detects the CLI and reads token
  activity from its local session history without loading transcript content. Its
  card, active-agent list, spend view, heatmap, and widgets use the official Sarvam
  mark; cost fields preserve their reported currency, fall back to USD when
  unspecified, and show `$0.00` when Sarvam has not logged a cost.
```

becomes

```
- **Sarvam Code joins usage tracking.**
```

## Verification

- 3.0.0: 17 bullets in, 17 out, 0 left uncondensed
- `--summary` accepted before or after the tag
- full mode unchanged when the flag is absent
- `v3.0.0-beta.6` still exits 1, so prerelease tags keep falling back to `--generate-notes`
- missing tag still exits 2
- `v2.7.0` condenses correctly, so older sections work too

The published `v3.0.0` release body has already been updated to the condensed form by hand; this makes every future release do it automatically.
