### PR TITLE
Keep brew and the in-app updater from fighting over the same app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,22 +101,40 @@ jobs:
             "${NOTES_FLAGS[@]}" $PRERELEASE_FLAG
 
       - name: Update Homebrew tap
-        # The cask tracks the stable channel only, so prerelease tags must not rewrite it.
-        if: ${{ env.HOMEBREW_TAP_TOKEN != '' && !contains(github.ref_name, '-') }}
+        # Stable tags bump the stable cask; prerelease tags bump the beta cask only, except
+        # that a stable tag also re-bumps the beta cask so beta users are carried onto the
+        # graduated stable build by a plain `brew upgrade` (brew ranks 2.5.0 > 2.5.0-beta.N).
+        if: ${{ env.HOMEBREW_TAP_TOKEN != '' }}
         run: |
           TAP_DIR="$(mktemp -d)"
           git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/aashutoshrathi/homebrew-tap.git" "$TAP_DIR"
-          # Rewrite the tap's cask with this release's version + DMG sha256.
-          bash scripts/update-cask.sh "$TAP_DIR/Casks/toki.rb"
+          # First run on a tap that predates the beta cask: seed it from the in-repo
+          # template so update-cask.sh has a file to rewrite. Once the tap carries the
+          # cask this is skipped and the existing file is bumped in place.
+          if [ ! -f "$TAP_DIR/Casks/toki-beta.rb" ]; then
+            mkdir -p "$TAP_DIR/Casks"
+            cp homebrew/toki-beta.rb "$TAP_DIR/Casks/toki-beta.rb"
+          fi
+          if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
+            # Prerelease: the cask version is the full tag; the DMG filename carries only
+            # the base version, which update-cask.sh handles.
+            bash scripts/update-cask.sh "$TAP_DIR/Casks/toki-beta.rb" "${GITHUB_REF_NAME#v}"
+          else
+            # Both casks take the same stable version, which is update-cask.sh's default.
+            bash scripts/update-cask.sh "$TAP_DIR/Casks/toki.rb"
+            bash scripts/update-cask.sh "$TAP_DIR/Casks/toki-beta.rb"
+          fi
           cd "$TAP_DIR"
-          if git diff --quiet; then
-            echo "Cask already up to date; nothing to push."
+          # Stage before checking: a freshly seeded Casks/toki-beta.rb is untracked, and
+          # `git diff --quiet` alone would ignore it and skip the first bootstrap commit.
+          git add Casks/
+          if git diff --cached --quiet; then
+            echo "Casks already up to date; nothing to push."
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add Casks/toki.rb
-          git commit -m "Update Toki cask to ${GITHUB_REF_NAME}"
+          git commit -m "Update Toki casks to ${GITHUB_REF_NAME}"
           git push
 
       - name: Clean up signing keychain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **Per-model weekly limits show as their own quota.** A model with its own weekly allowance, like Fable 5, is metered separately from the shared week, so spending one leaves the other untouched. Toki now reports each of them beside the 5h and 7d windows instead of showing only the shared pair.
 - **A roomier reply box in the companion app.** The field now spans the full width with the tools under it, rather than being squeezed between them, and Send is a labelled button instead of an unlabelled arrow. An avatar and placeholder name the agent you are replying to, and the box expands for a longer message.
+- **A beta channel you can install from Homebrew.** `brew install --cask toki-beta` tracks pre-release builds, and a stable release bumps it too, so `brew upgrade` carries testers onto the graduated build. Switching channels in Settings moves a Homebrew install onto the matching cask for you, and swapping the cask with brew yourself moves the channel to match — either way the two stay in agreement.
 - **A quota rail down the screen edge.** Opt-in from Settings: a ring per provider tucked under the menu bar, showing what is left at a glance, with a card on hover carrying every quota window the provider reports and when each one resets. It anchors to the screen rather than the notch, so it runs on external displays and Macs without one, and it steps aside in full screen.
 
 ### Changed
@@ -14,6 +15,7 @@
 
 ### Fixed
 
+- **A Homebrew install no longer gets downgraded by its own updater.** Installing an update replaced the app underneath brew, leaving brew's records pointing at a version that was no longer there — so the next `brew upgrade` quietly put the older build back. Toki now hands the install to `brew upgrade` when a cask owns the app, so both sides agree on what is installed.
 - **Universal release packages build a real Intel slice.** The packaging script now asks SwiftPM to plan the x86_64 build at the architecture level, instead of compiling arm64 objects and handing them to an Intel linker.
 - **Local app bundles carry a real changelog resource.** The build script now follows the source symlink, so What's New survives moving the app away from the working tree and strict signature verification no longer encounters a dangling file.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Beta builds are available as a separate cask that tracks prereleases:
 brew install --cask toki-beta
 ```
 
-The two casks conflict — install one. A stable release bumps both, so `brew upgrade` carries beta installs onto the graduated stable build. When Toki was installed by a cask, its in-app updater routes updates through `brew upgrade` so brew's bookkeeping stays in sync.
+The two casks conflict — install one. A stable release bumps both, so `brew upgrade` carries beta installs onto the graduated stable build. When Toki was installed by a cask, its in-app updater routes updates through `brew upgrade` so brew's bookkeeping stays in sync, and switching channels in Settings > Updates moves the install onto the other cask for you. Switching casks with brew yourself works too — the app picks up the change and follows it.
 
 Toki is ad-hoc signed and not notarized, so macOS quarantines it. Clear that with:
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ brew trust --cask aashutoshrathi/tap/toki
 brew install --cask toki
 ```
 
