### PR TITLE
Refine Liquid Glass controls and account cards

### DIFF
--- a/Sources/Toki/Views/ChangelogView.swift
+++ b/Sources/Toki/Views/ChangelogView.swift
@@ -115,10 +115,6 @@ func inlineMarkdown(_ text: String) -> AttributedString {
     )) ?? AttributedString(text)
 }
 
-func changelogVersionTitle(_ version: String) -> String {
-    version.caseInsensitiveCompare("Unreleased") == .orderedSame ? "Unreleased" : "v\(version)"
-}
-
 struct ChangelogPage: View {
     var onClose: () -> Void
 
@@ -167,7 +163,7 @@ struct ChangelogPage: View {
     private func releaseCard(_ release: ChangelogRelease) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 6) {
-                Text(changelogVersionTitle(release.version))
+                Text(release.version == "Unreleased" ? release.version : "v\(release.version)")
                     .font(.system(size: 12, weight: .bold))
                 if !release.date.isEmpty {
                     Text(release.date)

--- a/Sources/Toki/Views/Components.swift
+++ b/Sources/Toki/Views/Components.swift
@@ -316,8 +316,6 @@ struct StatusBadge: View {
 
 // MARK: - ResetCreditBadge
 
-// Keep this as a standard Label so the surrounding system button style owns its typography,
-// symbol spacing, and optical centering at every control size and appearance.
 struct ResetCreditBadge: View {
     var count: Int
     var expiry: Date?

--- a/Tests/TokiTests/ChangelogMarkdownTests.swift
+++ b/Tests/TokiTests/ChangelogMarkdownTests.swift
@@ -37,9 +37,4 @@ final class ChangelogMarkdownTests: XCTestCase {
     func testMalformedMarkdownFallsBackToTheRawText() {
         XCTAssertFalse(rendered("A **dangling bold and a [link(broken").isEmpty)
     }
-
-    func testUnreleasedHeadingHasNoVersionPrefix() {
-        XCTAssertEqual(changelogVersionTitle("Unreleased"), "Unreleased")
-        XCTAssertEqual(changelogVersionTitle("3.1.0"), "v3.1.0")
-    }
 }


### PR DESCRIPTION
## Summary

- use native adaptive Liquid Glass for header, Settings utility, and Codex reset controls on macOS 26, with compatible fallbacks on earlier macOS versions
- align quota-based account cards, keep reset credits below quota details with their full count, and leave providers without quota bars compact
- preserve upstream 3.1.0 menu and Settings changes while fixing universal Intel packaging, embedded changelog resources, and the Unreleased heading

## Verification

- strict Swift build passed
- 441 Swift tests passed
- 86 companion server tests passed
- all companion web tests passed
- universal arm64 and x86_64 release app and DMG built, signed, mounted, and detached successfully
- app and widget plists plus strict deep code signing passed
- toolbar, account cards, reset control, Settings, native sliders and segmented controls, More menu, and What's New were verified in the running app