### PR TITLE
Prepare the 3.1.0 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - **Pin exactly which providers the menu bar shows.** Any connected provider, in the order you pin them, replacing the modes hardcoded to Claude and Codex.
 - **Logo only mode, for a menu bar that is already full.** Just the Toki mark, roughly a quarter the width, with every number still one click away.
-- **A size setting for the menu bar readout.** Comfortable, Compact, or Stacked (two providers on two half-height rows), independent of what the menu bar shows.
+- **A size setting for the menu bar readout.** Stacked is the new default: two providers on two half-height rows, roughly half the width. Comfortable is the old layout, Compact sits between them.
 - **The menu bar says when a pin will not fit.** Comfortable and Compact draw three providers, Stacked draws two, and anything past the limit is named rather than quietly dropped.
 - **Banked Codex resets show when they expire.** The expiry sits beside the count, so you can tell whether to redeem one now or wait for the quota to reset on its own.
 - **A beta build says which beta it is.** A badge beside the version names the prerelease, so a bug report can say which build it came from.
@@ -17,6 +17,7 @@
 - **The menu bar mode list is current again.** Claude + Codex only duplicated Smart and Accounts drew an anonymous dot and a count; both are gone, and existing settings carry over.
 - **Settings are grouped into named sections.** Remote Control and Permissions lead with headers of their own, and the panel's display toggles move into a new Layout section.
 - **Remote Control wears a joystick.** The antenna glyph is now an arcade stick, everywhere the feature appears.
+- **Toki sits further right in the menu bar.** It now takes the right-hand end of the third-party area, next to the system icons, and stays wherever you drag it instead of moving between launches.
 - **Release notes are one line per change.** The release page carries each entry's headline; the full text stays here and in What's New.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,27 +4,29 @@
 
 ### Added
 
-- **Pin exactly which providers the menu bar shows.** The old Claude and Codex modes were hardcoded to two providers out of the fifteen Toki tracks, so a Cursor-only or Gemini-only setup had nothing to choose. Pinned works for any connected provider, draws them in the order you pin them, and skips a pin whose account is not connected. If you pin nothing it falls back to Smart rather than leaving an empty status item.
-- **A Logo only mode, for a menu bar that is already full.** Toki drops to its mark and nothing else, about a quarter of the width of the full readout, with every number still one click away in the panel. It is the same mark the panel header draws, so the two finally match.
-- **A size setting for the menu bar readout.** Comfortable is what Toki has always drawn. Compact shrinks the glyphs and numbers and drops the percent sign. Stacked puts two providers on two half-height rows, roughly halving the width, in the style of apps like Stats; going vertical saves enough on its own that it keeps the percent sign. Size is independent of what the menu bar shows, so every mode can run at every size.
-- **A beta build says which beta it is.** The version pill read the same on a prerelease as on the stable it came from, because the marketing version has to stay dotted-numeric and the suffix lives elsewhere. A prerelease now carries a badge beside the version naming it, so a bug report can say which build it came from.
-- **The menu bar tells you when a pin will not fit.** Comfortable and Compact draw three providers, Stacked draws two, and the status item competes with every other icon on the bar. Once you reach the limit the remaining providers dim and say which size you are on and what it fits, instead of accepting a pin that then quietly never appears. Changing size with more pinned than the new one fits marks the extras rather than silently shortening the readout.
+- **Pin exactly which providers the menu bar shows.** Any connected provider, in the order you pin them, replacing the modes hardcoded to Claude and Codex.
+- **Logo only mode, for a menu bar that is already full.** Just the Toki mark, roughly a quarter the width, with every number still one click away.
+- **A size setting for the menu bar readout.** Comfortable, Compact, or Stacked (two providers on two half-height rows), independent of what the menu bar shows.
+- **The menu bar says when a pin will not fit.** Comfortable and Compact draw three providers, Stacked draws two, and anything past the limit is named rather than quietly dropped.
+- **Banked Codex resets show when they expire.** The expiry sits beside the count, so you can tell whether to redeem one now or wait for the quota to reset on its own.
+- **A beta build says which beta it is.** A badge beside the version names the prerelease, so a bug report can say which build it came from.
 
 ### Changed
 
-- **Recent and weekly quotas share one compact account-card view.** Claude Code and Codex now show every applicable rolling window side by side, including reset countdowns when provided, while plans that expose only one window keep the single-window layout and Codex reset credits stay directly beneath it.
-- **The menu bar mode list is current again.** Claude + Codex ran the identical code path to Smart, so it was two menu entries for one behaviour, and Accounts drew an anonymous grey dot and a count that told you less than any other mode. Both are gone. Existing settings carry over: Claude and Codex become pins for those providers, Claude + Codex and Accounts become Smart.
-- **Settings are grouped into sections that say what they are.** Remote Control and Permissions were two unlabelled cards stacked directly on each other, reading as one long card; they now lead the panel with headers of their own. Show AI insight and Show quota rings move into a new Layout section under General. Remote Control is the tallest card in the panel and gets a roomier rhythm to match.
-- **Remote Control wears a joystick.** The antenna glyph is now an arcade stick, in all three places the feature appears: its Settings card, the panel header button that opens it, and the menu bar indicator that shows the server is running.
+- **Recent and weekly quotas share one compact account-card view.** Claude Code and Codex show every applicable window side by side, with reset countdowns where provided.
+- **The menu bar mode list is current again.** Claude + Codex only duplicated Smart and Accounts drew an anonymous dot and a count; both are gone, and existing settings carry over.
+- **Settings are grouped into named sections.** Remote Control and Permissions lead with headers of their own, and the panel's display toggles move into a new Layout section.
+- **Remote Control wears a joystick.** The antenna glyph is now an arcade stick, everywhere the feature appears.
+- **Release notes are one line per change.** The release page carries each entry's headline; the full text stays here and in What's New.
 
 ### Fixed
 