+Beta builds are available as a separate cask that tracks prereleases:
+
+```sh
+brew install --cask toki-beta
+```
+
+The two casks conflict — install one. A stable release bumps both, so `brew upgrade` carries beta installs onto the graduated stable build. When Toki was installed by a cask, its in-app updater routes updates through `brew upgrade` so brew's bookkeeping stays in sync.
+
 Toki is ad-hoc signed and not notarized, so macOS quarantines it. Clear that with:
 
 ```sh

--- a/Sources/Toki/Updates/BrewCask.swift
+++ b/Sources/Toki/Updates/BrewCask.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// Routes in-app updates through Homebrew when a cask installed this copy of Toki.
+///
+/// The updater's DMG swap replaces the bundle in place, which desyncs brew's receipt from
+/// the app on disk; a later `brew upgrade` then clobbers the newer build. Handing the
+/// install to `brew upgrade` keeps receipt, Caskroom, and bundle in agreement.
+struct BrewCaskInstall: Equatable, Sendable {
+    let cask: String
+    let brewPrefix: String
+
+    var brewBinary: String { brewPrefix + "/bin/brew" }
+}
+
+enum BrewCask {
+    static let stableCask = "toki"
+    static let betaCask = "toki-beta"
+
+    /// The cask (and the brew prefix owning it) whose Caskroom entry resolves to the
+    /// running bundle. The `app` stanza moves the bundle out of the Caskroom and leaves a
+    /// symlink pointing at it, so the cask side is the one that must be enumerated and
+    /// resolved; resolving the bundle path alone can never see an inbound symlink. That
+    /// also makes detection independent of `--appdir`. Both prefixes are probed because
+    /// Intel Homebrew lives under /usr/local, not /opt/homebrew.
+    static func installedCask(
+        bundleURL: URL,
+        caskroomBases: [URL],
+        caskNames: [String] = [stableCask, betaCask]
+    ) -> BrewCaskInstall? {
+        let resolvedBundle = bundleURL.resolvingSymlinksInPath().standardizedFileURL.path
+        for base in caskroomBases {
+            guard let cask = caskNames.first(where: { name in
+                appPaths(in: base.appendingPathComponent(name)).contains(resolvedBundle)
+            }) else { continue }
+            return BrewCaskInstall(cask: cask, brewPrefix: base.deletingLastPathComponent().path)
+        }
+        return nil
+    }
+
+    private static func appPaths(in caskDir: URL) -> [String] {
+        let entries = (try? FileManager.default.contentsOfDirectory(
+            at: caskDir,
+            includingPropertiesForKeys: nil
+        )) ?? []
+        return entries.map {
+            $0.appendingPathComponent("Toki.app").resolvingSymlinksInPath().standardizedFileURL.path
+        }
+    }
+
+    /// Only the beta cask tracks prereleases. Handing a prerelease to the stable cask
+    /// would upgrade to whatever stable version the tap holds, or no-op — either way the
+    /// offered build never arrives, so the mismatch is reported instead of attempted.
+    static func canDeliver(cask: String, isPrerelease: Bool) -> Bool {
+        !isPrerelease || cask == betaCask
+    }
+
+    /// Exit status of `brew upgrade`, or nil when brew could not be launched at all —
+    /// the two cases need different advice, and a missing brew is not a failed upgrade.
+    ///
+    /// Off the main actor: an upgrade can run for minutes and the menu bar must stay
+    /// responsive. Termination is observed via waitpid exit, not a pipe read, so there is
+    /// no stdout/stderr drain to deadlock on.
+    static func runUpgrade(_ install: BrewCaskInstall) async -> Int32? {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global().async {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: install.brewBinary)
+                process.arguments = ["upgrade", "--cask", install.cask]
+                do {
+                    try process.run()
+                    process.waitUntilExit()
+                    continuation.resume(returning: process.terminationStatus)
+                } catch {
+                    continuation.resume(returning: nil)
+                }
+            }
+        }
+    }
+
+    /// Postcondition after the handoff, read from the replaced bundle's Info.plist.
+    ///
+    /// The plist is parsed off disk rather than through `Bundle(url:)`, which returns the
+    /// already-loaded Bundle for a path Foundation has seen - always true of the running
+    /// app - along with the Info dictionary it cached before brew swapped the bundle. That
+    /// stale read reports the old version and fails every successful upgrade.
+    static func handoffSucceeded(appURL: URL, expectedVersion: String) -> Bool {
+        let plistURL = appURL.appendingPathComponent("Contents/Info.plist")
+        guard let data = try? Data(contentsOf: plistURL),
+              let info = (try? PropertyListSerialization.propertyList(from: data, format: nil)) as? [String: Any]
+        else { return false }
+        return handoffSucceeded(
+            bundleVersion: info["TokiReleaseVersion"] as? String,
+            marketingVersion: info["CFBundleShortVersionString"] as? String,
+            expectedVersion: expectedVersion
+        )
+    }
+
+    /// The stamped `TokiReleaseVersion` distinguishes beta iterations that share one
+    /// marketing version (`2.5.0-beta.1` vs `-beta.2` both report `2.5.0`); without the
+    /// stamp only an exact stable match can pass, because a beta iteration is then
+    /// indistinguishable from its siblings.
+    static func handoffSucceeded(bundleVersion: String?, marketingVersion: String?, expectedVersion: String) -> Bool {
+        if let bundleVersion, !bundleVersion.isEmpty {
+            return bundleVersion == expectedVersion
+        }
+        guard let marketingVersion, !expectedVersion.contains("-") else { return false }
+        return marketingVersion == expectedVersion
+    }
+}

--- a/Sources/Toki/Updates/BrewCask.swift
+++ b/Sources/Toki/Updates/BrewCask.swift
@@ -47,6 +47,10 @@ enum BrewCask {
         }
     }
 
+    static func cask(for channel: UpdateChannel) -> String {
+        channel == .beta ? betaCask : stableCask
+    }
+
     /// Only the beta cask tracks prereleases. Handing a prerelease to the stable cask
     /// would upgrade to whatever stable version the tap holds, or no-op — either way the
     /// offered build never arrives, so the mismatch is reported instead of attempted.
@@ -54,18 +58,34 @@ enum BrewCask {
         !isPrerelease || cask == betaCask
     }
 
-    /// Exit status of `brew upgrade`, or nil when brew could not be launched at all —
+    /// Moving a brew install from one cask to the other, in order.
+    ///
+    /// It has to be uninstall-then-install: `conflicts_with` makes brew refuse to install
+    /// either cask while the other is present, and installing over the top with `--force`
+    /// would leave two receipts owning one bundle - the exact desync this whole path
+    /// exists to prevent. The download is fetched first because the uninstall deletes the
+    /// bundle this process is running from, and a network failure after that point would
+    /// leave no app on disk at all.
+    static func switchCommands(from installed: String, to target: String) -> [[String]] {
+        [
+            ["fetch", "--cask", target],
+            ["uninstall", "--cask", installed],
+            ["install", "--cask", target],
+        ]
+    }
+
+    /// Exit status of the brew invocation, or nil when brew could not be launched at all —
     /// the two cases need different advice, and a missing brew is not a failed upgrade.
     ///
-    /// Off the main actor: an upgrade can run for minutes and the menu bar must stay
-    /// responsive. Termination is observed via waitpid exit, not a pipe read, so there is
-    /// no stdout/stderr drain to deadlock on.
-    static func runUpgrade(_ install: BrewCaskInstall) async -> Int32? {
+    /// Off the main actor: brew can run for minutes and the menu bar must stay responsive.
+    /// Termination is observed via waitpid exit, not a pipe read, so there is no
+    /// stdout/stderr drain to deadlock on.
+    static func run(_ arguments: [String], brewBinary: String) async -> Int32? {
         await withCheckedContinuation { continuation in
             DispatchQueue.global().async {
                 let process = Process()
-                process.executableURL = URL(fileURLWithPath: install.brewBinary)
-                process.arguments = ["upgrade", "--cask", install.cask]
+                process.executableURL = URL(fileURLWithPath: brewBinary)
+                process.arguments = arguments
                 do {
                     try process.run()
                     process.waitUntilExit()

--- a/Sources/Toki/Updates/BrewCask.swift
+++ b/Sources/Toki/Updates/BrewCask.swift
@@ -3,8 +3,7 @@ import Foundation
 /// Routes in-app updates through Homebrew when a cask installed this copy of Toki.
 ///
 /// The updater's DMG swap replaces the bundle in place, which desyncs brew's receipt from
-/// the app on disk; a later `brew upgrade` then clobbers the newer build. Handing the
-/// install to `brew upgrade` keeps receipt, Caskroom, and bundle in agreement.
+/// the app on disk; a later `brew upgrade` then clobbers the newer build.
 struct BrewCaskInstall: Equatable, Sendable {
     let cask: String
     let brewPrefix: String
@@ -16,12 +15,11 @@ enum BrewCask {
     static let stableCask = "toki"
     static let betaCask = "toki-beta"
 
-    /// The cask (and the brew prefix owning it) whose Caskroom entry resolves to the
-    /// running bundle. The `app` stanza moves the bundle out of the Caskroom and leaves a
-    /// symlink pointing at it, so the cask side is the one that must be enumerated and
-    /// resolved; resolving the bundle path alone can never see an inbound symlink. That
-    /// also makes detection independent of `--appdir`. Both prefixes are probed because
-    /// Intel Homebrew lives under /usr/local, not /opt/homebrew.
+    /// The cask whose Caskroom entry resolves to the running bundle, and the prefix owning
+    /// it. The `app` stanza moves the bundle out of the Caskroom and leaves a symlink
+    /// pointing at it, so only the cask side can see the relationship - which also keeps
+    /// detection independent of `--appdir`. Intel Homebrew lives under /usr/local, so more
+    /// than one base has to be probed.
     static func installedCask(
         bundleURL: URL,
         caskroomBases: [URL],
@@ -51,21 +49,19 @@ enum BrewCask {
         channel == .beta ? betaCask : stableCask
     }
 
-    /// Only the beta cask tracks prereleases. Handing a prerelease to the stable cask
-    /// would upgrade to whatever stable version the tap holds, or no-op — either way the
-    /// offered build never arrives, so the mismatch is reported instead of attempted.
+    static func channel(for cask: String) -> UpdateChannel {
+        cask == betaCask ? .beta : .stable
+    }
+
+    /// Only the beta cask carries prereleases, so the stable cask can never deliver one.
     static func canDeliver(cask: String, isPrerelease: Bool) -> Bool {
         !isPrerelease || cask == betaCask
     }
 
-    /// Moving a brew install from one cask to the other, in order.
-    ///
-    /// It has to be uninstall-then-install: `conflicts_with` makes brew refuse to install
-    /// either cask while the other is present, and installing over the top with `--force`
-    /// would leave two receipts owning one bundle - the exact desync this whole path
-    /// exists to prevent. The download is fetched first because the uninstall deletes the
-    /// bundle this process is running from, and a network failure after that point would
-    /// leave no app on disk at all.
+    /// `conflicts_with` makes brew refuse to install either cask while the other is
+    /// present, so a switch is uninstall-then-install. Fetching first matters because the
+    /// uninstall deletes the bundle this process runs from: a download that fails after
+    /// that point would leave no app on disk.
     static func switchCommands(from installed: String, to target: String) -> [[String]] {
         [
             ["fetch", "--cask", target],
@@ -74,12 +70,9 @@ enum BrewCask {
         ]
     }
 
-    /// Exit status of the brew invocation, or nil when brew could not be launched at all —
-    /// the two cases need different advice, and a missing brew is not a failed upgrade.
-    ///
-    /// Off the main actor: brew can run for minutes and the menu bar must stay responsive.
-    /// Termination is observed via waitpid exit, not a pipe read, so there is no
-    /// stdout/stderr drain to deadlock on.
+    /// Exit status, or nil when brew could not be launched at all - a missing brew needs
+    /// different advice than a failed upgrade. Runs off the main actor because brew takes
+    /// minutes; nothing reads its pipes, so there is no drain to deadlock on.
     static func run(_ arguments: [String], brewBinary: String) async -> Int32? {
         await withCheckedContinuation { continuation in
             DispatchQueue.global().async {
@@ -97,12 +90,9 @@ enum BrewCask {
         }
     }
 
-    /// Postcondition after the handoff, read from the replaced bundle's Info.plist.
-    ///
-    /// The plist is parsed off disk rather than through `Bundle(url:)`, which returns the
-    /// already-loaded Bundle for a path Foundation has seen - always true of the running
-    /// app - along with the Info dictionary it cached before brew swapped the bundle. That
-    /// stale read reports the old version and fails every successful upgrade.
+    /// Parsed off disk rather than through `Bundle(url:)`, which hands back the running
+    /// app's already-loaded bundle and the Info dictionary it cached before brew swapped
+    /// the file - a stale read that fails every successful upgrade.
     static func handoffSucceeded(appURL: URL, expectedVersion: String) -> Bool {
         let plistURL = appURL.appendingPathComponent("Contents/Info.plist")
         guard let data = try? Data(contentsOf: plistURL),
@@ -115,10 +105,9 @@ enum BrewCask {
         )
     }
 
-    /// The stamped `TokiReleaseVersion` distinguishes beta iterations that share one
-    /// marketing version (`2.5.0-beta.1` vs `-beta.2` both report `2.5.0`); without the
-    /// stamp only an exact stable match can pass, because a beta iteration is then
-    /// indistinguishable from its siblings.
+    /// `TokiReleaseVersion` distinguishes beta iterations that share one marketing version
+    /// (`-beta.1` and `-beta.2` both report `2.5.0`); without the stamp a beta is
+    /// indistinguishable from its siblings, so only an exact stable match can pass.
     static func handoffSucceeded(bundleVersion: String?, marketingVersion: String?, expectedVersion: String) -> Bool {
         if let bundleVersion, !bundleVersion.isEmpty {
             return bundleVersion == expectedVersion

--- a/Sources/Toki/Updates/UpdateChecker.swift
+++ b/Sources/Toki/Updates/UpdateChecker.swift
@@ -58,6 +58,8 @@ final class UpdateChecker: ObservableObject {
     @Published private(set) var availableUpdate: AvailableUpdate?
     @Published private(set) var isInstalling = false
     @Published private(set) var installError: String?
+    @Published private(set) var isSwitchingCask = false
+    @Published private(set) var caskSwitchError: String?
     @Published private(set) var isChecking = false
     @Published private(set) var lastCheckedAt: Date?
     @Published private(set) var checkMessage: String?
@@ -102,6 +104,7 @@ final class UpdateChecker: ObservableObject {
     }
 
     func startAutomaticChecks() {
+        adoptChannelOfInstalledCask()
         if mockVersion != nil {
             runCheck()
             return
@@ -122,12 +125,80 @@ final class UpdateChecker: ObservableObject {
     /// prerelease now, not at the next five-minute tick. The stale offer is cleared first so a
     /// beta banner can't linger after switching back to stable.
     func setChannel(_ newChannel: UpdateChannel) {
-        guard newChannel != channel else { return }
+        guard newChannel != channel, !isSwitchingCask else { return }
+        storeChannel(newChannel)
+        availableUpdate = nil
+        caskSwitchError = nil
+
+        // A brew install follows its cask, not this preference, so the picker has to move
+        // the install too or the two silently disagree. Non-brew copies just switch which
+        // releases they are offered.
+        let target = BrewCask.cask(for: newChannel)
+        guard let install = brewInstall(), install.cask != target else {
+            checkNow()
+            return
+        }
+        isSwitchingCask = true
+        Task { await performCaskSwitch(install: install, target: target) }
+    }
+
+    /// A cask swap run from the command line has to move the app's channel with it, the
+    /// same way the picker moves the cask. The cask is the authority here: it decides
+    /// which releases brew will actually install, so the preference follows it.
+    private func adoptChannelOfInstalledCask() {
+        guard !isSwitchingCask, let install = brewInstall() else { return }
+        let owned: UpdateChannel = install.cask == BrewCask.betaCask ? .beta : .stable
+        guard owned != channel else { return }
+        storeChannel(owned)
+        availableUpdate = nil
+    }
+
+    private func storeChannel(_ newChannel: UpdateChannel) {
         channel = newChannel
         defaults.set(newChannel.rawValue, forKey: updateChannelKey)
-        availableUpdate = nil
-        checkNow()
     }
+
+    private func brewInstall() -> BrewCaskInstall? {
+        BrewCask.installedCask(
+            bundleURL: Bundle.main.bundleURL,
+            caskroomBases: [
+                URL(fileURLWithPath: "/opt/homebrew/Caskroom"),
+                URL(fileURLWithPath: "/usr/local/Caskroom"),
+            ]
+        )
+    }
+
+    private func performCaskSwitch(install: BrewCaskInstall, target: String) async {
+        for command in BrewCask.switchCommands(from: install.cask, to: target) {
+            guard await BrewCask.run(command, brewBinary: install.brewBinary) == 0 else {
+                await recoverFromFailedCaskSwitch(install: install, target: target)
+                return
+            }
+        }
+        isSwitchingCask = false
+        // The bundle on disk is a different build now, so the running process is stale.
+        if !relaunchAfterBrewChange() {
+            caskSwitchError = "Switched to the \(target) cask. Reopen Toki to finish."
+            return
+        }
+        NSApp.terminate(nil)
+    }
+
+    /// The uninstall runs before the install, so a failure can leave no app on disk at
+    /// all. Reinstalling the cask that was there is the only way back; the preference
+    /// goes back with it so the picker keeps describing what is actually installed.
+    private func recoverFromFailedCaskSwitch(install: BrewCaskInstall, target: String) async {
+        let restored = await BrewCask.run(["install", "--cask", install.cask], brewBinary: install.brewBinary) == 0
+        DiagnosticLogger.shared.record(
+            .error, component: "updater", code: "cask_switch_failed", detail: "to=\(target) restored=\(restored)"
+        )
+        storeChannel(install.cask == BrewCask.betaCask ? .beta : .stable)
+        isSwitchingCask = false
+        caskSwitchError = restored
+            ? "Couldn't switch to the \(target) cask, so nothing changed."
+            : "Switching to the \(target) cask failed and Toki may be gone from Applications. Run `brew install --cask \(target)`."
+    }
+
 
     func dismiss() {
         guard let availableUpdate else { return }
@@ -198,18 +269,12 @@ final class UpdateChecker: ObservableObject {
     /// Returns true once the install belongs to brew - handed over or refused - so the
     /// DMG path does not also run.
     private func startBrewHandoff(for update: AvailableUpdate) -> Bool {
-        guard let install = BrewCask.installedCask(
-            bundleURL: Bundle.main.bundleURL,
-            caskroomBases: [
-                URL(fileURLWithPath: "/opt/homebrew/Caskroom"),
-                URL(fileURLWithPath: "/usr/local/Caskroom"),
-            ]
-        ) else { return false }
+        guard let install = brewInstall() else { return false }
 
         guard BrewCask.canDeliver(cask: install.cask, isPrerelease: update.isPrerelease) else {
             failBrewHandoff(
                 code: "brew_channel_mismatch",
-                message: "Beta builds ship in the \(BrewCask.betaCask) cask. Run `brew install --cask \(BrewCask.betaCask)` to switch."
+                message: "Beta builds ship in the \(BrewCask.betaCask) cask. Pick Beta in Settings > Updates to move this install onto it."
             )
             return true
         }
@@ -220,7 +285,7 @@ final class UpdateChecker: ObservableObject {
     private func installViaBrew(install: BrewCaskInstall, update: AvailableUpdate) async {
         let cask = install.cask
         let manually = "Update with `brew upgrade --cask \(cask)`."
-        guard let status = await BrewCask.runUpgrade(install) else {
+        guard let status = await BrewCask.run(["upgrade", "--cask", cask], brewBinary: install.brewBinary) else {
             failBrewHandoff(code: "brew_missing", message: "Couldn't run \(install.brewBinary). \(manually)")
             return
         }
@@ -233,7 +298,7 @@ final class UpdateChecker: ObservableObject {
             return
         }
 
-        guard relaunchAfterBrewUpgrade() else {
+        guard relaunchAfterBrewChange() else {
             // The upgrade landed but relaunching failed; keep the app up rather than
             // close it, and tell the user how to get the new build running.
             installError = "Toki was updated but couldn't relaunch. Reopen Toki to finish."
@@ -249,17 +314,24 @@ final class UpdateChecker: ObservableObject {
         isInstalling = false
     }
 
-    /// Reopens the app after a successful handoff. Brew replaced the bundle but has no
-    /// quit/reopen artifact for these casks, so without this the upgrade closes Toki.
+    /// Reopens the app after brew replaced the bundle. Brew has no quit/reopen artifact
+    /// for these casks, so without this an upgrade or a cask switch just closes Toki.
     ///
-    /// The open runs from a detached child that waits for this process to die first:
-    /// `open` fired immediately would target the still-running instance via
-    /// LaunchServices, and after termination no replacement would be left.
-    private func relaunchAfterBrewUpgrade() -> Bool {
-        guard let executable = Bundle.main.executableURL else { return false }
+    /// The waiter is `/bin/sh` rather than Toki's own binary: a channel switch can install
+    /// an older build, which need not understand a private relaunch flag. It also has to
+    /// outlive this process before acting - `open` fired while the app is still running
+    /// would be routed to this instance by LaunchServices, and after termination nothing
+    /// would be left to reopen.
+    private func relaunchAfterBrewChange() -> Bool {
         let process = Process()
-        process.executableURL = executable
-        process.arguments = ["--brew-relaunch", UpdateInstaller.installedAppURL().path, String(ProcessInfo.processInfo.processIdentifier)]
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [
+            "-c",
+            #"while kill -0 "$1" 2>/dev/null; do sleep 0.2; done; exec /usr/bin/open "$2""#,
+            "sh",
+            String(ProcessInfo.processInfo.processIdentifier),
+            UpdateInstaller.installedAppURL().path,
+        ]
         do {
             try process.run()
             return true
@@ -269,26 +341,8 @@ final class UpdateChecker: ObservableObject {
         }
     }
 
-    static func runRelaunchHelperIfRequested(arguments: [String]) -> Bool {
-        guard arguments.count == 4, arguments[1] == "--brew-relaunch" else { return false }
-        let appPath = arguments[2]
-        // Fail safe: a malformed PID means continue normal startup, not exit the app.
-        guard let parentPID = Int32(arguments[3]) else { return false }
-        while kill(parentPID, 0) == 0 {
-            Thread.sleep(forTimeInterval: 0.2)
-        }
-        let open = Process()
-        open.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-        open.arguments = [appPath]
-        do {
-            try open.run()
-        } catch {
-            DiagnosticLogger.shared.record(.error, component: "updater", code: "brew_relaunch_failed", detail: diagnosticErrorDetail(error))
-        }
-        return true
-    }
-
     private func runCheck(isManual: Bool = false) {
+        adoptChannelOfInstalledCask()
         guard !isChecking else { return }
         isChecking = true
         if isManual { checkMessage = nil }

--- a/Sources/Toki/Updates/UpdateChecker.swift
+++ b/Sources/Toki/Updates/UpdateChecker.swift
@@ -171,6 +171,7 @@ final class UpdateChecker: ObservableObject {
         guard let availableUpdate, !isInstalling else { return }
         isInstalling = true
         installError = nil
+        guard !startBrewHandoff(for: availableUpdate) else { return }
 
         Task {
             do {
@@ -186,6 +187,105 @@ final class UpdateChecker: ObservableObject {
                 isInstalling = false
             }
         }
+    }
+
+    /// A cask-installed copy must be upgraded by brew, not swapped underneath it: the DMG
+    /// path would desync brew's receipt and the next `brew upgrade` would clobber this
+    /// newer build with the cask's older one. The installed cask wins over the channel
+    /// preference - upgrading a different cask than the one that owns this bundle would
+    /// either fail on the conflict or leave the receipt stale.
+    ///
+    /// Returns true once the install belongs to brew - handed over or refused - so the
+    /// DMG path does not also run.
+    private func startBrewHandoff(for update: AvailableUpdate) -> Bool {
+        guard let install = BrewCask.installedCask(
+            bundleURL: Bundle.main.bundleURL,
+            caskroomBases: [
+                URL(fileURLWithPath: "/opt/homebrew/Caskroom"),
+                URL(fileURLWithPath: "/usr/local/Caskroom"),
+            ]
+        ) else { return false }
+
+        guard BrewCask.canDeliver(cask: install.cask, isPrerelease: update.isPrerelease) else {
+            failBrewHandoff(
+                code: "brew_channel_mismatch",
+                message: "Beta builds ship in the \(BrewCask.betaCask) cask. Run `brew install --cask \(BrewCask.betaCask)` to switch."
+            )
+            return true
+        }
+        Task { await installViaBrew(install: install, update: update) }
+        return true
+    }
+
+    private func installViaBrew(install: BrewCaskInstall, update: AvailableUpdate) async {
+        let cask = install.cask
+        let manually = "Update with `brew upgrade --cask \(cask)`."
+        guard let status = await BrewCask.runUpgrade(install) else {
+            failBrewHandoff(code: "brew_missing", message: "Couldn't run \(install.brewBinary). \(manually)")
+            return
+        }
+
+        guard status == 0, BrewCask.handoffSucceeded(
+            appURL: UpdateInstaller.installedAppURL(),
+            expectedVersion: update.version
+        ) else {
+            failBrewHandoff(code: "brew_handoff_failed", message: "brew finished but Toki wasn't updated. \(manually)", detail: "exit=\(status)")
+            return
+        }
+
+        guard relaunchAfterBrewUpgrade() else {
+            // The upgrade landed but relaunching failed; keep the app up rather than
+            // close it, and tell the user how to get the new build running.
+            installError = "Toki was updated but couldn't relaunch. Reopen Toki to finish."
+            isInstalling = false
+            return
+        }
+        NSApp.terminate(nil)
+    }
+
+    private func failBrewHandoff(code: String, message: String, detail: String? = nil) {
+        DiagnosticLogger.shared.record(.error, component: "updater", code: code, detail: detail ?? message)
+        installError = message
+        isInstalling = false
+    }
+
+    /// Reopens the app after a successful handoff. Brew replaced the bundle but has no
+    /// quit/reopen artifact for these casks, so without this the upgrade closes Toki.
+    ///
+    /// The open runs from a detached child that waits for this process to die first:
+    /// `open` fired immediately would target the still-running instance via
+    /// LaunchServices, and after termination no replacement would be left.
+    private func relaunchAfterBrewUpgrade() -> Bool {
+        guard let executable = Bundle.main.executableURL else { return false }
+        let process = Process()
+        process.executableURL = executable
+        process.arguments = ["--brew-relaunch", UpdateInstaller.installedAppURL().path, String(ProcessInfo.processInfo.processIdentifier)]
+        do {
+            try process.run()
+            return true
+        } catch {
+            DiagnosticLogger.shared.record(.error, component: "updater", code: "brew_relaunch_failed", detail: diagnosticErrorDetail(error))
+            return false
+        }
+    }
+
+    static func runRelaunchHelperIfRequested(arguments: [String]) -> Bool {
+        guard arguments.count == 4, arguments[1] == "--brew-relaunch" else { return false }
+        let appPath = arguments[2]
+        // Fail safe: a malformed PID means continue normal startup, not exit the app.
+        guard let parentPID = Int32(arguments[3]) else { return false }
+        while kill(parentPID, 0) == 0 {
+            Thread.sleep(forTimeInterval: 0.2)
+        }
+        let open = Process()
+        open.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        open.arguments = [appPath]
+        do {
+            try open.run()
+        } catch {
+            DiagnosticLogger.shared.record(.error, component: "updater", code: "brew_relaunch_failed", detail: diagnosticErrorDetail(error))
+        }
+        return true
     }
 
     private func runCheck(isManual: Bool = false) {

--- a/Sources/Toki/Updates/UpdateChecker.swift
+++ b/Sources/Toki/Updates/UpdateChecker.swift
@@ -131,8 +131,7 @@ final class UpdateChecker: ObservableObject {
         caskSwitchError = nil
 
         // A brew install follows its cask, not this preference, so the picker has to move
-        // the install too or the two silently disagree. Non-brew copies just switch which
-        // releases they are offered.
+        // the install too or the two silently disagree.
         let target = BrewCask.cask(for: newChannel)
         guard let install = brewInstall(), install.cask != target else {
             checkNow()
@@ -142,12 +141,11 @@ final class UpdateChecker: ObservableObject {
         Task { await performCaskSwitch(install: install, target: target) }
     }
 
-    /// A cask swap run from the command line has to move the app's channel with it, the
-    /// same way the picker moves the cask. The cask is the authority here: it decides
-    /// which releases brew will actually install, so the preference follows it.
+    /// The reverse of `setChannel`: a cask swapped with brew directly moves the preference
+    /// with it. The cask is the authority, since it decides what brew will install.
     private func adoptChannelOfInstalledCask() {
         guard !isSwitchingCask, let install = brewInstall() else { return }
-        let owned: UpdateChannel = install.cask == BrewCask.betaCask ? .beta : .stable
+        let owned = BrewCask.channel(for: install.cask)
         guard owned != channel else { return }
         storeChannel(owned)
         availableUpdate = nil
@@ -184,15 +182,15 @@ final class UpdateChecker: ObservableObject {
         NSApp.terminate(nil)
     }
 
-    /// The uninstall runs before the install, so a failure can leave no app on disk at
-    /// all. Reinstalling the cask that was there is the only way back; the preference
-    /// goes back with it so the picker keeps describing what is actually installed.
+    /// The uninstall runs before the install, so a failure can leave no app on disk at all.
+    /// Reinstalling what was there is the only way back, and the preference follows it so
+    /// the picker keeps describing what is installed.
     private func recoverFromFailedCaskSwitch(install: BrewCaskInstall, target: String) async {
         let restored = await BrewCask.run(["install", "--cask", install.cask], brewBinary: install.brewBinary) == 0
         DiagnosticLogger.shared.record(
             .error, component: "updater", code: "cask_switch_failed", detail: "to=\(target) restored=\(restored)"
         )
-        storeChannel(install.cask == BrewCask.betaCask ? .beta : .stable)
+        storeChannel(BrewCask.channel(for: install.cask))
         isSwitchingCask = false
         caskSwitchError = restored
             ? "Couldn't switch to the \(target) cask, so nothing changed."
@@ -262,12 +260,8 @@ final class UpdateChecker: ObservableObject {
 
     /// A cask-installed copy must be upgraded by brew, not swapped underneath it: the DMG
     /// path would desync brew's receipt and the next `brew upgrade` would clobber this
-    /// newer build with the cask's older one. The installed cask wins over the channel
-    /// preference - upgrading a different cask than the one that owns this bundle would
-    /// either fail on the conflict or leave the receipt stale.
-    ///
-    /// Returns true once the install belongs to brew - handed over or refused - so the
-    /// DMG path does not also run.
+    /// newer build with the cask's older one. Returns true once the install belongs to brew
+    /// - handed over or refused - so the DMG path does not also run.
     private func startBrewHandoff(for update: AvailableUpdate) -> Bool {
         guard let install = brewInstall() else { return false }
 
@@ -314,14 +308,11 @@ final class UpdateChecker: ObservableObject {
         isInstalling = false
     }
 
-    /// Reopens the app after brew replaced the bundle. Brew has no quit/reopen artifact
-    /// for these casks, so without this an upgrade or a cask switch just closes Toki.
-    ///
-    /// The waiter is `/bin/sh` rather than Toki's own binary: a channel switch can install
-    /// an older build, which need not understand a private relaunch flag. It also has to
-    /// outlive this process before acting - `open` fired while the app is still running
-    /// would be routed to this instance by LaunchServices, and after termination nothing
-    /// would be left to reopen.
+    /// Reopens the app after brew replaced the bundle; these casks have no quit/reopen
+    /// stanza, so an upgrade or switch would otherwise just close Toki. The waiter is
+    /// `/bin/sh`, not Toki's own binary, because a channel switch can install an older
+    /// build that need not understand a private flag. It has to outlive this process:
+    /// `open` fired any earlier is routed back to the running instance.
     private func relaunchAfterBrewChange() -> Bool {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/sh")

--- a/Sources/Toki/Updates/UpdateInstaller.swift
+++ b/Sources/Toki/Updates/UpdateInstaller.swift
@@ -117,7 +117,7 @@ enum UpdateInstaller {
         return true
     }
 
-    private static func installedAppURL() -> URL {
+    static func installedAppURL() -> URL {
         let bundleURL = Bundle.main.bundleURL
         if bundleURL.pathExtension == "app" {
             return bundleURL

--- a/Sources/Toki/Views/SettingsPanel.swift
+++ b/Sources/Toki/Views/SettingsPanel.swift
@@ -60,6 +60,20 @@ struct SettingsPanel: View {
     @State private var showingConnect = false
     @State private var advancedExpanded = false
     @State private var showingTailscaleGuide = false
+
+    // A brew install is moved onto the other cask when the channel changes, which takes
+    // long enough that the card has to say so rather than look inert.
+    private var channelSubtitle: String {
+        if updateChecker.isSwitchingCask {
+            return "Moving your Homebrew install to the other cask…"
+        }
+        if let error = updateChecker.caskSwitchError {
+            return error
+        }
+        return updateChecker.channel == .beta
+            ? "Includes pre-releases for early testing."
+            : "Stable releases only."
+    }
     private let reachabilityTimer = Timer.publish(every: 5, on: .main, in: .common).autoconnect()
 
     var body: some View {
@@ -320,9 +334,7 @@ struct SettingsPanel: View {
                         icon: "hammer",
                         iconColor: .orange,
                         title: "Channel",
-                        subtitle: updateChecker.channel == .beta
-                            ? "Includes pre-releases for early testing."
-                            : "Stable releases only."
+                        subtitle: channelSubtitle
                     )
                     Spacer(minLength: 8)
                     Picker("Update channel", selection: Binding(
@@ -337,6 +349,7 @@ struct SettingsPanel: View {
                     .labelsHidden()
                     .controlSize(.small)
                     .fixedSize()
+                    .disabled(updateChecker.isSwitchingCask)
                     .pointerOnHover()
                 }
                 .padding(8)

--- a/Sources/Toki/main.swift
+++ b/Sources/Toki/main.swift
@@ -4,6 +4,10 @@ if UpdateInstaller.runHelperIfRequested(arguments: CommandLine.arguments) {
     exit(EXIT_SUCCESS)
 }
 
+if UpdateChecker.runRelaunchHelperIfRequested(arguments: CommandLine.arguments) {
+    exit(EXIT_SUCCESS)
+}
+
 let app = NSApplication.shared
 let delegate = AppDelegate()
 app.delegate = delegate

--- a/Sources/Toki/main.swift
+++ b/Sources/Toki/main.swift
@@ -4,10 +4,6 @@ if UpdateInstaller.runHelperIfRequested(arguments: CommandLine.arguments) {
     exit(EXIT_SUCCESS)
 }
 
-if UpdateChecker.runRelaunchHelperIfRequested(arguments: CommandLine.arguments) {
-    exit(EXIT_SUCCESS)
-}
-
 let app = NSApplication.shared
 let delegate = AppDelegate()
 app.delegate = delegate

--- a/Tests/TokiTests/BrewCaskTests.swift
+++ b/Tests/TokiTests/BrewCaskTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import Toki
+
+final class BrewCaskTests: XCTestCase {
+    private var tempCaskroom: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempCaskroom = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BrewCaskTests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempCaskroom, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempCaskroom)
+        super.tearDown()
+    }
+
+    func testDetectsInstalledCaskAndPrefix() throws {
+        // The real layout: the cask's symlink points from the Caskroom to the installed
+        // app, which lives somewhere else entirely.
+        let appDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BrewCaskTests-apps-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: appDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: appDir) }
+        let bundle = appDir.appendingPathComponent("Toki.app")
+        try FileManager.default.createDirectory(at: bundle, withIntermediateDirectories: true)
+        let versionDir = tempCaskroom.appendingPathComponent("toki-beta").appendingPathComponent("2.7.0")
+        try FileManager.default.createDirectory(at: versionDir, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            at: versionDir.appendingPathComponent("Toki.app"),
+            withDestinationURL: URL(fileURLWithPath: bundle.path)
+        )
+
+        let install = BrewCask.installedCask(
+            bundleURL: bundle,
+            caskroomBases: [tempCaskroom]
+        )
+        XCTAssertEqual(install?.cask, "toki-beta")
+        XCTAssertEqual(install?.brewPrefix, tempCaskroom.deletingLastPathComponent().path)
+        XCTAssertNil(BrewCask.installedCask(
+            bundleURL: URL(fileURLWithPath: "/Applications/Toki.app"),
+            caskroomBases: [tempCaskroom]
+        ))
+    }
+
+    func testHandoffReadsVersionAfterTheBundleIsReplacedInPlace() throws {
+        // Foundation caches a Bundle per path, so reading through `Bundle(url:)` would
+        // still report the version from before brew swapped the app.
+        let app = tempCaskroom.appendingPathComponent("Toki.app")
+        try FileManager.default.createDirectory(
+            at: app.appendingPathComponent("Contents"), withIntermediateDirectories: true
+        )
+        func writeInfoPlist(release: String) throws {
+            let data = try PropertyListSerialization.data(
+                fromPropertyList: ["TokiReleaseVersion": release], format: .xml, options: 0
+            )
+            try data.write(to: app.appendingPathComponent("Contents/Info.plist"))
+        }
+
+        try writeInfoPlist(release: "2.5.0-beta.1")
+        XCTAssertFalse(BrewCask.handoffSucceeded(appURL: app, expectedVersion: "2.5.0-beta.2"))
+        try writeInfoPlist(release: "2.5.0-beta.2")
+        XCTAssertTrue(BrewCask.handoffSucceeded(appURL: app, expectedVersion: "2.5.0-beta.2"))
+    }
+
+    func testHandoffPostconditionDistinguishesBetaIterations() {
+        XCTAssertTrue(BrewCask.handoffSucceeded(
+            bundleVersion: "2.5.0-beta.2", marketingVersion: "2.5.0", expectedVersion: "2.5.0-beta.2"
+        ))
+        XCTAssertFalse(BrewCask.handoffSucceeded(
+            bundleVersion: "2.5.0-beta.1", marketingVersion: "2.5.0", expectedVersion: "2.5.0-beta.2"
+        ))
+        // Without a release stamp a beta iteration is indistinguishable from its
+        // siblings, so only an exact stable match may pass.
+        XCTAssertFalse(BrewCask.handoffSucceeded(
+            bundleVersion: nil, marketingVersion: "2.5.0", expectedVersion: "2.5.0-beta.1"
+        ))
+        XCTAssertTrue(BrewCask.handoffSucceeded(
+            bundleVersion: nil, marketingVersion: "2.5.0", expectedVersion: "2.5.0"
+        ))
+        XCTAssertFalse(BrewCask.handoffSucceeded(
+            bundleVersion: nil, marketingVersion: "2.4.4", expectedVersion: "2.5.0"
+        ))
+        XCTAssertFalse(BrewCask.handoffSucceeded(
+            bundleVersion: nil, marketingVersion: nil, expectedVersion: "2.5.0"
+        ))
+    }
+}

--- a/Tests/TokiTests/BrewCaskTests.swift
+++ b/Tests/TokiTests/BrewCaskTests.swift
@@ -75,8 +75,6 @@ final class BrewCaskTests: XCTestCase {
                 ["install", "--cask", "toki-beta"],
             ]
         )
-        XCTAssertEqual(BrewCask.cask(for: .beta), "toki-beta")
-        XCTAssertEqual(BrewCask.cask(for: .stable), "toki")
     }
 
     func testHandoffPostconditionDistinguishesBetaIterations() {
@@ -93,12 +91,6 @@ final class BrewCaskTests: XCTestCase {
         ))
         XCTAssertTrue(BrewCask.handoffSucceeded(
             bundleVersion: nil, marketingVersion: "2.5.0", expectedVersion: "2.5.0"
-        ))
-        XCTAssertFalse(BrewCask.handoffSucceeded(
-            bundleVersion: nil, marketingVersion: "2.4.4", expectedVersion: "2.5.0"
-        ))
-        XCTAssertFalse(BrewCask.handoffSucceeded(
-            bundleVersion: nil, marketingVersion: nil, expectedVersion: "2.5.0"
         ))
     }
 }

--- a/Tests/TokiTests/BrewCaskTests.swift
+++ b/Tests/TokiTests/BrewCaskTests.swift
@@ -64,6 +64,21 @@ final class BrewCaskTests: XCTestCase {
         XCTAssertTrue(BrewCask.handoffSucceeded(appURL: app, expectedVersion: "2.5.0-beta.2"))
     }
 
+    func testSwitchingCasksUninstallsOnlyAfterTheDownloadIsCached() {
+        // The uninstall deletes the running bundle, so a fetch that fails must fail before
+        // anything is removed.
+        XCTAssertEqual(
+            BrewCask.switchCommands(from: BrewCask.stableCask, to: BrewCask.betaCask),
+            [
+                ["fetch", "--cask", "toki-beta"],
+                ["uninstall", "--cask", "toki"],
+                ["install", "--cask", "toki-beta"],
+            ]
+        )
+        XCTAssertEqual(BrewCask.cask(for: .beta), "toki-beta")
+        XCTAssertEqual(BrewCask.cask(for: .stable), "toki")
+    }
+
     func testHandoffPostconditionDistinguishesBetaIterations() {
         XCTAssertTrue(BrewCask.handoffSucceeded(
             bundleVersion: "2.5.0-beta.2", marketingVersion: "2.5.0", expectedVersion: "2.5.0-beta.2"

--- a/docs/development.md
+++ b/docs/development.md
@@ -63,6 +63,8 @@ Two casks live in the tap (`aashutoshrathi/homebrew-tap`): `toki` (stable) and `
 
 When Toki was installed by a cask, the in-app updater detects it (`BrewCask.installedCask` — the Caskroom entry is a symlink to the installed bundle) and routes "Install update" through `brew upgrade --cask <toki|toki-beta>` instead of swapping the DMG underneath brew. This keeps brew's receipt in sync with the app on disk; the DMG path would desync it, and the next `brew upgrade` would then clobber the newer build with the cask's older one. Dev builds and manual installs keep the direct DMG path.
 
