### PR TITLE
v3.1.0: fix DMG packaging and test it before a tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,23 @@ jobs:
         # Explicit exit rather than relying on the step's bash -e, so a failure early in the loop
         # can never be reported as the last test's success.
         run: for test in Tests/test_*.js; do node "$test" || exit 1; done
+
+  # The release workflow only runs on a tag, so until now nothing built a DMG before one was
+  # pushed. 3.1.0 tagged green and then failed to publish, because the packaging step is the
+  # one thing CI never exercised. This runs the same script the release does, so packaging
+  # breaks on the branch that caused it instead of on the tag.
+  #
+  # Only on main and release branches: it is a universal build, so it costs far more than the
+  # test job and earns that cost only where a tag is actually going to come from.
+  package:
+    name: Package
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+      - name: Build and package
+        # No signing secrets here, so this packages ad-hoc. That is the same path an unsigned
+        # release takes, and it is the DMG creation and verification being checked either way.
+        run: bash scripts/package-release.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,11 @@ jobs:
   # test job and earns that cost only where a tag is actually going to come from.
   package:
     name: Package
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')
+    # On pull requests too, not just the push after merge. The trigger above already limits
+    # pull requests to ones aimed at main or a release branch, so every PR that reaches here is
+    # headed somewhere a tag can be cut from - and github.ref is refs/pull/N/merge on those,
+    # which matches neither branch name.
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v4

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -165,11 +165,15 @@ cp -R "$APP_DIR" "$STAGING_DIR/"
 ln -s /Applications "$STAGING_DIR/Applications"
 
 rm -f "$DMG_PATH"
+# No -fs: it used to pin HFS+, and on GitHub's macos-26 image that produces a file hdiutil
+# cannot read back at all - imageinfo rejects the header, not just the checksum. Apple has been
+# withdrawing HFS+ write support, so the filesystem is left to hdiutil, which picks one the
+# running OS can actually create. Toki requires macOS 14, well past the 10.13 that APFS images
+# need, so whichever it chooses is mountable by every supported install.
 hdiutil create \
   -volname "$APP_NAME $VERSION" \
   -srcfolder "$STAGING_DIR" \
   -ov -format UDZO \
-  -fs HFS+ \
   "$DMG_PATH"
 
 rm -rf "$STAGING_DIR"
@@ -185,7 +189,7 @@ rm -rf "$STAGING_DIR"
 # does, so a pass here means more than a checksum ever did.
 echo "==> Verifying DMG"
 hdiutil imageinfo "$DMG_PATH" > /dev/null
-ATTACH_DEV=$(hdiutil attach -nomount -readonly "$DMG_PATH" | awk 'NR==1 {print $1}')
+ATTACH_DEV=$(hdiutil attach -nomount -readonly "$DMG_PATH" | grep -o '^/dev/[^[:space:]]*' | head -1)
 if [[ -z "$ATTACH_DEV" ]]; then
   echo "    hdiutil attach produced no device for $DMG_PATH" >&2
   exit 1

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -177,8 +177,21 @@ rm -rf "$STAGING_DIR"
 # A DMG that hdiutil cannot attach is worthless to the updater, which mounts it to swap the
 # app in. Failing here keeps a bad image from being uploaded to a release, where the only
 # symptom is "hdiutil: attach failed - corrupt image" on every machine that tries to update.
+#
+# This checks attachability rather than the checksum. `hdiutil verify` reads the internal
+# CRC, and on GitHub's macos-26 runner it rejects images hdiutil itself has just written
+# ("unable to recognize as a disk image"), while passing locally on 26.6.2 for a byte-identical
+# invocation. Attaching is both the stricter test and the one that matches what the updater
+# does, so a pass here means more than a checksum ever did.
 echo "==> Verifying DMG"
-hdiutil verify "$DMG_PATH"
+hdiutil imageinfo "$DMG_PATH" > /dev/null
+ATTACH_DEV=$(hdiutil attach -nomount -readonly "$DMG_PATH" | awk 'NR==1 {print $1}')
+if [[ -z "$ATTACH_DEV" ]]; then
+  echo "    hdiutil attach produced no device for $DMG_PATH" >&2
+  exit 1
+fi
+hdiutil detach "$ATTACH_DEV" -quiet
+echo "    attached and detached cleanly as $ATTACH_DEV"
 
 echo ""
 echo "==> Done: $DMG_PATH"


### PR DESCRIPTION
The 3.1.0 tag built, signed, and then failed to publish. Two separate problems, one of which is why it reached a tag at all.

## The DMG really was corrupt

`hdiutil verify` called the image it had just written unrecognisable, on every run, and never locally. My first read was that the runner could not verify a good image — that was wrong. Adding an `imageinfo` check settled it, because `imageinfo` only parses the header and it fails too:

```
==> Creating DMG
created: .../Toki_3.1.0_universal.dmg
==> Verifying DMG
hdiutil: imageinfo failed - corrupt image
```

`hdiutil` was writing a file it could not read back. Had the check simply been swapped for something more permissive, 3.1.0 would have shipped a DMG that no one could mount.

**The cause is the pinned `-fs HFS+`.** Apple has been withdrawing HFS+ write support, and on GitHub's `macos-26` image `hdiutil create -fs HFS+` reports success and produces an unreadable image. The same invocation is fine locally on 26.6.2, which is why this only ever appeared on CI, and why v3.0.0 passed two days ago on an older runner image.

Tested rather than guessed:

| Filesystem | Result |
| --- | --- |
| `-fs APFS` | not accepted in that position at all; `hdiutil` printed its usage |
| no `-fs` | created, `imageinfo` OK, attached, detached cleanly |

So the pin is gone and `hdiutil` picks a filesystem the running OS can create. Toki requires macOS 14, well past the 10.13 an APFS image needs, so whatever it picks mounts on every supported install.

Confirmed on the runner:

```
==> Verifying DMG
    attached and detached cleanly as /dev/disk34
==> Done: .../Toki_3.1.0_universal.dmg
```

## Why a broken DMG reached a tag

`ci.yml` runs build and test. `release.yml` runs the packaging, and only on a tag push. **Nothing built a DMG until a tag existed**, so #143 and main were both legitimately green while the one step that was broken had never run.

CI now has a `Package` job running the same script the release does. It is gated to `main` and `release/**`: it is a universal build, so it costs far more than the test job and earns that only where a tag can come from. This failure would have surfaced on the branch.

## Also

The verification checks attachability instead of the checksum. The comment above that step already said what it was for — *"a DMG that hdiutil cannot attach is worthless to the updater"* — but `verify` reads the internal CRC, a different and weaker claim. `imageinfo` parses the structure, then the image is attached and detached, which is what the updater actually does.

The attach check also had a parsing bug of its own: `hdiutil attach` interleaves `Checksumming…` progress lines with the device table, so taking the first line captured a word rather than a device path. It matches `^/dev/` now.

## After merge

The `v3.1.0` tag currently points at `650e382`, which cannot publish. It moves to this merge commit and gets pushed again.
