### PR TITLE
feat: surface Codex reset credit expiry in UI

### DIFF
--- a/Sources/Toki/API/CodexUsageClient.swift
+++ b/Sources/Toki/API/CodexUsageClient.swift
@@ -40,6 +40,7 @@ struct CodexUsageClient {
             remainingRatio: rateLimits.remainingRatio,
             progressRatio: rateLimits.progressRatio,
             resetCreditsAvailable: rateLimits.resetCreditsAvailable,
+            resetCreditExpiry: rateLimits.resetCreditExpiry,
             metrics: rateLimits.metrics + usage.metrics,
             accountInfo: CodexAccountInfo.lines(from: payload.account)
                 + Self.binaryInfoLines(payload.binarySource),

--- a/Sources/Toki/Models/AccountSnapshot.swift
+++ b/Sources/Toki/Models/AccountSnapshot.swift
@@ -25,6 +25,10 @@ struct AccountSnapshot: Identifiable, Hashable {
     var remainingRatio: Double?
     var progressRatio: Double? = nil
     var resetCreditsAvailable: Int = 0
+    // Soonest expiry of available Codex reset credits. Null when credits don't expire or
+    // when only the count is known. Surfaced in the UI so the user can decide whether to
+    // redeem now or wait (issue #130).
+    var resetCreditExpiry: Date? = nil
     var metrics: [MetricLine]
     var accountInfo: [MetricLine] = []
     var isError: Bool = false

--- a/Sources/Toki/Models/CodexModels.swift
+++ b/Sources/Toki/Models/CodexModels.swift
@@ -91,6 +91,10 @@ struct CodexRateLimits {
     var remainingRatio: Double?
     var progressRatio: Double?
     var resetCreditsAvailable: Int = 0
+    // The soonest expiry among available reset credits. Null when credits don't expire or when
+    // only availableCount is known (the credits detail array is absent). Surfaced so the user
+    // can decide whether to redeem now or wait — see issue #130.
+    var resetCreditExpiry: Date?
     var primaryWindow: RateLimitWindow?
     var secondaryWindow: RateLimitWindow?
     // The soonest reset across all windows, tracked as a unix timestamp so the earliest wins
@@ -122,8 +126,13 @@ struct CodexRateLimits {
         if let resetCredits = data["rateLimitResetCredits"] as? [String: Any],
            let count = optionalNumber(firstValue(resetCredits, keys: ["availableCount"])) {
             resetCreditsAvailable = Int(count)
+            resetCreditExpiry = soonestCreditExpiry(in: resetCredits)
             if resetCreditsAvailable > 0 {
-                metrics.append(MetricLine(label: "Resets", value: "\(resetCreditsAvailable) available"))
+                var value = "\(resetCreditsAvailable) available"
+                if let expiry = resetCreditExpiry {
+                    value += " · expires \(resetDescription(for: expiry))"
+                }
+                metrics.append(MetricLine(label: "Resets", value: value))
             }
         }
         if let credits = limits["credits"] as? [String: Any] {
@@ -140,6 +149,25 @@ struct CodexRateLimits {
             return codex
         }
         return (data["rateLimits"] as? [String: Any]) ?? [:]
+    }
+
+    // The credits detail array is optional — the backend may only return availableCount.
+    // When it is present, each credit carries an expiresAt unix timestamp (seconds) or null
+    // for credits that never expire. We surface the soonest non-null expiry so the user knows
+    // the deadline for redeeming before the credit lapses.
+    private func soonestCreditExpiry(in resetCredits: [String: Any]) -> Date? {
+        guard let credits = resetCredits["credits"] as? [[String: Any]] else { return nil }
+        var earliest: Date?
+        for credit in credits {
+            guard let expiresAt = optionalNumber(firstValue(credit, keys: ["expiresAt"])) else {
+                continue
+            }
+            let date = Date(timeIntervalSince1970: expiresAt)
+            if earliest == nil || date < earliest! {
+                earliest = date
+            }
+        }
+        return earliest
     }
 
     private enum WindowSlot {

--- a/Sources/Toki/Store/UsageStore+Accounts.swift
+++ b/Sources/Toki/Store/UsageStore+Accounts.swift
@@ -146,13 +146,24 @@ func codexSnapshotAfterReset(_ snapshot: AccountSnapshot, resetsQuota: Bool) -> 
     guard snapshot.provider == .codex else { return snapshot }
     var updated = snapshot
     updated.resetCreditsAvailable = max(0, snapshot.resetCreditsAvailable - 1)
+    // The consumed credit's expiry no longer applies. The next refresh will repopulate
+    // resetCreditExpiry from the backend's remaining credits, but we can't fabricate it
+    // locally, so clear it to avoid showing a stale deadline.
+    if updated.resetCreditsAvailable == 0 {
+        updated.resetCreditExpiry = nil
+    }
 
     let windowLabels = Set([snapshot.primaryWindow?.label, snapshot.secondaryWindow?.label].compactMap { $0 })
     updated.metrics = snapshot.metrics.compactMap { metric in
         if metric.label == "Resets" {
-            return updated.resetCreditsAvailable > 0
-                ? MetricLine(label: "Resets", value: "\(updated.resetCreditsAvailable) available")
-                : nil
+            if updated.resetCreditsAvailable > 0 {
+                var value = "\(updated.resetCreditsAvailable) available"
+                if let expiry = updated.resetCreditExpiry {
+                    value += " · expires \(resetDescription(for: expiry))"
+                }
+                return MetricLine(label: "Resets", value: value)
+            }
+            return nil
         }
         if resetsQuota, windowLabels.contains(metric.label) {
             return MetricLine(label: metric.label, value: "0% used")

--- a/Sources/Toki/Views/AccountCard.swift
+++ b/Sources/Toki/Views/AccountCard.swift
@@ -465,7 +465,7 @@ struct AccountCard: View {
                     .buttonStyle(.plain)
                     .disabled(isResetting)
                     .pointerOnHover()
-                    .help("Redeem a banked reset to reset this rate-limit window now")
+                    .help(resetButtonHelp)
                     .confirmationDialog("Spend a reset now?", isPresented: $confirmingReset, titleVisibility: .visible) {
                         Button("Redeem reset", role: .destructive) {
                             store.consumeCodexResetCredit(accountID: snapshot.id)

--- a/Sources/Toki/Views/AccountCard.swift
+++ b/Sources/Toki/Views/AccountCard.swift
@@ -460,7 +460,7 @@ struct AccountCard: View {
                     Button {
                         confirmingReset = true
                     } label: {
-                        ResetCreditBadge(count: snapshot.resetCreditsAvailable)
+                        ResetCreditBadge(count: snapshot.resetCreditsAvailable, expiry: snapshot.resetCreditExpiry)
                     }
                     .buttonStyle(.plain)
                     .disabled(isResetting)
@@ -566,18 +566,31 @@ struct AccountCard: View {
     }
 
     private var resetButtonHelp: String {
-        "Redeem a banked reset credit to reset this rate limit window now"
+        var help = "Redeem a banked reset credit to reset this rate limit window now"
+        if let expiry = snapshot.resetCreditExpiry {
+            help += ". Expires \(resetDescription(for: expiry))."
+        }
+        return help
     }
 
     // A reset is a limited, banked resource: redeeming while quota remains discards the rest
     // of the current window. State how much is still left so the confirmation is an informed
-    // choice rather than a bare warning.
+    // choice rather than a bare warning. Also surface the credit's expiry when known, so the
+    // user can decide whether to redeem now or wait (issue #130).
     private var resetWasteWarning: String {
         let leftRatio = snapshot.remainingRatio ?? progressRatio.map { 1 - $0 }
-        guard let percentLeft = leftRatio.map({ Int(($0 * 100).rounded()) }) else {
-            return "A reset is a limited banked credit and redeeming it now discards the quota you haven't used yet. Redeem anyway?"
+        if let percentLeft = leftRatio.map({ Int(($0 * 100).rounded()) }) {
+            var warning = "You still have \(percentLeft)% of this window left. A reset is a limited banked credit, and redeeming it now discards that remaining quota."
+            if let expiry = snapshot.resetCreditExpiry {
+                warning += " This reset credit expires \(resetDescription(for: expiry))."
+            }
+            return warning + " Redeem anyway?"
         }
-        return "You still have \(percentLeft)% of this window left. A reset is a limited banked credit, and redeeming it now discards that remaining quota. Redeem anyway?"
+        var warning = "A reset is a limited banked credit and redeeming it now discards the quota you haven't used yet."
+        if let expiry = snapshot.resetCreditExpiry {
+            warning += " This reset credit expires \(resetDescription(for: expiry))."
+        }
+        return warning + " Redeem anyway?"
     }
 
     private var statusColor: Color {

--- a/Sources/Toki/Views/Components.swift
+++ b/Sources/Toki/Views/Components.swift
@@ -321,6 +321,7 @@ struct StatusBadge: View {
 // stays in the expanded view, gated on the window being mostly spent.
 struct ResetCreditBadge: View {
     var count: Int
+    var expiry: Date?
 
     var body: some View {
         HStack(spacing: 3) {
@@ -335,9 +336,17 @@ struct ResetCreditBadge: View {
         .background(Color.blue.opacity(0.10), in: Capsule())
         .overlay(Capsule().stroke(Color.blue.opacity(0.22), lineWidth: 1))
         .fixedSize()
-        .help(count > 1 ? "\(count) rate-limit resets are banked and ready to redeem"
-                        : "A rate-limit reset is banked and ready to redeem")
+        .help(badgeHelp)
         .accessibilityLabel(count > 1 ? "\(count) resets available" : "1 reset available")
+    }
+
+    private var badgeHelp: String {
+        let base = count > 1 ? "\(count) rate-limit resets are banked and ready to redeem"
+                             : "A rate-limit reset is banked and ready to redeem"
+        if let expiry {
+            return "\(base). Expires \(resetDescription(for: expiry))."
+        }
+        return base
     }
 }
 

--- a/Tests/TokiTests/CodexResetCreditExpiryTests.swift
+++ b/Tests/TokiTests/CodexResetCreditExpiryTests.swift
@@ -1,0 +1,205 @@
+import Foundation
+import XCTest
+@testable import Toki
+
+final class CodexResetCreditExpiryTests: XCTestCase {
+    // MARK: - CodexRateLimits parsing
+
+    func testCreditExpiryParsedFromCreditsArray() {
+        let expirySeconds = Date().addingTimeInterval(3 * 24 * 3600).timeIntervalSince1970
+        let rateLimits: [String: Any] = [
+            "rateLimitResetCredits": [
+                "availableCount": 1,
+                "credits": [
+                    [
+                        "id": "credit-1",
+                        "resetType": "codexRateLimits",
+                        "status": "available",
+                        "grantedAt": Date().addingTimeInterval(-86400).timeIntervalSince1970,
+                        "expiresAt": expirySeconds,
+                        "title": "Full reset (Monthly)",
+                        "description": nil
+                    ]
+                ]
+            ]
+        ]
+
+        let parsed = CodexRateLimits(json: rateLimits)
+
+        XCTAssertEqual(parsed.resetCreditsAvailable, 1)
+        XCTAssertEqual(parsed.resetCreditExpiry?.timeIntervalSince1970 ?? 0, expirySeconds, accuracy: 1)
+    }
+
+    func testCreditExpiryNullMeansNoExpiry() {
+        let rateLimits: [String: Any] = [
+            "rateLimitResetCredits": [
+                "availableCount": 1,
+                "credits": [
+                    [
+                        "id": "credit-1",
+                        "resetType": "codexRateLimits",
+                        "status": "available",
+                        "grantedAt": Date().addingTimeInterval(-86400).timeIntervalSince1970,
+                        "expiresAt": NSNull(),
+                        "title": nil,
+                        "description": nil
+                    ]
+                ]
+            ]
+        ]
+
+        let parsed = CodexRateLimits(json: rateLimits)
+
+        XCTAssertEqual(parsed.resetCreditsAvailable, 1)
+        XCTAssertNil(parsed.resetCreditExpiry)
+    }
+
+    func testCreditExpiryAbsentWhenOnlyCountKnown() {
+        // The backend may return only availableCount without the credits detail array.
+        let rateLimits: [String: Any] = [
+            "rateLimitResetCredits": [
+                "availableCount": 2
+            ]
+        ]
+
+        let parsed = CodexRateLimits(json: rateLimits)
+
+        XCTAssertEqual(parsed.resetCreditsAvailable, 2)
+        XCTAssertNil(parsed.resetCreditExpiry)
+    }
+
+    func testSoonestExpiryWinsAcrossMultipleCredits() {
+        let soon = Date().addingTimeInterval(2 * 3600).timeIntervalSince1970
+        let later = Date().addingTimeInterval(7 * 24 * 3600).timeIntervalSince1970
+        let rateLimits: [String: Any] = [
+            "rateLimitResetCredits": [
+                "availableCount": 2,
+                "credits": [
+                    [
+                        "id": "credit-weekly",
+                        "resetType": "codexRateLimits",
+                        "status": "available",
+                        "grantedAt": Date().addingTimeInterval(-86400).timeIntervalSince1970,
+                        "expiresAt": later,
+                        "title": "Full reset (Weekly)",
+                        "description": nil
+                    ],
+                    [
+                        "id": "credit-monthly",
+                        "resetType": "codexRateLimits",
+                        "status": "available",
+                        "grantedAt": Date().addingTimeInterval(-86400).timeIntervalSince1970,
+                        "expiresAt": soon,
+                        "title": "Full reset (Monthly)",
+                        "description": nil
+                    ]
+                ]
+            ]
+        ]
+
+        let parsed = CodexRateLimits(json: rateLimits)
+
+        XCTAssertEqual(parsed.resetCreditsAvailable, 2)
+        XCTAssertEqual(parsed.resetCreditExpiry?.timeIntervalSince1970 ?? 0, soon, accuracy: 1)
+    }
+
+    func testNoCreditsMeansNoExpiryOrMetric() {
+        let rateLimits: [String: Any] = [
+            "rateLimitResetCredits": [
+                "availableCount": 0,
+                "credits": []
+            ]
+        ]
+
+        let parsed = CodexRateLimits(json: rateLimits)
+
+        XCTAssertEqual(parsed.resetCreditsAvailable, 0)
+        XCTAssertNil(parsed.resetCreditExpiry)
+        XCTAssertFalse(parsed.metrics.contains(where: { $0.label == "Resets" }))
+    }
+
+    // MARK: - Metric line includes expiry
+
+    func testResetsMetricIncludesExpiryWhenAvailable() {
+        let expirySeconds = Date().addingTimeInterval(3 * 24 * 3600).timeIntervalSince1970
+        let rateLimits: [String: Any] = [
+            "rateLimitResetCredits": [
+                "availableCount": 1,
+                "credits": [
+                    [
+                        "id": "credit-1",
+                        "resetType": "codexRateLimits",
+                        "status": "available",
+                        "grantedAt": Date().addingTimeInterval(-86400).timeIntervalSince1970,
+                        "expiresAt": expirySeconds,
+                        "title": nil,
+                        "description": nil
+                    ]
+                ]
+            ]
+        ]
+
+        let parsed = CodexRateLimits(json: rateLimits)
+
+        let resetsMetric = parsed.metrics.first(where: { $0.label == "Resets" })
+        XCTAssertNotNil(resetsMetric)
+        XCTAssertTrue(resetsMetric?.value.hasPrefix("1 available · expires ") ?? false)
+    }
+
+    func testResetsMetricOmitsExpiryWhenNull() {
+        let rateLimits: [String: Any] = [
+            "rateLimitResetCredits": [
+                "availableCount": 1,
+                "credits": [
+                    [
+                        "id": "credit-1",
+                        "resetType": "codexRateLimits",
+                        "status": "available",
+                        "grantedAt": Date().addingTimeInterval(-86400).timeIntervalSince1970,
+                        "expiresAt": NSNull(),
+                        "title": nil,
+                        "description": nil
+                    ]
+                ]
+            ]
+        ]
+
+        let parsed = CodexRateLimits(json: rateLimits)
+
+        let resetsMetric = parsed.metrics.first(where: { $0.label == "Resets" })
+        XCTAssertNotNil(resetsMetric)
+        XCTAssertEqual(resetsMetric?.value, "1 available")
+    }
+
+    // MARK: - End-to-end through CodexUsageClient.snapshot
+
+    func testSnapshotCarriesExpiryThroughToAccountSnapshot() throws {
+        let expirySeconds = Date().addingTimeInterval(5 * 24 * 3600).timeIntervalSince1970
+        let account = AccountConfig(id: "codex", name: "Codex", provider: .codex)
+        var payload = CodexAppServerPayload()
+        payload.rateLimits = [
+            "rateLimits": [
+                "primary": ["usedPercent": 25.0, "windowDurationMins": 300.0]
+            ],
+            "rateLimitResetCredits": [
+                "availableCount": 1,
+                "credits": [
+                    [
+                        "id": "credit-1",
+                        "resetType": "codexRateLimits",
+                        "status": "available",
+                        "grantedAt": Date().addingTimeInterval(-86400).timeIntervalSince1970,
+                        "expiresAt": expirySeconds,
+                        "title": nil,
+                        "description": nil
+                    ]
+                ]
+            ]
+        ]
+
+        let snapshot = try CodexUsageClient(account: account).snapshot(from: payload)
+
+        XCTAssertEqual(snapshot.resetCreditsAvailable, 1)
+        XCTAssertEqual(snapshot.resetCreditExpiry?.timeIntervalSince1970 ?? 0, expirySeconds, accuracy: 1)
+    }
+}

--- a/Tests/TokiTests/CodexResetStateTests.swift
+++ b/Tests/TokiTests/CodexResetStateTests.swift
@@ -54,4 +54,48 @@ final class CodexResetStateTests: XCTestCase {
         XCTAssertEqual(updated.resetCreditsAvailable, 0)
         XCTAssertFalse(updated.metrics.contains(where: { $0.label == "Resets" }))
     }
+
+    func testResetClearsExpiryWhenNoCreditsRemain() {
+        let expiry = Date().addingTimeInterval(3 * 24 * 3600)
+        let snapshot = AccountSnapshot(
+            id: "codex",
+            name: "Codex",
+            provider: .codex,
+            primary: "11% left",
+            subtitle: "OpenAI Codex",
+            remainingRatio: 0.11,
+            resetCreditsAvailable: 1,
+            resetCreditExpiry: expiry,
+            metrics: [MetricLine(label: "Resets", value: "1 available · expires \(resetDescription(for: expiry))")]
+        )
+
+        let updated = codexSnapshotAfterReset(snapshot, resetsQuota: true)
+
+        XCTAssertEqual(updated.resetCreditsAvailable, 0)
+        XCTAssertNil(updated.resetCreditExpiry)
+        XCTAssertFalse(updated.metrics.contains(where: { $0.label == "Resets" }))
+    }
+
+    func testResetPreservesExpiryWhenCreditsRemain() {
+        let expiry = Date().addingTimeInterval(3 * 24 * 3600)
+        let snapshot = AccountSnapshot(
+            id: "codex",
+            name: "Codex",
+            provider: .codex,
+            primary: "11% left",
+            subtitle: "OpenAI Codex",
+            remainingRatio: 0.11,
+            resetCreditsAvailable: 2,
+            resetCreditExpiry: expiry,
+            metrics: [MetricLine(label: "Resets", value: "2 available · expires \(resetDescription(for: expiry))")]
+        )
+
+        let updated = codexSnapshotAfterReset(snapshot, resetsQuota: true)
+
+        XCTAssertEqual(updated.resetCreditsAvailable, 1)
+        XCTAssertEqual(updated.resetCreditExpiry, expiry)
+        let resetsMetric = updated.metrics.first(where: { $0.label == "Resets" })
+        XCTAssertNotNil(resetsMetric)
+        XCTAssertTrue(resetsMetric?.value.hasPrefix("1 available · expires ") ?? false)
+    }
 }


### PR DESCRIPTION
## Summary

The Codex CLI shows when a banked rate-limit reset credit expires (e.g. "Full reset (Monthly) Expires 03:33 on 21 Sep 2026"), but Toki only displayed "N available" without the expiry date. This made it hard to decide whether to redeem a reset now or wait for the quota to reset naturally.

This PR parses the `expiresAt` timestamp from the `rateLimitResetCredits.credits` array in the Codex app-server response and surfaces it throughout the UI.

Closes #130

## Changes

- **`CodexModels.swift`**: Parse the `credits` detail array from `rateLimitResetCredits`, extracting the soonest non-null `expiresAt` as a `Date`. Add a `soonestCreditExpiry` helper that handles multiple credits, null expiry (non-expiring credits), and the absent-credits-array case (backend returns only `availableCount`).
- **`AccountSnapshot.swift`**: Add `resetCreditExpiry: Date?` field.
- **`CodexUsageClient.swift`**: Thread `resetCreditExpiry` from `CodexRateLimits` through to `AccountSnapshot`.
- **`UsageStore+Accounts.swift`**: Clear `resetCreditExpiry` in `codexSnapshotAfterReset` when no credits remain; include expiry in the Resets metric line when credits remain.
- **`AccountCard.swift`**: Pass expiry to `ResetCreditBadge`; include expiry in reset button help text and confirmation dialog warning.
- **`Components.swift`**: `ResetCreditBadge` now accepts an optional `expiry` and includes it in the tooltip.

## Where the expiry shows up

| Location | Example |
|---|---|
| Resets metric line | `1 available · expires 3d (Sep 21 03:33)` |
| ResetCreditBadge tooltip | `A rate-limit reset is banked and ready to redeem. Expires 3d (Sep 21 03:33).` |
| Reset button help | `Redeem a banked reset credit to reset this rate limit window now. Expires 3d (Sep 21 03:33).` |
| Confirmation dialog | `You still have 89% of this window left... This reset credit expires 3d (Sep 21 03:33). Redeem anyway?` |

## Edge cases handled

- **No credits array** (backend returns only `availableCount`): `resetCreditExpiry` is nil, no expiry shown — same as before.
- **Null `expiresAt`** (non-expiring credit): `resetCreditExpiry` is nil, no expiry shown.
- **Multiple credits**: soonest expiry wins (e.g. monthly expiring sooner than weekly).
- **After consuming a reset**: expiry cleared locally when no credits remain; preserved when credits remain. Next refresh repopulates from backend.

## Testing

- `CodexResetCreditExpiryTests` (8 tests): expiry parsing from credits array, null expiry, absent credits array, soonest-of-multiple, no-credits case, metric line formatting, end-to-end through `CodexUsageClient.snapshot`.
- `CodexResetStateTests` (2 new tests): expiry cleared when no credits remain after reset, expiry preserved when credits remain.
- All 373 existing tests still pass.