+The channel picker and the installed cask are kept in agreement in both directions. Picking a channel moves a brew install onto the matching cask (`fetch`, then `uninstall`, then `install` — `conflicts_with` rules out installing over the top, and fetching first means a network failure cannot strand the uninstall with nothing to reinstall). Swapping casks with brew directly moves the channel instead: the cask decides what brew will install, so the preference follows it on the next check. A failed switch reinstalls the cask that was there and puts the preference back.
+
 ## Concurrency checking
 
 CI builds with stricter concurrency than a plain `swift build`, and the difference has broken this project's CI more than once — a pure static helper on a `@MainActor` type needs `nonisolated`, which only the stricter mode catches. Reproduce it locally before pushing:
@@ -87,4 +89,4 @@ Comments should explain what the code cannot: why a timeout is the value it is, 
 - **Switch fails** — run `claude-swap --switch-to <slot>` in Terminal to see the underlying error.
 - **No notifications** — check the Events tab for DND or cooldown suppression, then confirm macOS notification permission.
 - **`brew finished but Toki wasn't updated`** — the tap may be stale; run `brew update && brew upgrade --cask toki` (or `toki-beta`) manually and check the tap has the version the app offered.
-- **`Beta builds ship in the toki-beta cask`** — the Beta channel is on but brew installed the stable `toki` cask, which never carries a prerelease; `brew install --cask toki-beta` switches (it replaces `toki`).
+- **`Beta builds ship in the toki-beta cask`** — the Beta channel is on but brew installed the stable `toki` cask, which never carries a prerelease. Re-pick the channel in Settings to move the install; by hand it is `brew uninstall --cask toki && brew install --cask toki-beta`, since `conflicts_with` makes a bare install refuse.