-- **What's New reads as prose instead of markup.** The changelog is authored as markdown and every entry leads with a bold summary, so the panel was showing the asterisks, backticks, and link brackets as literal text. Inline formatting now renders, contributor links included.
-- **What's New and Quit Toki respond to the pointer.** They were system menu items, which keep the arrow cursor and the system highlight, so they were the only controls in the panel without the pointer and hover treatment everything else has.
-- **Toki actually asks macOS about notifications now.** It never did: the authorization check reported granted unconditionally, with no path that returned anything else, and delivery went through an API deprecated since macOS 10.14. So "Send a test" claimed success whether or not anything reached you, and the permissions row sat at "can't tell" forever. The row now reports what macOS really says, offers Allow when it has not been asked, and sends you to System Settings once it has been refused, because macOS will not ask twice.
-- **The permissions list notices a granted Accessibility tick.** macOS only hands new Accessibility trust to an app when it starts, so ticking the box left the row still reading "Allow" as though the grant had failed. It now offers a restart and explains that the tick is tied to the app's signature, which changes on every update until Toki has a Developer ID.
-- **The permissions card stops repeating its own name.** Its collapsed row leads with how many permissions are granted, and the note about a test notification clears once it stops describing something that just happened.
-- **Separators inside a settings card line up with the ones between cards.** The dividers within the notch card were inset differently from the card separators above and below them, so they visibly overhung on the left and fell short on the right.
+- **Toki actually asks macOS about notifications now.** The check reported granted unconditionally, so "Send a test" claimed success whether or not anything ever arrived.
+- **The permissions list notices a granted Accessibility tick.** macOS only hands new trust to an app when it starts, so the row offers a restart instead of reading "Allow" forever.
+- **What's New renders its markdown.** Asterisks, backticks, and link brackets were showing as literal text.
+- **What's New and Quit Toki respond to the pointer.** They were system menu items, the only controls in the panel without hover treatment.
+- **Separators inside a settings card line up with the ones between cards.** They were inset differently and visibly overhung.
+- **The permissions card stops repeating its own name.** Its collapsed row leads with how many permissions are granted.
 
 ### Thanks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 3.1.0 - 2026-08-29
 
 ### Added
 
@@ -21,8 +21,14 @@
 
 - **What's New reads as prose instead of markup.** The changelog is authored as markdown and every entry leads with a bold summary, so the panel was showing the asterisks, backticks, and link brackets as literal text. Inline formatting now renders, contributor links included.
 - **What's New and Quit Toki respond to the pointer.** They were system menu items, which keep the arrow cursor and the system highlight, so they were the only controls in the panel without the pointer and hover treatment everything else has.
+- **Toki actually asks macOS about notifications now.** It never did: the authorization check reported granted unconditionally, with no path that returned anything else, and delivery went through an API deprecated since macOS 10.14. So "Send a test" claimed success whether or not anything reached you, and the permissions row sat at "can't tell" forever. The row now reports what macOS really says, offers Allow when it has not been asked, and sends you to System Settings once it has been refused, because macOS will not ask twice.
+- **The permissions list notices a granted Accessibility tick.** macOS only hands new Accessibility trust to an app when it starts, so ticking the box left the row still reading "Allow" as though the grant had failed. It now offers a restart and explains that the tick is tied to the app's signature, which changes on every update until Toki has a Developer ID.
 - **The permissions card stops repeating its own name.** Its collapsed row leads with how many permissions are granted, and the note about a test notification clears once it stops describing something that just happened.
 - **Separators inside a settings card line up with the ones between cards.** The dividers within the notch card were inset differently from the card separators above and below them, so they visibly overhung on the left and fell short on the right.
