### PR TITLE
Ask macOS about notifications, and notice a granted Accessibility tick

### DIFF
--- a/Sources/Toki/Notifications/NotificationDelivery.swift
+++ b/Sources/Toki/Notifications/NotificationDelivery.swift
@@ -1,0 +1,97 @@
+import Foundation
+import UserNotifications
+
+/// What macOS says about notifications for this app, read rather than assumed.
+enum NotificationAuthorization: Equatable, Sendable {
+    case authorized
+    case denied
+    case notDetermined
+    /// The API cannot be used in this build at all, with the reason. Not a user decision, so it
+    /// is kept distinct from `denied` - there is nothing to grant and nowhere to send someone.
+    case unavailable(String)
+
+    var allowsDelivery: Bool { self == .authorized }
+
+    /// Why a notification cannot be handed over right now, or nil when it can.
+    var deliveryBlocker: String? {
+        switch self {
+        case .authorized: return nil
+        case .denied: return "macOS is set to not allow notifications from Toki. Allow it under System Settings › Notifications."
+        case .notDetermined: return "macOS has not been asked about notifications yet."
+        case .unavailable(let reason): return reason
+        }
+    }
+}
+
+/// The one place that talks to UserNotifications.
+///
+/// `UNUserNotificationCenter.current()` traps when the running executable has no bundle
+/// identifier, which is what `swift run Toki` - the documented dev workflow - produces. That
+/// trap is the reason this file exists. The previous code dodged it by asserting authorization
+/// unconditionally and delivering through the long-deprecated `NSUserNotificationCenter`, so a
+/// build that could not notify at all still reported that it had, and macOS was never actually
+/// asked for permission. Guarding on the bundle first makes the real API safe to call from any
+/// build, and lets an unbundled one say so instead of pretending.
+enum NotificationDelivery {
+    static var unavailableReason: String? {
+        // Both conditions are needed, because either one alone lets through a case that traps.
+        // `swift run Toki` has no bundle identifier at all; the test runner has one but is not
+        // an .app, and UNUserNotificationCenter raises "bundleProxyForCurrentProcess is nil"
+        // for it just the same. What the API actually wants is a real application bundle.
+        guard Bundle.main.bundleIdentifier != nil,
+              Bundle.main.bundleURL.pathExtension == "app" else {
+            return "This build has no app bundle, so macOS has nothing to attribute a notification to. Run Toki from Toki.app."
+        }
+        return nil
+    }
+
+    /// Reads the current status without prompting, so a checklist can show it before anything
+    /// is asked for.
+    static func authorizationStatus() async -> NotificationAuthorization {
+        if let unavailableReason { return .unavailable(unavailableReason) }
+        return mapped(await UNUserNotificationCenter.current().notificationSettings().authorizationStatus)
+    }
+
+    /// Puts macOS's own prompt up while the status is undetermined, and reports where that
+    /// left things. Once denied, macOS will not ask again, so this reads back as `denied`
+    /// rather than prompting a second time.
+    static func requestAuthorization() async -> NotificationAuthorization {
+        if let unavailableReason { return .unavailable(unavailableReason) }
+        // The granted flag is ignored in favour of reading the settings back: a request made
+        // while already denied resolves false without that meaning anything changed.
+        _ = try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound])
+        return await authorizationStatus()
+    }
+
+    /// Hands a notification to macOS. Returns nil on success, or why it could not be handed
+    /// over. Whether macOS then draws it on screen is its own decision and not observable.
+    static func deliver(title: String, body: String) async -> String? {
+        let status = await authorizationStatus()
+        if let blocker = status.deliveryBlocker { return blocker }
+
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = .default
+
+        do {
+            try await UNUserNotificationCenter.current().add(
+                UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)
+            )
+            return nil
+        } catch {
+            return error.localizedDescription
+        }
+    }
+
+    static func mapped(_ status: UNAuthorizationStatus) -> NotificationAuthorization {
+        switch status {
+        // Provisional delivers quietly to Notification Centre, which still counts as reaching
+        // the user; ephemeral is an App Clip state Toki cannot be in, mapped for completeness.
+        case .authorized, .provisional, .ephemeral: return .authorized
+        case .denied: return .denied
+        case .notDetermined: return .notDetermined
+        @unknown default: return .notDetermined
+        }
+    }
+}