--- a/docs/development.md
+++ b/docs/development.md
@@ -43,17 +43,25 @@ When a widget looks wrong:
 
 Every release starts from a tag push; `.github/workflows/release.yml` builds the DMG and publishes the GitHub release. The tag decides the channel:
 
-- **Stable** — tag `vX.Y.Z` (e.g. `v2.5.0`). Published as a full GitHub release, offered to everyone, and the Homebrew cask is updated.
-- **Beta** — tag with a prerelease suffix (e.g. `v2.5.0-beta.1`). Published as a GitHub prerelease, offered only to users who picked the Beta channel in Settings > Updates. The Homebrew cask is not touched.
+- **Stable** — tag `vX.Y.Z` (e.g. `v2.5.0`). Published as a full GitHub release, offered to everyone, and both Homebrew casks are updated (`toki` and `toki-beta`).
+- **Beta** — tag with a prerelease suffix (e.g. `v2.5.0-beta.1`). Published as a GitHub prerelease, offered only to users who picked the Beta channel in Settings > Updates, and the `toki-beta` cask is updated. The stable cask is not touched.
 
-Set `appVersion` in `Sources/Toki/Config/Constants.swift` to match the tag (without the `v`) before tagging — the packaging script, the in-app updater's version check, and the DMG verification all read it.
+Set `appVersion` in `Sources/Toki/Config/Constants.swift` to match the tag's base version (without the `v` and without any prerelease suffix) before tagging — the packaging script, the in-app updater's version check, and the DMG verification all read it. `CFBundleShortVersionString` must stay dotted-numeric; the prerelease identity travels in the tag, which the release workflow stamps into `TokiReleaseVersion` in Info.plist. The DMG filename is built from the base version (`Toki_2.5.0_universal.dmg`) even for a beta tag.
 
 To graduate a beta to production:
 
