### PR TITLE
Companion: rebuild the composer as a two-row card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- **A roomier reply box in the companion app.** The field now spans the full width with the tools under it, rather than being squeezed between them, and Send is a labelled button instead of an unlabelled arrow. An avatar and placeholder name the agent you are replying to, and the box expands for a longer message.
 - **A quota rail down the screen edge.** Opt-in from Settings: a ring per provider tucked under the menu bar, showing what is left at a glance, with a card on hover carrying every quota window the provider reports and when each one resets. It anchors to the screen rather than the notch, so it runs on external displays and Macs without one, and it steps aside in full screen.
 
 ## 3.1.0 - 2026-08-29

--- a/Sources/Toki/Resources/webui/app.js
+++ b/Sources/Toki/Resources/webui/app.js
@@ -403,6 +403,17 @@ function providerLogo(p) {
   return '<svg class="plogo" viewBox="0 0 24 24" fill="#888"><circle cx="12" cy="12" r="8"/></svg>';
 }
 
+// Same aliases providerLogo folds together, so the composer names whoever its avatar is showing.
+function providerLabel(p) {
+  if (p == "claude" || p == "claudeCode" || p == "anthropic") return "Claude";
+  if (p == "codex" || p == "openai" || p == "chatgpt") return "Codex";
+  if (p == "opencode" || p == "openCode") return "OpenCode";
+  if (p == "antigravity") return "Antigravity";
+  if (p == "fx") return "fx";
+  if (p == "sarvam" || p == "sarvamCode") return "Sarvam Code";
+  return p ? p.charAt(0).toUpperCase() + p.slice(1) : "";
+}
+
 // Trim a model id to the part worth glancing at on a phone: drop a provider path prefix
 // (anthropic/\u2026, zai/\u2026) and the redundant "claude-" vendor tag.
 function shortModel(m) {
@@ -479,7 +490,24 @@ function updateComposer(agent) {
   $("#screen").hidden = !canMirror;
   if (!writable || (modelMirror && (!agent || modelMirror.pid != agent.pid))) closeModelMirror();
   document.querySelectorAll("footer button,footer input,footer textarea").forEach(el => el.disabled = !enabled);
-  $("#msg").placeholder = writable ? "Reply to the agent\u2026" : (agent ? "Read-only session" : "No active session");
+  // The avatar names who the reply is going to, which the placeholder alone never did once
+  // more than one agent was running.
+  $("#composeravatar").innerHTML = agent ? providerLogo(agent.provider) : "";
+  const who = agent ? providerLabel(agent.provider) : "";
+  $("#msg").placeholder = writable
+    ? (who ? "Reply to " + who + "\u2026" : "Reply to the agent\u2026")
+    : (agent ? "Read-only session" : "No active session");
+}
+
+// A tall field is worth having for a long reply and in the way the rest of the time, so it is a
+// toggle rather than the default.
+function toggleComposerExpanded() {
+  const composer = document.querySelector(".composer");
+  const expanded = composer.classList.toggle("expanded");
+  $("#expand").setAttribute("aria-pressed", expanded ? "true" : "false");
+  $("#expand").title = expanded ? "Collapse the composer" : "Expand the composer";
+  if (!expanded) resizeComposer();
+  $("#msg").focus();
 }
 
 // Clearing is irreversible, so require a second tap within five seconds.
@@ -1310,11 +1338,17 @@ $("#log").addEventListener("click", e => {
 
 function resizeComposer() {
   const input = $("#msg");
+  if (document.querySelector(".composer").classList.contains("expanded")) {
+    input.style.height = "";
+    input.style.overflowY = "auto";
+    return;
+  }
   input.style.height = "auto";
   input.style.height = Math.min(input.scrollHeight, 200) + "px";
   input.style.overflowY = input.scrollHeight > 200 ? "auto" : "hidden";
 }
 
+$("#expand").addEventListener("click", toggleComposerExpanded);
 $("#msg").addEventListener("input", resizeComposer);
 $("#msg").addEventListener("keydown", e => {
   if (e.key == "Enter" && !e.isComposing && (e.metaKey || e.ctrlKey)) {

--- a/Sources/Toki/Resources/webui/index.html
+++ b/Sources/Toki/Resources/webui/index.html
@@ -66,9 +66,17 @@
   </div>
   <div id="attachpreview" hidden></div>
   <input id="fileinput" type="file" accept="image/*" hidden>
-  <div class="composer"><button id="attach" type="button" aria-label="Attach an image" title="Attach an image"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="m21 15-5-5L5 21"/></svg></button><button id="model" type="button" hidden aria-label="Change the agent&#8217;s model" title="Change model"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 7h9M17 7h3M4 17h3M11 17h9"/><circle cx="15.5" cy="7" r="2.2"/><circle cx="7.5" cy="17" r="2.2"/></svg></button><button id="screen" type="button" hidden aria-label="Mirror the agent&#8217;s terminal" title="Mirror the terminal"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="4" width="18" height="14" rx="2"/><path d="m7 9 3 2.5L7 14"/><path d="M13 14h4"/></svg></button><textarea id="msg" rows="1" placeholder="Reply to the agent&#8230;" aria-describedby="composerhint"></textarea>
-  <button id="clear" type="button" aria-label="Clear the agent&#8217;s context" title="Clear the agent&#8217;s context (/clear)"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18M8 6V4.5A1.5 1.5 0 0 1 9.5 3h5A1.5 1.5 0 0 1 16 4.5V6M18.5 6l-.8 13.1a2 2 0 0 1-2 1.9H8.3a2 2 0 0 1-2-1.9L5.5 6"/></svg></button>
-  <button id="send" aria-label="Send reply" aria-keyshortcuts="Meta+Enter Control+Enter" title="Send reply"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3.4 20.4 21 12 3.4 3.6l-.1 6.5L15 12 3.3 13.9Z"/></svg></button></div>
+  <div class="composer">
+    <div class="composer-top">
+      <span class="composer-avatar" id="composeravatar" aria-hidden="true"></span>
+      <textarea id="msg" rows="1" placeholder="Reply to the agent&#8230;" aria-describedby="composerhint"></textarea>
+      <button id="expand" type="button" aria-label="Expand the composer" title="Expand the composer" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M14 4h6v6M20 4l-7 7M10 20H4v-6M4 20l7-7"/></svg></button>
+    </div>
+    <div class="composer-actions">
+      <div class="composer-tools"><button id="attach" type="button" aria-label="Attach an image" title="Attach an image"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="m21 15-5-5L5 21"/></svg></button><button id="model" type="button" hidden aria-label="Change the agent&#8217;s model" title="Change model"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 7h9M17 7h3M4 17h3M11 17h9"/><circle cx="15.5" cy="7" r="2.2"/><circle cx="7.5" cy="17" r="2.2"/></svg></button><button id="screen" type="button" hidden aria-label="Mirror the agent&#8217;s terminal" title="Mirror the terminal"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="4" width="18" height="14" rx="2"/><path d="m7 9 3 2.5L7 14"/><path d="M13 14h4"/></svg></button><button id="clear" type="button" aria-label="Clear the agent&#8217;s context" title="Clear the agent&#8217;s context (/clear)"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18M8 6V4.5A1.5 1.5 0 0 1 9.5 3h5A1.5 1.5 0 0 1 16 4.5V6M18.5 6l-.8 13.1a2 2 0 0 1-2 1.9H8.3a2 2 0 0 1-2-1.9L5.5 6"/></svg></button></div>
+      <button id="send" aria-label="Send reply" aria-keyshortcuts="Meta+Enter Control+Enter" title="Send reply">Send</button>
+    </div>
+  </div>
   <div class="composer-hint" id="composerhint">Return adds a line <span aria-hidden="true">&middot;</span> &#8984;/Ctrl + Return sends</div>
   <div id="status" role="status" aria-live="polite"></div>
 </footer>

--- a/Sources/Toki/Resources/webui/styles.css
+++ b/Sources/Toki/Resources/webui/styles.css
@@ -246,27 +246,43 @@ footer{position:absolute;left:0;right:0;bottom:0;z-index:4;background:var(--surf
 .keys button small{font-size:9px;color:var(--text-3);font-weight:500}
 input{flex:1;padding:11px;border-radius:var(--r-sm);background:var(--surface-2);color:var(--text);
       border:1px solid var(--line);font-size:16px}
-.composer{display:flex;gap:4px;align-items:flex-end;
-          background:var(--surface-2);border:1px solid var(--line);
-          border-radius:24px;padding:5px 6px}
-.composer textarea{flex:1;min-width:0;min-height:34px;max-height:200px;padding:7px 6px;
-                   resize:none;overflow-y:hidden;border:none;background:transparent;color:var(--text);
-                   font:16px/1.4 -apple-system,system-ui,sans-serif}
-.composer textarea:focus-visible{outline:none}
-.composer button{width:38px;min-width:38px;height:38px;padding:0;border-radius:50%;
-                 background:linear-gradient(180deg,var(--accent-2),var(--accent));color:#fff;border:1px solid var(--accent-line);
-                 box-shadow:0 1px 0 #ffffff40 inset,0 2px 8px #0d2a4d55;flex:none;
+/* Two rows rather than one: the text gets the full width on top, and the tools sit under it
+   instead of squeezing the field between five circles on a phone. */
+.composer{display:flex;flex-direction:column;gap:6px;
+          background:var(--surface-2);border:1px solid var(--line-strong);
+          border-radius:22px;padding:10px 12px}
+.composer-top{display:flex;gap:9px;align-items:flex-start}
+.composer-avatar{flex:none;width:30px;height:30px;border-radius:50%;overflow:hidden;
+                 background:var(--surface-3);border:1px solid var(--line);
                  display:flex;align-items:center;justify-content:center}
+.composer-avatar svg{width:19px;height:19px}
+.composer-avatar:empty{display:none}
+.composer textarea{flex:1;min-width:0;min-height:30px;max-height:200px;padding:4px 0;
+                   resize:none;overflow-y:hidden;border:none;background:transparent;color:var(--text);
+                   font:16px/1.45 -apple-system,system-ui,sans-serif}
+.composer textarea:focus-visible{outline:none}
+.composer.expanded textarea{min-height:132px}
+.composer-actions{display:flex;align-items:center;justify-content:space-between;gap:8px}
+.composer-tools{display:flex;align-items:center;gap:2px;min-width:0}
+/* Ghost by default. The send button is the only thing in here that should pull the eye. */
+.composer button{width:36px;min-width:36px;height:36px;padding:0;border-radius:50%;
+                 background:transparent;color:var(--text-2);border:1px solid transparent;
+                 box-shadow:none;flex:none;
+                 display:flex;align-items:center;justify-content:center}
+.composer button:active{background:var(--surface-3)}
 .composer button svg{width:20px;height:20px;fill:currentColor}
-#clear{background:var(--surface-2);border-color:var(--line-strong);color:var(--text-2);
-       box-shadow:0 1px 0 #ffffff0d inset}
+#expand{width:30px;min-width:30px;height:30px}
+#expand svg{width:16px;height:16px;fill:none;stroke:currentColor;stroke-width:2;
+            stroke-linecap:round;stroke-linejoin:round}
+#send{width:auto;min-width:0;height:36px;padding:0 20px;border-radius:18px;
+      background:linear-gradient(180deg,var(--accent-2),var(--accent));color:#fff;
+      border:1px solid var(--accent-line);
+      box-shadow:0 1px 0 #ffffff40 inset,0 2px 8px #0d2a4d55;
+      font:700 15px/1 -apple-system,system-ui,sans-serif}
+#send:disabled{opacity:.45}
 #clear svg{fill:none;stroke:currentColor;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}
 #clear.armed{background:var(--danger-surface);border-color:var(--danger-line);color:#eda0a0}
-#attach{background:var(--surface-2);border-color:var(--line-strong);color:var(--text-2);
-        box-shadow:0 1px 0 #ffffff0d inset}
 #attach svg{fill:none;stroke:currentColor}
-#model,#screen{background:var(--surface-2);border-color:var(--line-strong);color:var(--text-2);
-       box-shadow:0 1px 0 #ffffff0d inset}
 #model[hidden],#screen[hidden]{display:none}
 #model svg,#screen svg{fill:none;stroke:currentColor;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}
 #modelmirror{margin-bottom:8px;border:1px solid var(--line-strong);border-radius:var(--r);

--- a/Tests/test_remote_ux.js
+++ b/Tests/test_remote_ux.js
@@ -13,7 +13,19 @@ assert.match(html, /<textarea id="msg"/);
 assert.match(html, /Return adds a line/);
 assert.match(html, /Ctrl \+ Return sends/);
 assert.match(html, /aria-keyshortcuts="Meta\+Enter Control\+Enter"/);
-assert.match(html, /<button id="send"[^>]+><svg/);
+// The send button is a labelled pill rather than an icon: it is the one control in the
+// composer that should pull the eye, and an unlabelled arrow made it a guess.
+assert.match(html, /<button id="send"[^>]+>Send<\/button>/);
+// The composer is two rows now, so the field gets the full width and the tools sit under it.
+assert.match(html, /<div class="composer-top">/);
+assert.match(html, /<div class="composer-actions">/);
+assert.match(html, /<span class="composer-avatar" id="composeravatar"/);
+assert.match(html, /<button id="expand"/);
+// Every control that carried wiring has to survive the restructure.
+for (const id of ["msg", "attach", "model", "screen", "clear", "send"]) {
+  assert.match(html, new RegExp('id="' + id + '"'), id + " went missing from the composer");
+}
+assert.match(css, /\.composer\.expanded textarea/);
 assert.match(html, /<small>Reject<\/small>/);
 assert.match(app, /Approve<\/button>/);
 assert.match(app, /Reject<\/button>/);


### PR DESCRIPTION
Reworks the companion app's composer along the lines of the reply box in the reference: the text field across the top, the tools underneath, and a labelled send button.

## Screenshots

| | |
| --- | --- |
| **Collapsed.** Avatar, placeholder naming the provider, expand control top-right, tools and Send below. | <img width="338" height="193" alt="image" src="https://github.com/user-attachments/assets/964c4b67-b05a-4bb7-97ad-04ad0df5089b" /> |
| **Expanded.** The field grows and the tools stay anchored to the bottom of the card. | <img width="344" height="239" alt="image" src="https://github.com/user-attachments/assets/f93c9d38-59b8-4d4f-a3de-d93cb82462f1" /> |

---

## Why

The composer was a single row: `[attach] [model] [screen] [textarea] [clear] [send]`, every button a 38px circle. On a phone that left the field narrower than the controls around it, and five filled circles meant nothing in the row read as *the* action.

Now it is two rows. The field takes the full width on top; the tools sit under it.

## What changed

- **Send is a labelled pill.** It was an unlabelled paper-plane icon, indistinguishable in weight from the four buttons beside it. It is the only control in the card with a filled background now.
- **The tools are ghosts.** Attach, model, screen and clear each carried their own surface and border. They keep their shape on press but no longer compete with Send.
- **An avatar, naming who the reply goes to.** The same provider mark the transcript uses. The placeholder reads "Reply to Claude…" rather than "Reply to the agent…", which stopped being specific once more than one agent was running. It names the *provider*, not `agent.title`, which runs to a full sentence.
- **Expand.** A tall field is worth having for a long reply and in the way the rest of the time, so it is a toggle rather than the default. Autogrow steps aside while it is on, instead of writing an inline height that fights the class.

## Wiring

Every `id` the existing JavaScript hangs off is unchanged: `msg`, `attach`, `model`, `screen`, `clear`, `send`. `updateComposer` still gates each control the same way, and `document.querySelectorAll("footer button,...")` still disables the lot on a read-only session, which now covers the expand control too.

## Testing

All six companion suites pass, plus the 86 server tests.

`test_remote_ux.js` asserted `/<button id="send"[^>]+><svg/`, which the label broke. It now checks for the label, the two rows, the avatar, the expand control, the expanded-field rule in CSS, and that none of the six wired controls went missing in the restructure — the last of which is the failure mode a markup rewrite actually risks.

Checked in a browser at phone width against a live `toki_remote.py`, collapsed and expanded, with the placeholder resolving to the connected agent's provider.