--- a/Sources/Toki/Permissions/SystemPermissions.swift
+++ b/Sources/Toki/Permissions/SystemPermissions.swift
@@ -92,11 +92,18 @@ struct SetupFacts: Equatable {
     /// A Claude account exists in config, so failing to read a sign-in is a problem worth naming.
     var claudeAccountConfigured = false
     var notificationsEnabled = true
+    /// What macOS says, as opposed to whether Toki's own switch is on. Both matter: Toki can be
+    /// set to notify while macOS refuses to show any of it.
+    var notificationAuthorization = NotificationAuthorization.notDetermined
     /// Terminals installed on this Mac that Toki types replies into, with where each one stands.
     var automation: [AutomationTarget] = []
     /// Only relevant while an editor whose windows Toki raises is running.
     var workspaceAppRunning = false
     var accessibilityGranted = false
+    /// True once Toki has sent the user to the Accessibility pane in this run. A grant made
+    /// over there does not reach a process that is already running, so this is what separates
+    /// "not asked yet" from "asked, and still not trusted", which need different advice.
+    var accessibilityRequested = false
     var remoteControlRunning = false
     var launchAtLoginEnabled = false
 }
@@ -164,16 +171,7 @@ enum SetupChecklist {
             ))
         }
 
-        steps.append(SetupStep(
-            kind: .notifications,
-            title: "Notifications",
-            detail: facts.notificationsEnabled
-                ? "Toki tells you when quota runs low or an agent is waiting on you. macOS asks the first time one is sent."
-                : "Turned off in Toki, so nothing is delivered and macOS is never asked.",
-            status: facts.notificationsEnabled ? .unknown : .done,
-            actionLabel: facts.notificationsEnabled ? "Send a test" : nil,
-            isRequestable: facts.notificationsEnabled
-        ))
+        steps.append(notificationStep(facts))
 
         // Only for terminals actually installed: an Automation row for an app that isn't here
         // asks for a permission that can never be used.