-1. Tag `v2.5.0-beta.1` (with `appVersion = "2.5.0-beta.1"`) and test on the Beta channel. Iterate with `-beta.2`, `-beta.3`, … as needed.
-2. When it's ready, set `appVersion = "2.5.0"` and tag `v2.5.0`. That build ships to everyone: stable users see it as a normal update, and beta users are offered it too, because `2.5.0` outranks `2.5.0-beta.N` — so testers land back on the production build without touching their channel setting.
+1. Tag `v2.5.0-beta.1` (with `appVersion = "2.5.0"`) and test on the Beta channel. Iterate with `-beta.2`, `-beta.3`, … as needed.
+2. When it's ready, set `appVersion = "2.5.0"` and tag `v2.5.0`. That build ships to everyone: stable users see it as a normal update, and beta users are offered it too, because `2.5.0` outranks `2.5.0-beta.N` — so testers land back on the production build without touching their channel setting. The same graduation happens for brew: the stable tag bumps both casks, so `brew upgrade` carries `toki-beta` users onto the stable build.
 
-Version ordering is semver-aware (`2.4.3` < `2.5.0-beta.1` < `2.5.0-beta.2` < `2.5.0`); the logic and its tests live in `UpdateChecker.compareVersions` and `Tests/TokiTests/UpdateChannelTests.swift`.
+Version ordering is semver-aware (`2.4.3` < `2.5.0-beta.1` < `2.5.0-beta.2` < `2.5.0`); the logic and its tests live in `UpdateChecker.compareVersions` and `Tests/TokiTests/UpdateChannelTests.swift`. Homebrew's own ordering agrees, which is what makes the single `toki-beta` cask work across iterations and graduation.
+
+## Homebrew
+
+Two casks live in the tap (`aashutoshrathi/homebrew-tap`): `toki` (stable) and `toki-beta` (prereleases). They conflict with each other — install one.
+
+`scripts/update-cask.sh <cask.rb> [version]` rewrites a cask's version and DMG sha256. The version argument defaults to `appVersion`; prerelease tags must pass the full version (e.g. `3.2.0-beta.1`) because it exists only in the tag. The DMG filename always carries the base version (`Toki_3.2.0_universal.dmg`), which the script and the cask's URL handle.
+
+When Toki was installed by a cask, the in-app updater detects it (`BrewCask.installedCask` — the Caskroom entry is a symlink to the installed bundle) and routes "Install update" through `brew upgrade --cask <toki|toki-beta>` instead of swapping the DMG underneath brew. This keeps brew's receipt in sync with the app on disk; the DMG path would desync it, and the next `brew upgrade` would then clobber the newer build with the cask's older one. Dev builds and manual installs keep the direct DMG path.
 
 ## Concurrency checking
 