+
+### Thanks
+
+[@thepushkarp](https://github.com/thepushkarp) contributed the compact recent-and-weekly quota windows on the account cards.
 
 ## 3.0.0 - 2026-08-27
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@
 </p>
 
 <p align="center">
-  <strong>A tiny macOS menu bar companion for AI coding agents and usage.</strong>
+  <strong>One menu bar app for every AI coding agent you run.</strong><br>
+  Track usage across all of them, see where the money goes, watch live sessions, and answer a waiting agent from your phone.
 </p>
 
 <p align="center">
-  <img alt="Version 2.7.0" src="https://img.shields.io/badge/version-2.7.0-2f80ed">
+  <img alt="Version 3.1.0" src="https://img.shields.io/badge/version-3.1.0-2f80ed">
   <img alt="Downloads" src="https://img.shields.io/github/downloads/aashutoshrathi/toki/total">
   <img alt="Stars" src="https://img.shields.io/github/stars/aashutoshrathi/toki">
   <img alt="macOS 14+" src="https://img.shields.io/badge/macOS-14%2B-111111">
@@ -17,24 +18,33 @@
   <a href="https://github.com/aashutoshrathi/toki"><img alt="Contribute on GitHub" src="https://img.shields.io/badge/contribute-GitHub-24292e?logo=github"></a>
 </p>
 
-<p align="center">
-  <code>/toki</code> keeps your active AI coding accounts, current-session quota, and weekly quota one click away, and lets you answer a waiting agent from your phone.
-</p>
-
 | Menu bar | Widget |
 |:---:|:---:|
 | ![Toki menu bar popover preview](https://files.aashutosh.dev/toki-preview.png) | ![Toki macOS widgets preview](https://files.aashutosh.dev/toki-widgets.png) |
 
+## What Toki does
 
-## Why Toki
+If you move between Claude Code, Codex, Cursor, and half a dozen others during the day, each one keeps its own quota, its own bill, and its own idea of what is running. Toki puts all of it in one place.
 
-Toki is built for people who jump between Claude Code, Codex, Cursor, Copilot, Gemini, Grok, OpenCode, Pi, Sarvam Code, Vercel's fx, and Google's Antigravity during the day and want a fast, local view of usage and active agents.
+**Usage across every harness.** Live quota for Claude Code and Codex, a spend ring for Cursor, and local token and spend tracking for OpenCode, Pi, Sarvam Code, and Vercel's fx. Whichever provider you are actively running sorts to the top. Multiple Claude Code accounts are discovered and switchable in one click.
 
-It works especially well with [`claude-swap`](https://github.com/realiti4/claude-swap): Toki discovers the same Claude Code account registry, shows active and inactive accounts, and lets you switch accounts without reimplementing credential-management logic.
+**Analytics that go back further than the install.** Spend and token counts across today, this week, this month, and all time, plus a thirty-day heatmap filterable by provider. Both are read from each tool's own session history, so they cover work you did before Toki existed. Reported currencies are preserved.
 
-Toki stays local. Credentials are read from your Mac, your configured commands, or provider auth files. The app does not run a cloud service.
+**Live sessions, and the ones stuck waiting.** Agent discovery across every supported tool, with navigation to the terminal tab or app hosting each one. A session parked on a permission prompt or a question gets a red dot and the question itself, on the card, the tab, and the menu bar, so you find out now rather than twenty minutes later.
 
-When an agent is waiting on you and you are not at your desk, Remote Control lets your phone answer it over your own tailnet, typing into the terminal the agent is already running in.
+**Remote Control, with no middleman.** Follow a running agent's transcript from another room and answer it: send a message, approve or reject a prompt, pick an option, switch its model, or mirror its terminal and drive whatever is on screen. There is a server, but it is **your Mac** — no relay, no account, no service of ours in the path. Replies land in the session already running, delivered to the agent's own TTY, so the agent cannot tell the difference. Off by default. See [Remote Control](docs/remote-control.md).
+
+Also: on-device Apple Intelligence summaries on macOS 26+, low-quota and session notifications with cooldowns and DND, desktop widgets, provider-colored quota rings, and an experimental notch mode.
+
+## Supported tools
+
+| | |
+|---|---|
+| **Quota tracked** | Claude Code (multi-account), Codex |
+| **Spend tracked** | Cursor, OpenCode, Pi, Sarvam Code, Vercel's fx |
+| **Sessions detected** | All of the above, plus Copilot CLI, Gemini CLI, Grok CLI, Google's Antigravity, and ChatGPT-hosted Codex |
+
+Toki works especially well with [`claude-swap`](https://github.com/realiti4/claude-swap): it reads the same Claude Code account registry, so accounts switch without either tool reimplementing the other's credential handling.
 
 ## Install
 
@@ -46,18 +56,17 @@ brew trust --cask aashutoshrathi/tap/toki
 brew install --cask toki
 ```
 
-The cask installs the latest release DMG. Toki is ad-hoc signed and not notarized, so macOS quarantines it. Clear the quarantine with:
+Toki is ad-hoc signed and not notarized, so macOS quarantines it. Clear that with:
 
 ```sh
 xattr -dr com.apple.quarantine /Applications/Toki.app
 ```
 
-The `-r` (recursive) is important: it also clears the bundled widget extension. Right-clicking Toki and choosing **Open** unblocks the app itself but leaves the nested extension quarantined, so macOS refuses to load it and the widgets stay blank — the recursive `xattr` is what makes the widgets work.
+The `-r` matters. It also clears the bundled widget extension: right-clicking Toki and choosing **Open** unblocks the app but leaves the nested extension quarantined, so macOS refuses to load it and the widgets stay blank.
 
 ### Direct download
 
 Grab the latest `Toki_<version>_universal.dmg` from the [releases page](https://github.com/aashutoshrathi/toki/releases/latest), open it, and drag Toki to Applications. Updates install in-app once running.
-
 
 ### From source
 
@@ -65,26 +74,6 @@ Grab the latest `Toki_<version>_universal.dmg` from the [releases page](https://
 swift run Toki                # run in place
 scripts/install-app.sh        # build a bundle and install to ~/Applications
 ```
-
-## What it does
-
-**Quota and spend.** Live rate-limit tracking for Claude Code (multi-account via `claude-swap`, with one-click switching) and Codex, a spend ring for Cursor read from your account, and local token and spend tracking for OpenCode, Pi, Sarvam Code, and Vercel's fx. Every spend figure carries the token count behind it, across today, this week, this month, and all time, and whichever provider you are actively running sorts to the top. Reported currencies are preserved; costs without a currency are treated as USD.
-
-**Active agents.** Discovery across Codex, Claude Code, Cursor, Copilot CLI, Gemini CLI, Grok CLI, OpenCode, Pi, Sarvam Code, Vercel's fx, Google's Antigravity, and ChatGPT-hosted Codex, with best-effort navigation to the terminal tab or app hosting each one.
-
-**Agents waiting on you.** A session parked on a permission prompt or a question is called out with a red dot and the question itself — on the card, the tab, and the menu bar — so you don't discover it twenty minutes later.
-
-**Remote Control from your phone, over Tailscale.** Follow a running agent's transcript from another room and answer it: send a message, approve or reject a permission prompt, pick an option, switch the model it is running, mirror its terminal to watch and drive whatever is on screen, or clear the session. Each agent carries a badge naming the model it is on. Replies are delivered to the agent's own TTY — `tmux send-keys` where there is a pane, iTerm2 by tty otherwise, Terminal as a fallback — so they land in the session already running rather than starting a new one, and the agent cannot tell the difference. Tailscale is the recommended route and keeps this off the public internet entirely; the host setting decides which networks the server will answer at all. Off by default. See [Remote Control](docs/remote-control.md).
-
-**Daily usage heatmap.** Thirty days, filterable by provider, read from each tool's own session history — so it covers work done before Toki was installed.
-
-**Insights and notifications.** An on-device Apple Intelligence summary on macOS 26+ (deterministic recommendation elsewhere), low-quota and session warnings with cooldowns and DND, and a session mode for tracking burn during a focused run. The insight card can be hidden from Settings.
-
-**Desktop widgets.** Small and medium macOS WidgetKit widgets put account quota, agents awaiting input, and break suggestions on your desktop or in Notification Center — plus a separate quota-rings widget for percentage-based accounts. They refresh from Toki's live data while it runs.
-
-**Quota rings.** Provider-colored rings that show remaining percentage at a glance, in the Accounts panel and as the standalone macOS widget, with provider details on hover. On by default; hide them from the panel or Settings.
-
-**Experimental notch mode.** Off by default, notched Macs only — moves the readout into the display notch, expanding on hover.
 
 ## Documentation
 
@@ -99,9 +88,9 @@ scripts/install-app.sh        # build a bundle and install to ~/Applications
 
 ## Privacy
 
-Toki stays local. Credentials are read from your Mac's Keychain or the provider auth files already on it; there is no cloud service and no telemetry. Session history is read for token counts, costs, timestamps, and titles — never message content. Diagnostics contain error categories and status codes only.
+Toki stays on your Mac. Credentials are read from your Keychain or the provider auth files already there. There is no cloud service and no telemetry. Session history is read for token counts, costs, timestamps, and titles, never message content. Diagnostics carry error categories and status codes only.
 
-Remote Control is the one feature that reads message content, because showing you a transcript is the point of it. It is off by default. When it is on, the transcript travels from your Mac straight to your phone and nowhere else: there is no relay and no account. If you use the hosted companion interface, that host serves the page only and never receives your agent data — and serving the page from your own Mac instead removes it from the picture entirely, which is why that is the recommended setting.
+Remote Control is the one feature that reads message content, because showing you a transcript is the point of it. It is off by default. When on, the transcript goes from your Mac straight to your phone and nowhere else. Tailscale is the recommended route and keeps it off the public internet entirely; the host setting decides which networks the server answers at all. If you use the hosted companion interface, that host serves the page only and never receives agent data, and serving the page from your own Mac instead removes it from the picture completely, which is why that is the default.
 
 Backwards-compatible fallbacks for the old TokenBar config paths are still honoured.
 

--- a/Sources/Toki/App/AppDelegate.swift
+++ b/Sources/Toki/App/AppDelegate.swift
@@ -88,7 +88,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         installEditMenu()
         installCLISymlink()
 
+        seedPreferredStatusItemPosition()
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        // A stable name is what makes a position stick. Without one AppKit invents a key per
+        // launch order, so dragging Toki somewhere lasted only until the next launch.
+        statusItem.autosaveName = Self.statusItemAutosaveName
         updateStatusItem()
         statusItem.button?.target = self
         statusItem.button?.action = #selector(togglePopover)
@@ -195,6 +199,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate {
         if FileManager.default.fileExists(atPath: symlinkPath) {
             DiagnosticLogger.shared.record(.info, component: "cli", code: "symlink_installed", detail: symlinkPath)
         }
+    }
+
+    private static let statusItemAutosaveName = "toki-status-item"
+
+    // macOS keeps third-party status items in their own region, to the left of the system ones
+    // (Control Center, clock, battery). Nothing an app can call puts it among those, so the
+    // furthest right Toki can sit is the right-hand end of the third-party region, immediately
+    // before them - which is what a preferred position of 0 asks for.
+    //
+    // AppKit reads this default when the item is created, so it has to be written first. Only
+    // seeded when absent: once the item exists AppKit owns the key, and overwriting it on every
+    // launch would drag Toki back rightwards every time someone moved it.
+    private func seedPreferredStatusItemPosition() {
+        let key = "NSStatusItem Preferred Position \(Self.statusItemAutosaveName)"
+        guard UserDefaults.standard.object(forKey: key) == nil else { return }
+        UserDefaults.standard.set(0, forKey: key)
     }
 
     private func updateStatusItem() {

--- a/Sources/Toki/Config/Constants.swift
+++ b/Sources/Toki/Config/Constants.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-let appVersion = "3.0.0"
+let appVersion = "3.1.0"
 let appUserAgent = "Toki/\(appVersion)"
 
 /// Display label for the prerelease part of a release identity, or nil for a stable build.

--- a/Sources/Toki/Models/UsageState.swift
+++ b/Sources/Toki/Models/UsageState.swift
@@ -159,7 +159,9 @@ struct AppPreferences: Codable, Equatable {
     var lowQuotaThreshold = 0.20
     var notificationCooldownMinutes = 90
     var menuBarMode = MenuBarDisplayMode.smart
-    var menuBarDensity = MenuBarDensity.comfortable
+    /// Stacked by default: the menu bar is the most contested space on the screen, and two
+    /// half-height rows show the same two providers in roughly half the width.
+    var menuBarDensity = MenuBarDensity.stacked
     /// Which providers `MenuBarDisplayMode.pinned` shows, in the order they are shown. Empty
     /// means the mode has nothing to draw, so the readout falls back to Smart rather than
     /// leaving an empty status item behind.

--- a/Sources/Toki/Utilities/MenuBarPinning.swift
+++ b/Sources/Toki/Utilities/MenuBarPinning.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// What the settings panel needs in order to draw the pin chips honestly.
+///
+/// The panel makes three claims at once - how many pins fit, which ones are reaching the menu
+/// bar, and which are pinned but being dropped - and all three have to agree with what
+/// `menuBarEntries` actually draws. Keeping the arithmetic here rather than in private view
+/// properties is what lets that agreement be tested.
+struct MenuBarPinState: Equatable {
+    /// Pins that could reach the bar: pinned and backed by a connected account, in pin order.
+    let effective: [Provider]
+    /// The tail of `effective` that the current density has no room for. Only ever non-empty
+    /// after a density change shrank the cap underneath an existing selection, since the panel
+    /// blocks adding past it.
+    let overflow: [Provider]
+    let cap: Int
+
+    /// Pins that actually reach the bar, which is what `menuBarEntries` will draw.
+    var drawn: [Provider] { Array(effective.prefix(cap)) }
+
+    /// False once the cap is reached, which is when the panel stops accepting new pins rather
+    /// than accepting one that then quietly never appears.
+    var canPinMore: Bool { effective.count < cap }
+}
+
+/// A pin whose provider has no connected account is skipped rather than counted: it never
+/// reaches the bar, so letting it use up a slot would block a pin that would have.
+func menuBarPinState(
+    pinned: [Provider],
+    connected: [Provider],
+    density: MenuBarDensity
+) -> MenuBarPinState {
+    let connectedSet = Set(connected)
+    let effective = pinned.filter(connectedSet.contains)
+    return MenuBarPinState(
+        effective: effective,
+        overflow: Array(effective.dropFirst(density.maxSegments)),
+        cap: density.maxSegments
+    )
+}
+
+/// "Claude Code", "Claude Code and Codex", "Claude Code, Codex and Cursor" - for naming the
+/// pins a density is dropping, in a sentence rather than as a bare list.
+func listedNames(_ providers: [Provider]) -> String {
+    let names = providers.map(\.displayName)
+    guard names.count > 1 else { return names.first ?? "" }
+    return names.dropLast().joined(separator: ", ") + " and " + (names.last ?? "")
+}
+
+/// The percent sign is the one character in a readout carrying no information the glyph beside
+/// it doesn't already imply, so Compact - whose whole job is width - spends it on something
+/// else. Stacked has already halved the readout by going vertical and keeps it. Cost readouts
+/// ("$12.30") have no percent sign and are returned untouched.
+func menuBarDisplayValue(_ value: String, density: MenuBarDensity) -> String {
+    guard density == .compact, value.hasSuffix("%") else { return value }
+    return String(value.dropLast())
+}

--- a/Sources/Toki/Views/MenuBarStatusView.swift
+++ b/Sources/Toki/Views/MenuBarStatusView.swift
@@ -71,20 +71,11 @@ struct MenuBarStatusView: View {
             } else {
                 ProviderLogo(provider: entry.provider, size: metrics.glyphSize)
             }
-            Text(displayValue(for: entry))
+            Text(menuBarDisplayValue(entry.value, density: density))
                 .font(.system(size: metrics.valueSize, weight: .regular, design: .monospaced))
                 .foregroundStyle(.primary)
                 .frame(minWidth: metrics.valueMinWidth, alignment: .trailing)
         }
-    }
-
-    // Compact only. The percent sign is the one character carrying no information the glyph
-    // beside it doesn't already imply, so the density whose whole job is width spends it on
-    // something else. Stacked has already halved the width by going vertical and has the room
-    // to keep it. Cost readouts ("$12.30") have no percent sign and are left alone.
-    private func displayValue(for entry: MenuBarStatusEntry) -> String {
-        guard density == .compact, entry.value.hasSuffix("%") else { return entry.value }
-        return String(entry.value.dropLast())
     }
 
     private var metrics: Metrics { Metrics(density: density) }

--- a/Sources/Toki/Views/SettingsPanel.swift
+++ b/Sources/Toki/Views/SettingsPanel.swift
@@ -500,20 +500,18 @@ struct SettingsPanel: View {
         return store.snapshots.filter { !$0.isError }.map(\.provider).filter { seen.insert($0).inserted }
     }
 
-    /// How many pins the current density can actually draw.
-    private var pinCap: Int { store.preferences.menuBarDensity.maxSegments }
-
-    /// Pins in the order they will be drawn, ignoring ones with no connected account since
-    /// those never reach the bar and so never use up a slot.
-    private var effectivePins: [Provider] {
-        store.preferences.menuBarPinnedProviders.filter { pinnableProviders.contains($0) }
+    /// The arithmetic behind the chips lives in `menuBarPinState` so the counts this panel
+    /// promises can be checked against what the menu bar actually draws.
+    private var pinState: MenuBarPinState {
+        menuBarPinState(
+            pinned: store.preferences.menuBarPinnedProviders,
+            connected: pinnableProviders,
+            density: store.preferences.menuBarDensity
+        )
     }
 
-    /// Pins past the cap. Non-empty only after a density change shrank the cap underneath an
-    /// existing selection, since adding past it is blocked.
-    private var overflowPins: [Provider] {
-        Array(effectivePins.dropFirst(pinCap))
-    }
+    private var pinCap: Int { pinState.cap }
+    private var overflowPins: [Provider] { pinState.overflow }
 
     @ViewBuilder
     private var pinnedProvidersRow: some View {
@@ -534,12 +532,12 @@ struct SettingsPanel: View {
                     // is being dropped instead of silently shortening the readout.
                     exposureNote(
                         "\(store.preferences.menuBarDensity.label) fits \(pinCap). "
-                        + "\(listed(overflowPins)) \(overflowPins.count == 1 ? "is" : "are") pinned but hidden — "
+                        + "\(listedNames(overflowPins)) \(overflowPins.count == 1 ? "is" : "are") pinned but hidden. "
                         + "unpin, or switch to Comfortable.",
                         level: .warning
                     )
                 } else {
-                    Text(effectivePins.count >= pinCap
+                    Text(!pinState.canPinMore
                          ? "\(store.preferences.menuBarDensity.label) fits \(pinCap). Unpin one to swap in another."
                          : "Shows up to \(pinCap), in the order you pin them. Pin nothing and Toki falls back to Smart.")
                         .font(.system(size: 9))
@@ -551,12 +549,6 @@ struct SettingsPanel: View {
         .padding(.leading, 18)
     }
 
-    private func listed(_ providers: [Provider]) -> String {
-        let names = providers.map(\.displayName)
-        guard names.count > 1 else { return names.first ?? "" }
-        return names.dropLast().joined(separator: ", ") + " and " + (names.last ?? "")
-    }
-
     private func pinToggle(for provider: Provider) -> some View {
         let pins = store.preferences.menuBarPinnedProviders
         let isPinned = pins.contains(provider)
@@ -564,7 +556,7 @@ struct SettingsPanel: View {
         // thing that made the old cap feel broken. Unpinning is always allowed, so the user is
         // never stuck, and an over-cap selection carried in from a density change stays
         // editable.
-        let isBlocked = !isPinned && effectivePins.count >= pinCap
+        let isBlocked = !isPinned && !pinState.canPinMore
         let isHidden = overflowPins.contains(provider)
 
         return Button {

--- a/Sources/Toki/Views/SettingsPanel.swift
+++ b/Sources/Toki/Views/SettingsPanel.swift
@@ -485,6 +485,7 @@ struct SettingsPanel: View {
                     }
                     .pickerStyle(.segmented)
                     .labelsHidden()
+                    .controlSize(.small)
                     .help("Comfortable and Compact fit 3 providers; Compact drops the percent sign. Stacked fits 2, on two rows")
                 }
                 .padding(8)
@@ -678,6 +679,7 @@ struct SettingsPanel: View {
                     }
                     .pickerStyle(.segmented)
                     .labelsHidden()
+                    .controlSize(.small)
                     .fixedSize()
                     .help("Hanging drops below the notch; Sideways sits in the menu bar beside it")
                 }

--- a/Tests/TokiTests/MenuBarPinningTests.swift
+++ b/Tests/TokiTests/MenuBarPinningTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+@testable import Toki
+
+// The settings panel makes three claims at once: how many pins fit, which are reaching the
+// menu bar, and which are pinned but dropped. All three have to agree with what
+// `menuBarEntries` actually draws, which is what these cover.
+final class MenuBarPinningTests: XCTestCase {
+    private let connected: [Provider] = [.claudeCode, .codex, .cursor, .gemini]
+
+    func testPinsAreKeptInTheOrderTheyWerePinned() {
+        let state = menuBarPinState(pinned: [.cursor, .claudeCode], connected: connected, density: .comfortable)
+        XCTAssertEqual(state.effective, [.cursor, .claudeCode])
+        XCTAssertEqual(state.drawn, [.cursor, .claudeCode])
+        XCTAssertTrue(state.overflow.isEmpty)
+    }
+
+    // A pin with no account behind it never reaches the bar, so letting it hold a slot would
+    // block one that would have.
+    func testAPinWithNoConnectedAccountDoesNotUseUpASlot() {
+        let state = menuBarPinState(
+            pinned: [.gemini, .claudeCode, .codex, .cursor],
+            connected: [.claudeCode, .codex, .cursor],
+            density: .comfortable
+        )
+        XCTAssertEqual(state.effective, [.claudeCode, .codex, .cursor])
+        XCTAssertTrue(state.overflow.isEmpty, "the unconnected pin must not push a real one out")
+        XCTAssertFalse(state.canPinMore)
+    }
+
+    func testTheCapFollowsTheDensity() {
+        XCTAssertEqual(menuBarPinState(pinned: [], connected: [], density: .comfortable).cap, 3)
+        XCTAssertEqual(menuBarPinState(pinned: [], connected: [], density: .compact).cap, 3)
+        XCTAssertEqual(menuBarPinState(pinned: [], connected: [], density: .stacked).cap, 2)
+    }
+
+    func testMoreCanBePinnedUntilTheCapIsReached() {
+        let pins: [Provider] = [.claudeCode, .codex]
+        XCTAssertTrue(menuBarPinState(pinned: pins, connected: connected, density: .comfortable).canPinMore)
+        XCTAssertFalse(menuBarPinState(pinned: pins, connected: connected, density: .stacked).canPinMore)
+    }
+
+    // The case the panel cannot block: switching density shrinks the cap under a selection
+    // that was legal when it was made.
+    func testShrinkingTheCapPushesTheTailIntoOverflow() {
+        let pins: [Provider] = [.claudeCode, .codex, .cursor]
+        let comfortable = menuBarPinState(pinned: pins, connected: connected, density: .comfortable)
+        XCTAssertTrue(comfortable.overflow.isEmpty)
+
+        let stacked = menuBarPinState(pinned: pins, connected: connected, density: .stacked)
+        XCTAssertEqual(stacked.drawn, [.claudeCode, .codex])
+        XCTAssertEqual(stacked.overflow, [.cursor])
+    }
+
+    // The panel's promise and the bar's behaviour are two separate code paths; this is the one
+    // test that holds them to each other.
+    func testWhatThePanelSaysIsDrawnIsWhatTheBarDraws() {
+        let snapshots = connected.map {
+            AccountSnapshot(id: $0.rawValue, name: $0.rawValue, provider: $0, primary: "", subtitle: "",
+                            remainingRatio: 0.5, metrics: [], menuBarValue: nil)
+        }
+        let pins: [Provider] = [.claudeCode, .codex, .cursor, .gemini]
+
+        for density in MenuBarDensity.allCases {
+            let state = menuBarPinState(pinned: pins, connected: connected, density: density)
+            let entries = menuBarEntries(for: snapshots, mode: .pinned, pinnedProviders: pins, density: density)
+            XCTAssertEqual(state.drawn, entries.map(\.provider), "\(density.label) disagrees with the menu bar")
+        }
+    }
+}
+
+// Naming the pins a density is dropping, in a sentence rather than as a bare list.
+final class ListedNamesTests: XCTestCase {
+    func testNothingReadsAsNothing() {
+        XCTAssertEqual(listedNames([]), "")
+    }
+
+    func testOneNameStandsAlone() {
+        XCTAssertEqual(listedNames([.codex]), "Codex")
+    }
+
+    func testTwoNamesAreJoinedWithAnd() {
+        XCTAssertEqual(listedNames([.claudeCode, .codex]), "Claude Code and Codex")
+    }
+
+    func testThreeOrMoreTakeCommasThenAnd() {
+        XCTAssertEqual(listedNames([.claudeCode, .codex, .cursor]), "Claude Code, Codex and Cursor")
+    }
+}
+
+final class MenuBarDisplayValueTests: XCTestCase {
+    // Compact buys width by shrinking, so every character counts.
+    func testCompactDropsThePercentSign() {
+        XCTAssertEqual(menuBarDisplayValue("42%", density: .compact), "42")
+    }
+
+    // Stacked has already halved the readout by going vertical and can afford to keep it.
+    func testComfortableAndStackedKeepThePercentSign() {
+        XCTAssertEqual(menuBarDisplayValue("42%", density: .comfortable), "42%")
+        XCTAssertEqual(menuBarDisplayValue("42%", density: .stacked), "42%")
+    }
+
+    // Cost providers have no percent sign, and trimming their last character would turn
+    // "$12.30" into "$12.3".
+    func testCostReadoutsAreLeftAloneAtEveryDensity() {
+        for density in MenuBarDensity.allCases {
+            XCTAssertEqual(menuBarDisplayValue("$12.30", density: density), "$12.30")
+        }
+    }
+
+    func testThePlaceholderIsLeftAlone() {
+        XCTAssertEqual(menuBarDisplayValue("--", density: .compact), "--")
+    }
+
+    func testTheLongestStackedValueSurvivesIntact() {
+        XCTAssertEqual(menuBarDisplayValue("100%", density: .stacked), "100%")
+    }
+}

--- a/Tests/TokiTests/ShellNoiseAndDiagnosticsTests.swift
+++ b/Tests/TokiTests/ShellNoiseAndDiagnosticsTests.swift
@@ -32,7 +32,14 @@ final class ShellNoiseAndDiagnosticsTests: XCTestCase {
     func testRunShellReturnsExactlyTheCommandsOutput() throws {
         // End to end through /bin/zsh -l: whatever the login profile on this machine prints
         // must not reach the caller.
-        XCTAssertEqual(try SecretResolver.runShell("printf 'hi'"), "hi")
+        //
+        // The timeout is raised well above the 15s production default because the two are
+        // measuring different things. That default is tuned for a user waiting on a key fetch,
+        // where giving up matters. Here the only claim under test is that profile noise is
+        // stripped, and a cold CI runner's first `zsh -l` pays for path_helper and the rest of
+        // /etc/zprofile all at once - which is what made this fail on a merge commit whose
+        // code had already passed on the branch.
+        XCTAssertEqual(try SecretResolver.runShell("printf 'hi'", timeout: 120), "hi")
     }
     #endif
 

--- a/Tests/TokiTests/StateCompatibilityTests.swift
+++ b/Tests/TokiTests/StateCompatibilityTests.swift
@@ -107,9 +107,12 @@ final class StateCompatibilityTests: XCTestCase {
         XCTAssertEqual(state.preferences.menuBarPinnedProviders, [.codex])
     }
 
-    func testStateFromBeforeMenuBarDensityKeepsTheComfortableDefault() throws {
+    // A state file written before the key existed adopts the current default, which is Stacked:
+    // the menu bar is contested space and two half-height rows cost about half the width.
+    func testStateFromBeforeMenuBarDensityAdoptsTheCurrentDefault() throws {
         let state = try decodeState(#"{"preferences": {"menuBarMode": "smart"}}"#)
-        XCTAssertEqual(state.preferences.menuBarDensity, .comfortable)
+        XCTAssertEqual(state.preferences.menuBarDensity, .stacked)
+        XCTAssertEqual(state.preferences.menuBarMode, .smart, "a stored mode still wins over the default")
     }
 }
 

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -15,6 +15,10 @@ WIDGET_RESOURCES_DIR="$WIDGET_CONTENTS_DIR/Resources"
 cd "$ROOT_DIR"
 VERSION=$(grep '^let appVersion' Sources/Toki/Config/Constants.swift | sed 's/.*"\(.*\)"/\1/')
 BUILD_NUMBER="${TOKI_BUILD_NUMBER:-$(date +%s)}"
+# Matches package-release.sh so a local build can carry a prerelease identity too. Without it
+# the two scripts produce differently shaped bundles, and anything reading this key - the
+# updater, the header's prerelease badge - is untestable outside a tagged CI run.
+RELEASE_VERSION="${TOKI_RELEASE_VERSION:-$VERSION}"
 swift build -c release
 
 rm -rf "$APP_DIR"
@@ -52,6 +56,8 @@ cat > "$CONTENTS_DIR/Info.plist" <<PLIST
   <string>$VERSION</string>
   <key>CFBundleVersion</key>
   <string>$BUILD_NUMBER</string>
+  <key>TokiReleaseVersion</key>
+  <string>$RELEASE_VERSION</string>
   <key>TokiWidgetDataMode</key>
   <string>local</string>
   <key>LSMinimumSystemVersion</key>
@@ -86,6 +92,8 @@ cat > "$WIDGET_CONTENTS_DIR/Info.plist" <<PLIST
   <string>$VERSION</string>
   <key>CFBundleVersion</key>
   <string>$BUILD_NUMBER</string>
+  <key>TokiReleaseVersion</key>
+  <string>$RELEASE_VERSION</string>
   <key>TokiWidgetDataMode</key>
   <string>local</string>
   <key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
Prepares the 3.1.0 stable release. Merging this makes the merge commit the release point, covering everything since `v3.0.0`: #139, #140, and #141.

## The CI failure

`ShellNoiseAndDiagnosticsTests.testRunShellReturnsExactlyTheCommandsOutput` failed on the #139 merge commit after **17.2s**, with `LocalizedErrorMessage("API key command timed out")`. The same code had passed on the branch minutes earlier, and passes locally in under a second, so nothing in #139 broke it.

The test runs end to end through `/bin/zsh -l` on purpose, to prove that login-profile output never reaches the caller. It inherited `runShell`'s 15s default, and a cold CI runner's first login shell pays for `path_helper` and the rest of `/etc/zprofile` in one go, which went past it.

The two numbers measure different things. The 15s default is tuned for a user waiting on a key fetch, where giving up promptly matters. The test's only claim is that profile noise is stripped, and no one is waiting on it, so it now passes a timeout suited to a cold machine. **Production behaviour is unchanged** — this is one argument at one call site in a test.

## Release

- `appVersion` 3.0.0 → **3.1.0**
- `## Unreleased` → `## 3.1.0 - 2026-08-29`, rewritten at roughly a line per entry rather than a paragraph explaining why each change was made
- README version badge 2.7.0 → 3.1.0, which was two releases stale
- `### Thanks` credits [@thepushkarp](https://github.com/thepushkarp) for #140, matching how 3.0.0 credits contributors

### Everything since the tag

`v3.0.0` is at #134, so the release range is wider than the Unreleased section covered. That section was written on the #139 branch and only knew about what was in front of it. Full range:

| PR | In the notes |
| --- | --- |
| #135 | Release notes cut to one line per change |
| #136 | No. It added a Thanks section to 3.0.0's notes; nothing changes in 3.1.0 |
| #137 | Banked Codex resets show when they expire |
| #139 | Menu bar modes, density, pin limit, settings regroup, beta badge |
| #140 | Compact recent-and-weekly quota windows |
| #141 | The notification permission never asked for, the Accessibility tick never noticed |

#137, #135, and #141 were all missing before this.

Every bold headline is a complete sentence, because `release-notes.sh --summary` (from #135) publishes only that part. Three of them ended mid-clause and would have shipped as fragments on the release page:

```
- **What's New renders its markdown**
- **What's New and Quit Toki respond to the pointer**
- **Separators inside a settings card line up**
```

## Tests for the pin limit

The arithmetic behind the pin chips was private view state in `SettingsPanel`, so the three claims the panel makes at once — how many pins fit, which reach the bar, and which are pinned but dropped — could not be checked against what `menuBarEntries` actually draws. Two code paths, no test holding them to each other.

`menuBarPinState` and `menuBarDisplayValue` are plain functions now, and the views call them. 15 new tests cover pin ordering, a pin whose provider has no connected account not consuming a slot, the per-density caps, and the overflow a density change creates. The one that earns its place:

```swift
func testWhatThePanelSaysIsDrawnIsWhatTheBarDraws() {
    for density in MenuBarDensity.allCases {
        let state = menuBarPinState(pinned: pins, connected: connected, density: density)
        let entries = menuBarEntries(for: snapshots, mode: .pinned, pinnedProviders: pins, density: density)
        XCTAssertEqual(state.drawn, entries.map(\.provider))
    }
}
```

`menuBarDisplayValue` also gets the percent-sign rule under test, including that `$12.30` is never trimmed to `$12.3`.

## README

It opened with "a tiny macOS menu bar companion for AI coding agents and usage", which says nothing, then spent ten dense paragraphs listing features. It now leads with the four things Toki is for:

- **Usage across every harness** — the point of the app, previously buried under "Why Toki"
- **Analytics that go back further than the install**, since both the spend view and the heatmap read each tool's own history
- **Live sessions, and the ones stuck waiting**
- **Remote Control with no middleman** — there *is* a server, but it is your Mac; no relay, no account, nothing of ours in the path

Provider support moves into a table split by what Toki can actually do for each (quota / spend / detection only), which is the distinction people need and the prose kept blurring. Net 61 lines lighter with nothing dropped except repetition.

## Testing

`swift build` clean, **440 tests passing** (15 new). The previously failing test passes.

## After merge

Tag the merge commit `v3.1.0` and push; CI publishes the release.