@@ -194,17 +192,7 @@ enum SetupChecklist {
         // On a first run this is listed whether or not an editor is open right now: the point is
         // to show the whole cost up front, not to wait until the click that needs it.
         if !facts.accessibilityGranted, isFirstRun || facts.workspaceAppRunning {
-            steps.append(SetupStep(
-                kind: .accessibility,
-                title: "Accessibility",
-                detail: facts.workspaceAppRunning
-                    ? "Only used to raise the right VS Code window when you click an agent running in it."
-                    : "Only used to raise the right VS Code window when you click an agent running in one. Skip it if you work in a terminal.",
-                status: .pending,
-                actionLabel: "Allow",
-                isOptional: true,
-                isRequestable: true
-            ))
+            steps.append(accessibilityStep(facts))
         }
 
         if isFirstRun || facts.remoteControlRunning {
@@ -239,6 +227,88 @@ enum SetupChecklist {
         }
 
         return steps
+    }
+
+    // Accessibility is granted in System Settings, not in a dialog Toki can wait on, and macOS
+    // only hands the new trust to a process when it starts. So a user who has just ticked the
+    // box comes back to a row still reading "Allow", which looks like the grant did not take.
+    // Once Toki has sent someone over there, the row says what is actually needed instead.
+    private static func accessibilityStep(_ facts: SetupFacts) -> SetupStep {
+        guard facts.accessibilityRequested else {
+            return SetupStep(
+                kind: .accessibility,
+                title: "Accessibility",
+                detail: facts.workspaceAppRunning
+                    ? "Only used to raise the right VS Code window when you click an agent running in it."
+                    : "Only used to raise the right VS Code window when you click an agent running in one. Skip it if you work in a terminal.",
+                status: .pending,
+                actionLabel: "Allow",
+                isOptional: true,
+                isRequestable: true
+            )
+        }
+
+        return SetupStep(
+            kind: .accessibility,
+            title: "Accessibility",
+            detail: "If you have ticked Toki under Privacy & Security › Accessibility, restart it to pick that up: macOS only hands the new trust to Toki when it starts. Toki is ad-hoc signed until it has a Developer ID, and macOS ties the tick to that signature, so an update can drop it and need ticking again.",
+            status: .pending,
+            actionLabel: "Restart Toki",
+            isOptional: true
+        )
+    }
+
+    // Two independent switches: Toki's own preference, and what macOS has been told. The row
+    // used to report only the first and always sat at `.unknown`, which is how a build that
+    // could not deliver anything still looked like it might be fine.
+    private static func notificationStep(_ facts: SetupFacts) -> SetupStep {
+        guard facts.notificationsEnabled else {
+            return SetupStep(
+                kind: .notifications,
+                title: "Notifications",
+                detail: "Turned off in Toki, so nothing is delivered and macOS is never asked.",
+                status: .done,
+                actionLabel: nil
+            )
+        }
+
+        switch facts.notificationAuthorization {
+        case .authorized:
+            return SetupStep(
+                kind: .notifications,
+                title: "Notifications",
+                detail: "macOS is letting Toki through. You will hear about low quota and agents waiting on you.",
+                status: .done,
+                actionLabel: "Send a test",
+                isRequestable: true
+            )
+        case .notDetermined:
+            return SetupStep(
+                kind: .notifications,
+                title: "Notifications",
+                detail: "Toki tells you when quota runs low or an agent is waiting on you. macOS has not been asked yet.",
+                status: .pending,
+                actionLabel: "Allow",
+                isRequestable: true
+            )
+        case .denied:
+            // macOS will not ask twice, so the only route left is System Settings.
+            return SetupStep(
+                kind: .notifications,
+                title: "Notifications",
+                detail: "macOS is set to not allow notifications from Toki, so low-quota and agent warnings will not appear. Turn them on under Notifications in System Settings.",
+                status: .blocked,
+                actionLabel: "Open Settings"
+            )
+        case .unavailable(let reason):
+            return SetupStep(
+                kind: .notifications,
+                title: "Notifications",
+                detail: reason,
+                status: .unknown,
+                actionLabel: nil
+            )
+        }
     }
 
     private static func automationDetail(for target: AutomationTarget) -> String {
@@ -301,7 +371,11 @@ enum SetupChecklist {
     ]
 
     @MainActor
-    static func currentFacts(store: UsageStore, remoteControlRunning: Bool) async -> SetupFacts {
+    static func currentFacts(
+        store: UsageStore,
+        remoteControlRunning: Bool,
+        accessibilityRequested: Bool = false
+    ) async -> SetupFacts {
         var facts = SetupFacts()
         facts.hasConnectedAccount = !store.snapshots.isEmpty
         // What the scan actually does, not just the stored answer: once onboarding is over the
@@ -314,10 +388,12 @@ enum SetupChecklist {
         facts.claudeSignInFound = store.snapshots.contains { $0.provider.isClaudeAccount && !$0.isError }
             || store.detectedProviders.contains { $0.provider.isClaudeAccount }
         facts.notificationsEnabled = store.preferences.notificationsEnabled
+        facts.notificationAuthorization = await NotificationDelivery.authorizationStatus()
         // Off the main actor: this is a TCC lookup per terminal, and the list is rebuilt every
         // time the app becomes active - which is exactly when TCC is least likely to answer fast.
         facts.automation = await SystemPermissions.automationStatuses(for: SystemPermissions.installed(scriptedTerminals))
         facts.accessibilityGranted = SystemPermissions.accessibilityGranted
+        facts.accessibilityRequested = accessibilityRequested
         facts.workspaceAppRunning = SystemPermissions.isRunning(anyOf: workspaceApps)
         facts.remoteControlRunning = remoteControlRunning
         facts.launchAtLoginEnabled = LaunchAtLogin.isEnabled
@@ -411,6 +487,19 @@ enum SystemPermissions {
     static func openNotificationSettings() {
         guard let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension") else { return }
         NSWorkspace.shared.open(url)
+    }
+
+    /// Quits and reopens, which is the only way a process picks up an Accessibility grant made
+    /// while it was running. Reopening is handed to a detached shell that waits for this
+    /// process to go away first, so the two never overlap and race over the state file.
+    @MainActor
+    static func relaunch() {
+        let path = Bundle.main.bundleURL.path
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/bin/sh")
+        task.arguments = ["-c", "sleep 1; /usr/bin/open \"\(path)\""]
+        try? task.run()
+        NSApp.terminate(nil)
     }
 
     @MainActor

--- a/Sources/Toki/Store/UsageStore+Notifications.swift
+++ b/Sources/Toki/Store/UsageStore+Notifications.swift
@@ -76,22 +76,37 @@ extension UsageStore {
         }
     }
 
-    // The setup checklist's notification step. macOS asks about notifications the first time one
-    // is delivered, so this is how that prompt is brought forward to a moment the user chose,
-    // rather than arriving with the first low-quota warning.
-    func sendTestNotification() {
-        let detail = "Toki will tell you here when quota runs low or an agent is waiting on you."
-        deliverNotification(title: "Toki notifications are on", detail: detail) { handedOver, failureDetail in
-            // "Handed to macOS", not "delivered": nothing here can see whether it was actually shown.
-            self.appendEvent(
+    // The setup checklist's notification step. It asks macOS for permission first, which is the
+    // whole point of the row: bringing that prompt forward to a moment the user chose, rather
+    // than letting it arrive with the first low-quota warning. Then it sends one, so a granted
+    // permission is confirmed by something actually appearing.
+    // Awaitable so the checklist's "allow all" pass can put this dialog up and wait for the
+    // answer before moving to the next one, the way every other request in that pass does.
+    func sendTestNotification() async {
+        let authorization = await NotificationDelivery.requestAuthorization()
+        notificationAuthorization = authorization
+
+        guard authorization.allowsDelivery else {
+            appendEvent(
                 kind: .notification,
                 title: "Test notification",
-                detail: handedOver
-                    ? "Sent to macOS. If nothing appeared, allow Toki under System Settings › Notifications."
-                    : "Not sent: \(failureDetail ?? detail)",
-                deliveredNotification: handedOver
+                detail: "Not sent. \(authorization.deliveryBlocker ?? "")",
+                deliveredNotification: false
             )
+            return
         }
+
+        let detail = "Toki will tell you here when quota runs low or an agent is waiting on you."
+        let failure = await NotificationDelivery.deliver(title: "Toki notifications are on", body: detail)
+        appendEvent(
+            kind: .notification,
+            title: "Test notification",
+            // "Handed to macOS", not "shown": whether it draws is macOS's call and is not
+            // observable from here.
+            detail: failure.map { "Not sent. \($0)" }
+                ?? "Sent to macOS. If nothing appeared, check Toki under System Settings › Notifications.",
+            deliveredNotification: failure == nil
+        )
     }
 
     private func notifyOrRecord(key: String, kind: TokiEventKind, title: String, detail: String, at date: Date) {
@@ -132,34 +147,13 @@ extension UsageStore {
         detail: String,
         completion: @escaping @MainActor (Bool, String?) -> Void
     ) {
-        resolveNotificationAuthorization { granted, error in
-            if let error {
-                Task { @MainActor in completion(false, error) }
-                return
-            }
-            guard granted else {
-                Task { @MainActor in completion(false, "notification permission denied") }
-                return
-            }
-
-            let notification = NSUserNotification()
-            notification.title = title
-            notification.informativeText = detail
-            notification.soundName = NSUserNotificationDefaultSoundName
-            NSUserNotificationCenter.default.deliver(notification)
-            Task { @MainActor in completion(true, nil) }
+        Task { @MainActor in
+            let failure = await NotificationDelivery.deliver(title: title, body: detail)
+            // Cached so the checklist and the next delivery can read where things stand
+            // without another round trip to macOS.
+            notificationAuthorization = await NotificationDelivery.authorizationStatus()
+            completion(failure == nil, failure)
         }
-    }
-
-    private func resolveNotificationAuthorization(completion: @escaping @Sendable (Bool, String?) -> Void) {
-        if notificationAuthorization == true {
-            completion(true, nil)
-            return
-        }
-        // macOS 26.6 has a crash in UNUserNotificationCenter.current() — use NSUserNotificationCenter
-        // (deprecated since 10.14 but still works on all supported OS versions).
-        notificationAuthorization = true
-        completion(true, nil)
     }
 
     func appendEvent(

--- a/Sources/Toki/Store/UsageStore.swift
+++ b/Sources/Toki/Store/UsageStore.swift
@@ -54,7 +54,9 @@ final class UsageStore: ObservableObject {
     var dailyActivityScannedAt: Date?
     var eventGeneration = 0
     var insightGeneration = 0
-    var notificationAuthorization: Bool?
+    /// Last status read back from macOS, so the checklist can report it without asking again.
+    /// nil until something has looked.
+    var notificationAuthorization: NotificationAuthorization?
     var agentTimer: Timer?
     // The provider scan in flight, so a caller that needs a fresh one can wait for it rather than
     // colliding with it and silently doing nothing.

--- a/Sources/Toki/Views/SetupChecklistView.swift
+++ b/Sources/Toki/Views/SetupChecklistView.swift
@@ -28,6 +28,9 @@ struct SetupChecklistView: View {
     @State private var requestingAll = false
     @State private var currentRequest: String?
     @State private var notificationTestSent = false
+    /// Sticky for the life of this view: once Toki has sent someone to the Accessibility pane,
+    /// the row keeps offering the restart that makes a grant made over there take effect.
+    @State private var accessibilityRequested = false
     @State private var launchAtLoginError: String?
 
     private var outstanding: [SetupStep] { SetupChecklist.outstanding(steps) }
@@ -265,17 +268,18 @@ struct SetupChecklistView: View {
     }
 
     private func refresh() {
-        Task {
-            let facts = await SetupChecklist.currentFacts(store: store, remoteControlRunning: remoteServer.isRunning)
-            steps = SetupChecklist.steps(from: facts, mode: mode)
-        }
+        Task { await refreshAndWait() }
     }
 
     // Awaiting the refresh matters inside the "allow all" pass: each request has to see the list
     // as it stands after the previous answer, or a permission granted along the way gets asked
     // for twice.
     private func refreshAndWait() async {
-        let facts = await SetupChecklist.currentFacts(store: store, remoteControlRunning: remoteServer.isRunning)
+        let facts = await SetupChecklist.currentFacts(
+            store: store,
+            remoteControlRunning: remoteServer.isRunning,
+            accessibilityRequested: accessibilityRequested
+        )
         steps = SetupChecklist.steps(from: facts, mode: mode)
     }
 
@@ -305,6 +309,12 @@ struct SetupChecklistView: View {
             case .account: store.rescanProviders()
             case .automation: SystemPermissions.openPrivacySettings(anchor: "Privacy_Automation")
             case .localNetwork: SystemPermissions.openPrivacySettings(anchor: "Privacy_LocalNetwork")
+            // Reachable once macOS has been told no: it will not ask again, so the row's only
+            // remaining action is to open the pane where that can be undone.
+            case .notifications: SystemPermissions.openNotificationSettings()
+            // The row only offers this once it has already sent the user to System Settings,
+            // so the remaining step is the restart that makes a grant there take effect.
+            case .accessibility: SystemPermissions.relaunch()
             default: break
             }
             recheck()
@@ -338,10 +348,9 @@ struct SetupChecklistView: View {
             // the user has asked for the read here.
             await store.approveKeychainReads()
         case .notifications:
-            // Delivery returns immediately and macOS decides for itself when to put its own
-            // notification prompt on screen, so unlike the others this one cannot be sequenced -
-            // it may land alongside the next dialog. Bringing it forward at all is the point.
-            store.sendTestNotification()
+            // Now sequenced like the rest: asking macOS for permission is a real dialog that
+            // can be awaited, so it no longer risks landing on top of the next one.
+            await store.sendTestNotification()
             notificationTestSent = true
         case .automation:
             guard let bundleID = step.subject else { return }
@@ -355,6 +364,7 @@ struct SetupChecklistView: View {
             }
         case .accessibility:
             SystemPermissions.requestAccessibility()
+            accessibilityRequested = true
         case .account, .localNetwork:
             break
         }

--- a/Tests/TokiTests/NotificationAuthorizationTests.swift
+++ b/Tests/TokiTests/NotificationAuthorizationTests.swift
@@ -1,0 +1,177 @@
+import UserNotifications
+import XCTest
+@testable import Toki
+
+// Toki used to assert that notifications were authorized without asking macOS anything, so a
+// build that could not deliver at all still reported that it had. These cover the status the
+// checklist now reads and the wording it shows for each one.
+final class NotificationAuthorizationTests: XCTestCase {
+    func testProvisionalStillCountsAsReachingTheUser() {
+        // Provisional delivers quietly to Notification Centre, which is still delivery.
+        XCTAssertEqual(NotificationDelivery.mapped(.provisional), .authorized)
+        XCTAssertEqual(NotificationDelivery.mapped(.authorized), .authorized)
+    }
+
+    func testDeniedAndUndeterminedStayApart() {
+        // They lead to different rows: one can still be asked, the other only opens Settings.
+        XCTAssertEqual(NotificationDelivery.mapped(.denied), .denied)
+        XCTAssertEqual(NotificationDelivery.mapped(.notDetermined), .notDetermined)
+    }
+
+    func testOnlyAuthorizedAllowsDelivery() {
+        XCTAssertTrue(NotificationAuthorization.authorized.allowsDelivery)
+        XCTAssertFalse(NotificationAuthorization.denied.allowsDelivery)
+        XCTAssertFalse(NotificationAuthorization.notDetermined.allowsDelivery)
+        XCTAssertFalse(NotificationAuthorization.unavailable("no bundle").allowsDelivery)
+    }
+
+    func testEveryBlockedStateSaysWhy() {
+        XCTAssertNil(NotificationAuthorization.authorized.deliveryBlocker)
+        for state: NotificationAuthorization in [.denied, .notDetermined, .unavailable("no bundle")] {
+            XCTAssertFalse(state.deliveryBlocker?.isEmpty ?? true, "\(state) must explain itself")
+        }
+    }
+
+    func testUnavailableCarriesItsOwnReasonThrough() {
+        XCTAssertEqual(
+            NotificationAuthorization.unavailable("no bundle").deliveryBlocker,
+            "no bundle"
+        )
+    }
+
+    // The test runner carries a bundle identifier but is not an .app, so it traps exactly the
+    // way `swift run Toki` does. Checking the identifier alone was not enough, which is what
+    // this test found.
+    func testBuildThatIsNotAnAppReportsItselfUnavailable() {
+        XCTAssertNotEqual(Bundle.main.bundleURL.pathExtension, "app",
+                          "precondition: the test binary is not an app bundle")
+        XCTAssertNotNil(NotificationDelivery.unavailableReason)
+    }
+
+    func testStatusIsUnavailableRatherThanTrappingWhenUnbundled() async {
+        let status = await NotificationDelivery.authorizationStatus()
+        guard case .unavailable = status else {
+            return XCTFail("an unbundled build must report unavailable, got \(status)")
+        }
+    }
+
+    func testDeliveryRefusesInsteadOfClaimingSuccessWhenUnbundled() async {
+        let failure = await NotificationDelivery.deliver(title: "t", body: "b")
+        XCTAssertNotNil(failure, "delivery that cannot happen must not report success")
+    }
+}
+
+// The checklist row that reports all of the above.
+final class NotificationChecklistStepTests: XCTestCase {
+    private func step(enabled: Bool, authorization: NotificationAuthorization) -> SetupStep {
+        var facts = SetupFacts()
+        facts.notificationsEnabled = enabled
+        facts.notificationAuthorization = authorization
+        let steps = SetupChecklist.steps(from: facts)
+        return steps.first { $0.kind == .notifications }!
+    }
+
+    func testUnaskedRowCanStillAsk() {
+        let row = step(enabled: true, authorization: .notDetermined)
+        XCTAssertEqual(row.status, .pending)
+        XCTAssertTrue(row.isRequestable)
+        XCTAssertEqual(row.actionLabel, "Allow")
+    }
+
+    func testGrantedRowReadsAsDone() {
+        let row = step(enabled: true, authorization: .authorized)
+        XCTAssertEqual(row.status, .done)
+    }
+
+    // macOS does not ask twice, so offering to request again would be a button that does nothing.
+    func testDeniedRowOffersSettingsRatherThanAnotherRequest() {
+        let row = step(enabled: true, authorization: .denied)
+        XCTAssertEqual(row.status, .blocked)
+        XCTAssertFalse(row.isRequestable)
+        XCTAssertEqual(row.actionLabel, "Open Settings")
+    }
+
+    // A denied permission is real outstanding work; it used to sit at .unknown and count as nothing.
+    func testDeniedRowCountsAsOutstanding() {
+        var facts = SetupFacts()
+        facts.notificationAuthorization = .denied
+        let outstanding = SetupChecklist.outstanding(SetupChecklist.steps(from: facts))
+        XCTAssertTrue(outstanding.contains { $0.kind == .notifications })
+    }
+
+    // Nothing to grant and nowhere to send anyone, so the row explains instead of acting.
+    func testUnavailableRowHasNoActionAtAll() {
+        let row = step(enabled: true, authorization: .unavailable("no app bundle"))
+        XCTAssertNil(row.actionLabel)
+        XCTAssertFalse(row.isRequestable)
+        XCTAssertEqual(row.detail, "no app bundle")
+    }
+
+    // Toki's own switch is off, so macOS is never asked and there is nothing outstanding.
+    func testTokisOwnSwitchBeingOffSettlesTheRow() {
+        let row = step(enabled: false, authorization: .denied)
+        XCTAssertEqual(row.status, .done)
+        XCTAssertNil(row.actionLabel)
+    }
+
+    // The pass exists to bring dialogs forward; an unasked notification permission is one.
+    func testUnaskedRowJoinsTheAllowAllPass() {
+        var facts = SetupFacts()
+        facts.notificationAuthorization = .notDetermined
+        let order = SetupChecklist.requestOrder(SetupChecklist.steps(from: facts))
+        XCTAssertTrue(order.contains { $0.kind == .notifications })
+    }
+
+    func testDeniedRowIsLeftOutOfTheAllowAllPass() {
+        var facts = SetupFacts()
+        facts.notificationAuthorization = .denied
+        let order = SetupChecklist.requestOrder(SetupChecklist.steps(from: facts))
+        XCTAssertFalse(order.contains { $0.kind == .notifications })
+    }
+}
+
+// Accessibility is granted in System Settings rather than a dialog, and macOS only hands the
+// new trust to a process when it starts, so a user who has just ticked the box comes back to a
+// row that still says "Allow" and reads as if nothing happened.
+final class AccessibilityStepTests: XCTestCase {
+    private func step(requested: Bool, granted: Bool = false) -> SetupStep? {
+        var facts = SetupFacts()
+        facts.accessibilityGranted = granted
+        facts.accessibilityRequested = requested
+        facts.workspaceAppRunning = true
+        return SetupChecklist.steps(from: facts).first { $0.kind == .accessibility }
+    }
+
+    func testUnaskedRowOffersToAsk() {
+        let row = step(requested: false)
+        XCTAssertEqual(row?.actionLabel, "Allow")
+        XCTAssertEqual(row?.isRequestable, true)
+    }
+
+    // Asking again would just reopen a pane the user has already been to.
+    func testRowOffersARestartOnceItHasSentTheUserToSettings() {
+        let row = step(requested: true)
+        XCTAssertEqual(row?.actionLabel, "Restart Toki")
+        XCTAssertEqual(row?.isRequestable, false)
+    }
+
+    func testTheRestartRowExplainsWhyTheTickDidNotTake() {
+        let detail = step(requested: true)?.detail ?? ""
+        XCTAssertTrue(detail.contains("restart"), "the row has to say what the button is for")
+    }
+
+    // Requesting twice in the "allow all" pass would open System Settings a second time.
+    func testARequestedRowDropsOutOfTheAllowAllPass() {
+        var facts = SetupFacts()
+        facts.accessibilityRequested = true
+        facts.workspaceAppRunning = true
+        let order = SetupChecklist.requestOrder(SetupChecklist.steps(from: facts))
+        XCTAssertFalse(order.contains { $0.kind == .accessibility })
+    }
+
+    // Granted is granted: the row goes away whether or not it was asked for in this run.
+    func testAGrantedPermissionShowsNoRowEitherWay() {
+        XCTAssertNil(step(requested: true, granted: true))
+        XCTAssertNil(step(requested: false, granted: true))
+    }
+}

--- a/Tests/TokiTests/SetupChecklistTests.swift
+++ b/Tests/TokiTests/SetupChecklistTests.swift
@@ -130,6 +130,9 @@ final class SetupChecklistTests: XCTestCase {
         facts.hasConnectedAccount = true
         facts.keychainApproved = true
         facts.remoteControlRunning = true
+        // Granted, so it drops out. Left unasked it is outstanding work in its own right, which
+        // is covered in NotificationChecklistStepTests.
+        facts.notificationAuthorization = .authorized
         facts.automation = [
             AutomationTarget(name: "iTerm", bundleID: "com.googlecode.iterm2", status: .done),
             AutomationTarget(name: "Terminal", bundleID: "com.apple.Terminal", status: .blocked)


### PR DESCRIPTION
Follow-up to #139, which surfaced these while working on the permissions card. **Based on `feat/menubar-display-options`**, since both touch `SetupChecklistView`; GitHub will retarget this to `main` when #139 merges.

## Screenshots

| | |
| --- | --- |
| **Notifications, not yet asked.** Pending, offering Allow. | <!-- drop an image here --> |
| **Notifications, denied.** Blocked, offering only Open Settings. | <!-- drop an image here --> |
| **Accessibility after a trip to System Settings.** The row offering Restart Toki. | <!-- drop an image here --> |

---

## Toki never asked for notification permission

`resolveNotificationAuthorization` set its cached flag to `true` and reported granted, unconditionally. There was no path that returned anything else:

```swift
// before
private func resolveNotificationAuthorization(completion: @escaping @Sendable (Bool, String?) -> Void) {
    if notificationAuthorization == true { completion(true, nil); return }
    notificationAuthorization = true
    completion(true, nil)
}
```

Delivery then went through `NSUserNotificationCenter`, deprecated since 10.14. Consequences: "Send a test" reported success whether or not anything reached you, macOS was never asked for permission at all, and the checklist row sat at `.unknown` forever, so a build that could not notify still looked like it might be fine.

### Why the shortcut was there, and why it is not needed

`git log -S` traces it to `65de098`, which replaced a real `requestAuthorization` call with the constant, citing a crash in `UNUserNotificationCenter.current()`. That crash is real: the API raises `bundleProxyForCurrentProcess is nil` whenever the running executable is not a proper `.app`, which covers `swift run Toki` (the documented dev workflow) and the test runner.

So the guard belongs on the bundle, not on the whole API. `NotificationDelivery` checks first and only then touches `UNUserNotificationCenter`, which makes it safe to call from any build while letting an unbundled one report itself unavailable rather than pretending.

Checking only for a bundle identifier was **not** enough, and the new tests caught it: the test runner has one (`bundleURL` is `.../Xcode.app/Contents/Developer/usr/bin/`). The condition is a bundle identifier *and* a `.app` bundle URL.

### What the row says now

| macOS says | Row | Action |
| --- | --- | --- |
| Not asked | pending | **Allow**, and it joins the allow-all pass |
| Denied | blocked | **Open Settings** only, since macOS will not ask twice |
| Authorized | done | Send a test |
| Unusable in this build | unknown | none, it explains itself |

`sendTestNotification` is awaitable now, so its dialog is sequenced with the rest of the allow-all pass instead of possibly landing on top of the next one.

## Accessibility did not notice a tick

Reported separately, same root area. Accessibility is granted in System Settings, not in a dialog Toki can wait on, and macOS only hands the new trust to a process **when it starts**. So ticking the box left the row still reading "Allow", exactly as if the grant had failed.

Once Toki has sent you to that pane, the row now offers **Restart Toki** and explains what is going on. The relaunch is handed to a detached shell that waits for this process to exit before reopening, so two instances never overlap and race over the state file.

It also names the sharper edge: macOS ties the tick to the app's code signature, and Toki is ad-hoc signed until it has a Developer ID (`docs/release-signing.md`). The cdhash changes on every build, so **an update drops the grant and it has to be ticked again**. That is not fixable in code; it needs the signing identity. Worth knowing it affects shipped releases, not just dev builds.

## Testing

`swift build` clean, 419 tests passing (24 new). The unavailability path is covered by the test binary itself being an unbundled build, so `authorizationStatus()` and `deliver()` are exercised against the exact shape that used to trap.

One existing test changed premise: `testOnlyPendingAndRefusedStepsCountAsOutstanding` now sets `notificationAuthorization = .authorized`. An unasked notification permission counting as outstanding work is the fix, not a regression.

## Not verified end to end

I could not confirm a notification actually appears on screen. The dev build is ad-hoc signed, and whether macOS draws a notification for it is its own decision and not observable from the app. The code path is right and honest about failure; a signed build is the real test.