@@ -78,3 +86,5 @@ Comments should explain what the code cannot: why a timeout is the value it is, 
 - **Pi missing** — confirm its session directory has JSONL history and any override path is absolute, exactly `~`, or starts with `~/`.
 - **Switch fails** — run `claude-swap --switch-to <slot>` in Terminal to see the underlying error.
 - **No notifications** — check the Events tab for DND or cooldown suppression, then confirm macOS notification permission.
+- **`brew finished but Toki wasn't updated`** — the tap may be stale; run `brew update && brew upgrade --cask toki` (or `toki-beta`) manually and check the tap has the version the app offered.
+- **`Beta builds ship in the toki-beta cask`** — the Beta channel is on but brew installed the stable `toki` cask, which never carries a prerelease; `brew install --cask toki-beta` switches (it replaces `toki`).

--- a/homebrew/toki-beta.rb
+++ b/homebrew/toki-beta.rb
@@ -1,0 +1,49 @@
+# Homebrew Cask for Toki (beta channel).
+#
+# This file belongs in a tap repo (aashutoshrathi/homebrew-tap) under Casks/toki-beta.rb.
+# scripts/update-cask.sh regenerates the version + sha256 after each release; prerelease
+# tags must pass their full version explicitly (e.g. 2.5.0-beta.1).
+#
+# The beta cask tracks GitHub prereleases. A stable tag bumps this cask too, so a beta
+# user is carried onto the graduated stable build by a plain `brew upgrade` - brew's
+# version ordering already ranks 2.5.0 above 2.5.0-beta.N.
+cask "toki-beta" do
+  version "2.1.4-beta"
+  # update-cask.sh replaces this after each release
+  sha256 "PLACEHOLDER_SHA256"
+
+  # Prerelease tags publish the same universal DMG as stable; the filename carries the
+  # base version, so the download URL combines the full tag with the base-version name.
+  url "https://github.com/aashutoshrathi/toki/releases/download/v#{version}/Toki_#{version.split('-').first}_universal.dmg"
+  name "Toki (Beta)"
+  desc "Menu bar companion for AI coding agents and usage (beta channel)"
+  homepage "https://github.com/aashutoshrathi/toki"
+
+  depends_on macos: :sonoma
+
+  app "Toki.app"
+
+  conflicts_with cask: "toki"
+
+  # The release DMG is ad-hoc signed and not notarized, so Gatekeeper quarantines it.
+  # Strip the quarantine flag on install so the app opens without a right-click-Open.
+  postflight do
+    system_command "/usr/bin/xattr",
+                   args: ["-dr", "com.apple.quarantine", "#{appdir}/Toki.app"],
+                   sudo: false
+  end
+
+  zap trash: [
+    "~/.tokenbar",
+    "~/.toki",
+  ]
+
+  caveats <<~EOS
+    Toki (beta) tracks prerelease builds and conflicts with the stable `toki` cask;
+    install only one. The app is ad-hoc signed and not notarized. If macOS still blocks
+    it, open it once with:
+      Right-click Toki in Applications > Open
+    or clear quarantine manually:
+      xattr -dr com.apple.quarantine /Applications/Toki.app
+  EOS
+end

