### PR TITLE
Show recent and weekly quotas in account cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **Recent and weekly quotas share one compact account-card view.** Claude Code and Codex now show every applicable rolling window side by side, including reset countdowns when provided, while plans that expose only one window keep the single-window layout and Codex reset credits stay directly beneath it.
+
 ## 3.0.0 - 2026-08-27
 
 ### Added

--- a/Sources/Toki/API/ClaudeCodeUsageClient.swift
+++ b/Sources/Toki/API/ClaudeCodeUsageClient.swift
@@ -120,13 +120,6 @@ struct ClaudeCodeUsageClient {
         let primary = "\(percentLeft)% left"
         let email = record.email ?? record.credentials.flatMap(ClaudeCodeCredentialReader.emailIdentifier)
 
-        // Surface Claude Code's single rolling window the same way Codex exposes its windows,
-        // so consumers like the quota-rings panel can show "resets in <time>" beside it. The
-        // main account card reads its reset line from `metrics`, so this doesn't duplicate there.
-        let primaryWindow = primaryMetric.resetDescription.map {
-            RateLimitWindow(label: primaryMetric.label, percentLeft: percentLeft, resetHint: "resets in \($0)")
-        }
-
         return AccountSnapshot(
             id: record.id,
             name: record.displayName,
@@ -141,7 +134,8 @@ struct ClaudeCodeUsageClient {
             switchCommand: account.claudeSwapCommand,
             emoji: record.label?.emoji,
             colorHex: record.label?.color,
-            primaryWindow: primaryWindow
+            primaryWindow: usage.rateLimitWindows.first,
+            secondaryWindow: usage.rateLimitWindows.dropFirst().first
         )
     }
 

--- a/Sources/Toki/Models/ClaudeCodeModels.swift
+++ b/Sources/Toki/Models/ClaudeCodeModels.swift
@@ -59,6 +59,7 @@ struct UsageMetric {
 struct ClaudeCodeUsage {
     var primaryMetric: UsageMetric?
     var metrics: [MetricLine] = []
+    var rateLimitWindows: [RateLimitWindow] = []
     var worstUtilization: Double?
 
     var hasUsage: Bool {
@@ -69,7 +70,7 @@ struct ClaudeCodeUsage {
         guard let data = json as? [String: Any] else { return }
 
         if let fiveHour = data["five_hour"] as? [String: Any] {
-            setPrimaryWindow("Daily", fiveHour)
+            appendWindow("5h", fiveHour)
         }
         if let sevenDay = data["seven_day"] as? [String: Any] {
             appendWindow("7d", sevenDay)
@@ -79,27 +80,31 @@ struct ClaudeCodeUsage {
         }
     }
 
-    private mutating func setPrimaryWindow(_ label: String, _ window: [String: Any]) {
-        let utilization = numericValue(window["utilization"] ?? 0)
+    private mutating func appendWindow(_ label: String, _ window: [String: Any]) {
+        // Anthropic keeps a window key in the response even when that quota does not apply,
+        // using null utilization. Treat that as absent rather than inventing 0% usage.
+        guard let utilization = optionalNumber(window["utilization"]) else { return }
+
         worstUtilization = max(worstUtilization ?? utilization, utilization)
-        primaryMetric = UsageMetric(
+        let reset = resetDescription(window["resets_at"])
+        let metric = UsageMetric(
             label: label,
             utilization: utilization,
-            resetDescription: resetDescription(window["resets_at"])
+            resetDescription: reset
         )
-        var value = "\(Int(utilization.rounded()))% used"
-        if let reset = primaryMetric?.resetDescription {
-            value += " - resets in \(reset)"
+        if primaryMetric == nil {
+            primaryMetric = metric
         }
-        metrics.append(MetricLine(label: label, value: value))
-    }
 
-    private mutating func appendWindow(_ label: String, _ window: [String: Any]) {
-        let utilization = numericValue(window["utilization"] ?? 0)
-        worstUtilization = max(worstUtilization ?? utilization, utilization)
+        let clampedUsed = max(0, min(100, utilization))
+        rateLimitWindows.append(RateLimitWindow(
+            label: label,
+            percentLeft: Int((100 - clampedUsed).rounded()),
+            resetHint: reset.map { "resets in \($0)" }
+        ))
 
         var value = "\(Int(utilization.rounded()))% used"
-        if let reset = resetDescription(window["resets_at"]) {
+        if let reset {
             value += " - resets in \(reset)"
         }
         metrics.append(MetricLine(label: label, value: value))

--- a/Sources/Toki/Utilities/Formatting.swift
+++ b/Sources/Toki/Utilities/Formatting.swift
@@ -47,6 +47,26 @@ func resetDescription(for resetDate: Date) -> String {
     return "\(countdown) (\(formatter.string(from: resetDate)))"
 }
 
+// Compact quota cards already establish that the secondary line is a reset time. Keep only the
+// relative countdown there; the full relative and absolute description remains in the tooltip
+// and expanded metric row. This function only shortens strings produced by Toki itself.
+func compactResetDescription(_ value: String?) -> String? {
+    guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+        return nil
+    }
+
+    let prefix = "resets in "
+    let hasPrefix = value.hasPrefix(prefix)
+    var countdown = hasPrefix ? String(value.dropFirst(prefix.count)) : value
+    if let dateStart = countdown.range(of: " (") {
+        countdown = String(countdown[..<dateStart.lowerBound])
+    }
+    countdown = countdown.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !countdown.isEmpty else { return nil }
+    if countdown == "now" { return countdown }
+    return hasPrefix ? "in \(countdown)" : countdown
+}
+
 func formatCompact(_ value: Double) -> String {
     let absValue = abs(value)
     let scaled: Double

--- a/Sources/Toki/Views/AccountCard.swift
+++ b/Sources/Toki/Views/AccountCard.swift
@@ -448,15 +448,22 @@ struct AccountCard: View {
             }
             .lineLimit(1)
             .minimumScaleFactor(0.8)
-        } else if snapshot.provider == .codex, !codexWindows.isEmpty {
-            // Codex carries two independent quota windows (5h + weekly) instead of Claude's
-            // single rolling one, so it gets its own summary instead of the generic fallback
-            // to a raw token count below - shows just one line when only one window is available.
+        } else if !quotaWindows.isEmpty {
+            // Providers expose only the windows that apply to the selected allowance. Keep each
+            // one in its own compact column instead of merging unrelated quota buckets or adding
+            // an empty placeholder when a plan has only a recent or weekly limit.
             VStack(alignment: .trailing, spacing: 3) {
-                ForEach(codexWindows) { window in
-                    QuotaSummaryLine(label: window.label, value: "\(window.percentLeft)% left", resetHint: window.resetHint)
+                HStack(alignment: .top, spacing: 10) {
+                    ForEach(quotaWindows) { window in
+                        QuotaSummaryLine(
+                            label: window.label,
+                            value: "\(window.percentLeft)% left",
+                            resetHint: window.resetHint
+                        )
+                        .frame(minWidth: quotaWindows.count > 1 ? 68 : nil, alignment: .trailing)
+                    }
                 }
-                if snapshot.resetCreditsAvailable > 0 {
+                if snapshot.provider == .codex, snapshot.resetCreditsAvailable > 0 {
                     Button {
                         confirmingReset = true
                     } label: {
@@ -481,7 +488,7 @@ struct AccountCard: View {
         }
     }
 
-    private var codexWindows: [RateLimitWindow] {
+    private var quotaWindows: [RateLimitWindow] {
         [snapshot.primaryWindow, snapshot.secondaryWindow].compactMap { $0 }
     }
 

--- a/Sources/Toki/Views/Components.swift
+++ b/Sources/Toki/Views/Components.swift
@@ -402,7 +402,7 @@ struct QuotaSummaryLine: View {
 
     var body: some View {
         VStack(alignment: .trailing, spacing: 0) {
-            HStack(spacing: 6) {
+            HStack(spacing: 4) {
                 Text(label)
                     .font(.system(size: 10, weight: .medium))
                     .foregroundStyle(.secondary)
@@ -410,13 +410,13 @@ struct QuotaSummaryLine: View {
                     .lineLimit(1)
                     .minimumScaleFactor(0.8)
             }
-            if let resetHint {
-                Text(resetHint)
+            if let compactReset = compactResetDescription(resetHint) {
+                Text(compactReset)
                     .font(.system(size: 9, weight: .regular))
                     .foregroundStyle(.tertiary)
                     .multilineTextAlignment(.trailing)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .frame(maxWidth: 120, alignment: .trailing)
+                    .lineLimit(1)
+                    .help(resetHint ?? compactReset)
             }
         }
     }

--- a/Sources/Toki/Views/MenuContentView.swift
+++ b/Sources/Toki/Views/MenuContentView.swift
@@ -415,6 +415,7 @@ struct MenuContentView: View {
                         }
                     }
                 }
+                .padding(.trailing, 8)
             }
             .frame(maxHeight: .infinity)
         }

--- a/Tests/TokiTests/QuotaWindowTests.swift
+++ b/Tests/TokiTests/QuotaWindowTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import Toki
+
+final class QuotaWindowTests: XCTestCase {
+    func testClaudeExposesRecentAndWeeklyWindowsForCompactCards() {
+        let usage = ClaudeCodeUsage(json: [
+            "five_hour": ["utilization": 12.0, "resets_at": NSNull()],
+            "seven_day": ["utilization": 34.0, "resets_at": "2099-01-02T03:04:05Z"]
+        ])
+
+        XCTAssertEqual(usage.rateLimitWindows.map(\.label), ["5h", "7d"])
+        XCTAssertEqual(usage.rateLimitWindows.map(\.percentLeft), [88, 66])
+        XCTAssertNil(usage.rateLimitWindows[0].resetHint)
+        XCTAssertNotNil(usage.rateLimitWindows[1].resetHint)
+        XCTAssertEqual(usage.metrics.map(\.label), ["5h", "7d"])
+        XCTAssertEqual(usage.primaryMetric?.label, "5h")
+    }
+
+    func testClaudeKeepsAWindowWithoutAResetTimestamp() {
+        let usage = ClaudeCodeUsage(json: [
+            "five_hour": ["utilization": 0.0, "resets_at": NSNull()]
+        ])
+
+        XCTAssertEqual(usage.rateLimitWindows.count, 1)
+        XCTAssertEqual(usage.rateLimitWindows[0].percentLeft, 100)
+        XCTAssertNil(usage.rateLimitWindows[0].resetHint)
+    }
+
+    func testClaudeOmitsAWindowWhoseUtilizationIsNull() {
+        let usage = ClaudeCodeUsage(json: [
+            "five_hour": ["utilization": NSNull(), "resets_at": NSNull()],
+            "seven_day": ["utilization": 9.0, "resets_at": NSNull()]
+        ])
+
+        XCTAssertEqual(usage.rateLimitWindows.map(\.label), ["7d"])
+        XCTAssertEqual(usage.primaryMetric?.label, "7d")
+    }
+
+    func testCodexExposesBothWindowsWhenThePrimaryAllowanceProvidesThem() {
+        let limits = CodexRateLimits(json: [
+            "rateLimitsByLimitId": [
+                "codex": [
+                    "planType": "plus",
+                    "primary": ["usedPercent": 20, "windowDurationMins": 300, "resetsAt": 4_102_444_800],
+                    "secondary": ["usedPercent": 40, "windowDurationMins": 10_080, "resetsAt": 4_103_049_600]
+                ]
+            ]
+        ])
+
+        XCTAssertEqual(limits.primaryWindow?.label, "5h")
+        XCTAssertEqual(limits.primaryWindow?.percentLeft, 80)
+        XCTAssertEqual(limits.secondaryWindow?.label, "7d")
+        XCTAssertEqual(limits.secondaryWindow?.percentLeft, 60)
+    }
+
+    func testCodexKeepsAWeeklyOnlyPrimaryAllowanceSeparateFromOtherBuckets() {
+        let limits = CodexRateLimits(json: [
+            "rateLimitsByLimitId": [
+                "codex": [
+                    "planType": "pro",
+                    "primary": ["usedPercent": 1, "windowDurationMins": 10_080, "resetsAt": 4_103_049_600]
+                ],
+                "codex_model_specific": [
+                    "planType": "pro",
+                    "primary": ["usedPercent": 75, "windowDurationMins": 300, "resetsAt": 4_102_444_800],
+                    "secondary": ["usedPercent": 50, "windowDurationMins": 10_080, "resetsAt": 4_103_049_600]
+                ]
+            ]
+        ])
+
+        XCTAssertEqual(limits.primaryWindow?.label, "7d")
+        XCTAssertEqual(limits.primaryWindow?.percentLeft, 99)
+        XCTAssertNil(limits.secondaryWindow)
+    }
+
+    func testCompactResetDescriptionKeepsOnlyTheRelativeCountdown() {
+        XCTAssertEqual(compactResetDescription("resets in 4h (18:00)"), "in 4h")
+        XCTAssertEqual(compactResetDescription("resets in 6d (Sep 4 00:58)"), "in 6d")
+        XCTAssertEqual(compactResetDescription("resets in now (12:00)"), "now")
+        XCTAssertNil(compactResetDescription(nil))
+    }
+}


### PR DESCRIPTION
## Summary

- show both recent and weekly Claude Code and Codex quota windows in compact account cards, using whichever windows the provider exposes
- retain applicable windows without reset timestamps, omit null windows, and keep Codex model-specific limits separate from the main allowance
- shorten reset countdowns in compact cards while keeping the full reset time in expanded details and tooltips
- preserve the Codex reset-credit control below the quota summary
- add a narrow scroll gutter so the macOS overlay scrollbar stays clear of account cards

## Testing

- `swift test --filter QuotaWindowTests`
- `swift test` (369 tests)
- `python3 -m unittest discover -s Tests -p 'test_*.py'` (86 tests)
- `for test in Tests/test_*.js; do node "$test" || exit 1; done`
- `swift build --build-tests -Xswiftc -strict-concurrency=complete`
- `scripts/build-app.sh`
- launched the packaged app with local Claude Code and Codex accounts
- upstream macOS CI build, Swift tests, companion-server tests, and companion-app tests