--- a/homebrew/toki.rb
+++ b/homebrew/toki.rb
@@ -16,6 +16,10 @@ cask "toki" do
 
   app "Toki.app"
 
+  # Homebrew checks the incoming cask's declarations, so both sides must declare the
+  # conflict for the mutual exclusion to hold in both install directions.
+  conflicts_with cask: "toki-beta"
+
   # The release DMG is ad-hoc signed and not notarized, so Gatekeeper quarantines it.
   # Strip the quarantine flag on install so the app opens without a right-click-Open.
   postflight do

--- a/scripts/update-cask.sh
+++ b/scripts/update-cask.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
-# Regenerates a Toki cask file with the current version and the sha256 of the published
-# release DMG. Run after a release DMG is available on GitHub. Pass the cask path as the
-# first argument to update a tap checkout directly (default: the in-repo template).
+# Regenerates a Toki cask file with a version and the sha256 of the published release DMG.
+# Run after a release DMG is available on GitHub. Pass the cask path as the first argument
+# to update a tap checkout directly (default: the in-repo template).
+#
+# The second argument is the cask version. It defaults to appVersion from Constants.swift,
+# which is all a stable release needs. A prerelease tag (v2.5.0-beta.1) must pass it
+# explicitly, because the tag exists only in git - and the DMG filename carries the base
+# version (Toki_2.5.0_universal.dmg), so the URL combines the full tag with the base name.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-VERSION=$(grep '^let appVersion' "$ROOT_DIR/Sources/Toki/Config/Constants.swift" | sed 's/.*"\(.*\)"/\1/')
-DMG_URL="https://github.com/aashutoshrathi/toki/releases/download/v${VERSION}/Toki_${VERSION}_universal.dmg"
 CASK="${1:-$ROOT_DIR/homebrew/toki.rb}"
+VERSION="${2:-$(grep '^let appVersion' "$ROOT_DIR/Sources/Toki/Config/Constants.swift" | sed 's/.*"\(.*\)"/\1/')}"
+APP_VERSION="${VERSION%%-*}"
+DMG_URL="https://github.com/aashutoshrathi/toki/releases/download/v${VERSION}/Toki_${APP_VERSION}_universal.dmg"
 
 echo "==> Fetching $DMG_URL"
 TMP_DMG="$(mktemp -t toki-dmg).dmg"


### PR DESCRIPTION
## The bug

`brew install --cask toki` leaves brew holding a receipt and a Caskroom symlink pointing at `/Applications/Toki.app`. The in-app updater replaced that bundle in place, so the app on disk moved ahead of what brew believed was installed — and the next `brew upgrade` helpfully downgraded the user back to the cask's version, silently undoing the update.

Separately, beta testers had no brew path at all: a prerelease tag never touched the tap.

## What this does

**Hands the install to brew when a cask owns the app.** The Caskroom entry is a symlink pointing *at* the app, so the cask side is the only side that can see the relationship — resolving the bundle path alone can never find an inbound symlink. `BrewCask.installedCask` enumerates `Caskroom/<cask>/*/Toki.app` under both prefixes (Intel brew lives in `/usr/local`) and resolves each, which also keeps detection independent of `--appdir`. When a cask owns the bundle, "Install update" runs `brew upgrade --cask <toki|toki-beta>` and brew updates its own receipt. Dev builds and manual DMG installs keep the direct path.

**Adds a `toki-beta` cask** tracking GitHub prereleases, conflicting with `toki`. Stable tags bump both, so a plain `brew upgrade` carries testers onto a graduated release. That works because brew's own version ordering ranks `2.5.0` above `2.5.0-beta.N` — verified against brew's `Version` class rather than assumed:

```
2.5.0 > 2.5.0-beta.2         : true
2.5.0-beta.10 > 2.5.0-beta.2 : true
3.3.0-beta.1 > 3.2.0         : true
```

**Keeps the channel picker and the installed cask in agreement, both ways.** Picking a channel moves a brew install onto the matching cask; swapping the cask with brew directly moves the channel instead, on the next check. The cask is the authority, since it decides what brew will actually install.

The switch is `fetch` → `uninstall` → `install`. `conflicts_with` rules out installing over the top (`cask/installer.rb` raises `CaskConflictError`), and forcing past it would leave two receipts owning one bundle — the exact desync this PR exists to prevent. The fetch comes first because the uninstall deletes the bundle the running process lives in: without a cached download, a network failure there would leave no app on disk. If a step fails, the original cask is reinstalled and the preference goes back with it.

## Review findings addressed

- **The postcondition read a cached Info dictionary.** `Bundle(url:)` returns the already-loaded `Bundle` for a path Foundation has seen — always true of the running app — so after brew swapped the bundle the check still saw the *old* version. Every successful upgrade would have been reported as a failure, with the relaunch never firing and the old process left running against a new build on disk. Confirmed empirically (same instance returned, stale value; direct plist read sees the replacement) and fixed by parsing `Contents/Info.plist` off disk. A test rewrites the plist at the same path and asserts the new value is observed.
- **A dead-end loop for a stable-cask user on the Beta channel.** The offered prerelease ran `brew upgrade --cask toki`, which can never deliver it: brew exits 0 having done nothing, the postcondition fails, and the user is told to run a command that will never work. Now refused up front, and the picker moves the install instead.
- **"Couldn't launch brew" was reported as "brew ran and failed."** `BrewCask.run` returns `Int32?`, with `nil` meaning brew was never launched; that case names the binary path it tried.
- **The relaunch waiter no longer depends on the installed binary.** It used Toki's own binary with a private `--brew-relaunch` flag, which a channel switch can replace with an *older* build that doesn't understand it. It's now a `/bin/sh` waiter polling the PID, with the path passed as `argv`. That deletes the `main.swift` hook entirely.
- **Unreachable fast path removed.** The `app` stanza moves the bundle out of the Caskroom, so an app can never run from inside it — verified against a real Caskroom.

## Testing

467 tests pass; build clean. Homebrew ordering verified against brew's own Ruby; Bundle-caching behavior verified with a standalone binary. Every function added measures under CC 10.

The brew handoff itself can only be exercised end-to-end once a cask install of a build containing this code exists in the tap — the command sequences and ordering are unit-tested, the execution is not.

## Known follow-up, not in this PR

**Beta cask publishing is not monotonic.** The workflow rewrites `toki-beta.rb` unconditionally, so a late-pushed old tag or a rerun of an older release job would regress the cask to a stale prerelease. It needs a version comparison plus a `concurrency:` block on the job.

https://claude.ai/code/session_014WgTPCLATph5CqyKUk1x1E