### PR TITLE
Say when the provider is the one that is down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- **An outage indicator on the provider cards.** A coloured dot on the account logo when a provider's own status page reports an outage or degraded service, and a line in the opened card naming what is down, with a link to the page. Claude, Codex, Copilot, and Cursor are covered, checked at most every five minutes and only for the providers you actually use, and each change is recorded in Events.
+
 ## 3.2.0 - 2026-09-03
 
 ### Added

--- a/Sources/Toki/API/ServiceStatusClient.swift
+++ b/Sources/Toki/API/ServiceStatusClient.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Reads provider health off the public Statuspage instances the providers already publish.
+///
+/// These endpoints are unauthenticated and identical in shape across every page Toki reads, so
+/// one parser covers all of them and a new provider is a table entry in `ServiceStatusSource`.
+enum ServiceStatusClient {
+    static func fetch(sources: [ServiceStatusSource], checkedAt: Date = Date()) async -> [Provider: ServiceStatus] {
+        await withTaskGroup(of: [Provider: ServiceStatus].self) { group in
+            for source in sources {
+                group.addTask { await fetch(source: source, checkedAt: checkedAt) }
+            }
+            var merged: [Provider: ServiceStatus] = [:]
+            for await statuses in group {
+                merged.merge(statuses) { _, latest in latest }
+            }
+            return merged
+        }
+    }
+
+    static func fetch(source: ServiceStatusSource, checkedAt: Date = Date()) async -> [Provider: ServiceStatus] {
+        do {
+            let payload = try await requestJSON(url: source.summaryURL, headers: ["Accept": "application/json"])
+            return parse(summary: payload, source: source, checkedAt: checkedAt)
+        } catch {
+            DiagnosticLogger.shared.record(
+                .warning,
+                component: "service_status",
+                code: "fetch_failed",
+                detail: "\(source.id): \(error.localizedDescription)"
+            )
+            return [:]
+        }
+    }
+
+    static func parse(summary: Any, source: ServiceStatusSource, checkedAt: Date) -> [Provider: ServiceStatus] {
+        guard let root = summary as? [String: Any] else { return [:] }
+        let page = root["status"] as? [String: Any]
+        let pageDescription = (page?["description"] as? String) ?? ""
+        let pageLevel = (page?["indicator"] as? String).flatMap(ServiceStatusLevel.init(pageIndicator:))
+        let components = (root["components"] as? [[String: Any]]) ?? []
+
+        var statuses: [Provider: ServiceStatus] = [:]
+        for (provider, prefixes) in source.componentPrefixes {
+            let matched = components.compactMap { component -> (name: String, level: ServiceStatusLevel)? in
+                guard let name = component["name"] as? String,
+                      matches(name: name, prefixes: prefixes),
+                      let status = component["status"] as? String,
+                      let level = ServiceStatusLevel(componentStatus: status) else { return nil }
+                return (name, level)
+            }
+
+            let level: ServiceStatusLevel
+            var affected: [String] = []
+            if let worst = matched.map(\.level).max() {
+                level = worst
+                affected = matched
+                    .filter { $0.level.isDisrupted }
+                    .sorted { $0.level > $1.level }
+                    .map(\.name)
+            } else if let pageLevel {
+                // No component of this provider's own on the page (or none Toki understands):
+                // the whole-page roll-up is the only signal, and it is better than nothing.
+                level = pageLevel
+            } else {
+                continue
+            }
+
+            statuses[provider] = ServiceStatus(
+                provider: provider,
+                level: level,
+                pageDescription: pageDescription.isEmpty ? level.label : pageDescription,
+                affectedComponents: affected,
+                pageURL: source.pageURL,
+                checkedAt: checkedAt
+            )
+        }
+        return statuses
+    }
+
+    private static func matches(name: String, prefixes: [String]) -> Bool {
+        guard !prefixes.isEmpty else { return false }
+        let normalized = name.lowercased()
+        return prefixes.contains { normalized.hasPrefix($0) }
+    }
+}

--- a/Sources/Toki/Models/ServiceStatus.swift
+++ b/Sources/Toki/Models/ServiceStatus.swift
@@ -1,0 +1,166 @@
+import Foundation
+
+/// How healthy a provider's own service is, independent of whether Toki can read its usage.
+///
+/// The cases are the five component states a Statuspage exposes, collapsed to what a user needs
+/// to decide whether to keep working: everything is fine, it is slow, part of it is down, or it
+/// is down. `severity` is the ordering used to pick one level for a provider whose service spans
+/// several components.
+enum ServiceStatusLevel: String, Sendable, Hashable, Comparable {
+    case operational
+    case maintenance
+    case degraded
+    case partialOutage
+    case majorOutage
+
+    /// Statuspage's per-component state, e.g. `"degraded_performance"`.
+    init?(componentStatus: String) {
+        switch componentStatus {
+        case "operational": self = .operational
+        case "under_maintenance": self = .maintenance
+        case "degraded_performance": self = .degraded
+        case "partial_outage": self = .partialOutage
+        case "major_outage": self = .majorOutage
+        default: return nil
+        }
+    }
+
+    /// Statuspage's whole-page roll-up, e.g. `"minor"`. Used for a provider the page does not
+    /// break out into a component of its own.
+    init?(pageIndicator: String) {
+        switch pageIndicator {
+        case "none": self = .operational
+        case "maintenance": self = .maintenance
+        case "minor": self = .degraded
+        case "major": self = .partialOutage
+        case "critical": self = .majorOutage
+        default: return nil
+        }
+    }
+
+    /// Maintenance sorts below degraded: it is planned, so a real fault reported by any other
+    /// component of the same provider is the one worth surfacing.
+    var severity: Int {
+        switch self {
+        case .operational: return 0
+        case .maintenance: return 1
+        case .degraded: return 2
+        case .partialOutage: return 3
+        case .majorOutage: return 4
+        }
+    }
+
+    static func < (lhs: ServiceStatusLevel, rhs: ServiceStatusLevel) -> Bool {
+        lhs.severity < rhs.severity
+    }
+
+    var isDisrupted: Bool { self != .operational }
+
+    var label: String {
+        switch self {
+        case .operational: return "Operational"
+        case .maintenance: return "Maintenance"
+        case .degraded: return "Degraded"
+        case .partialOutage: return "Partial outage"
+        case .majorOutage: return "Outage"
+        }
+    }
+
+    /// Reads as a sentence after a provider name, for an event title.
+    var eventPhrase: String {
+        switch self {
+        case .operational: return "is operational"
+        case .maintenance: return "is under maintenance"
+        case .degraded: return "is degraded"
+        case .partialOutage: return "is partly down"
+        case .majorOutage: return "is down"
+        }
+    }
+}
+
+/// A provider's service health as of the last check, with the components that caused it.
+struct ServiceStatus: Hashable, Sendable, Identifiable {
+    var provider: Provider
+    var level: ServiceStatusLevel
+    /// What the status page calls the current state, e.g. "All Systems Operational".
+    var pageDescription: String
+    /// Names of this provider's components that are not operational, most severe first.
+    var affectedComponents: [String]
+    var pageURL: URL
+    var checkedAt: Date
+
+    var id: String { provider.rawValue }
+
+    /// One line for a tooltip or a card row: the affected components when the page names them,
+    /// falling back to the page's own wording.
+    var detail: String {
+        guard !affectedComponents.isEmpty else { return pageDescription }
+        return affectedComponents.joined(separator: ", ")
+    }
+}
+
+/// A Statuspage instance and the components on it that belong to each provider Toki tracks.
+///
+/// Matching is by lowercased prefix rather than exact name because these pages rename components
+/// freely (Anthropic's page moved to status.claude.com and renamed every component with it). A
+/// prefix also collapses a family in one entry: "codex" covers Codex API, Codex Web and Codex in
+/// ChatGPT Desktop, which is what a Codex CLI user means by "is Codex up".
+struct ServiceStatusSource: Sendable {
+    var id: String
+    var pageURL: URL
+    var componentPrefixes: [Provider: [String]]
+
+    var summaryURL: URL {
+        pageURL.appendingPathComponent("api/v2/summary.json")
+    }
+
+    var providers: [Provider] { Array(componentPrefixes.keys) }
+
+    static let all: [ServiceStatusSource] = [claude, openai, github, cursor]
+
+    static let claude = ServiceStatusSource(
+        id: "claude",
+        pageURL: URL(string: "https://status.claude.com")!,
+        componentPrefixes: [
+            .claudeCode: ["claude code"],
+            .claude: ["claude.ai"],
+            .anthropic: ["claude api"]
+        ]
+    )
+
+    static let openai = ServiceStatusSource(
+        id: "openai",
+        pageURL: URL(string: "https://status.openai.com")!,
+        componentPrefixes: [
+            .codex: ["codex"],
+            .openai: ["chat completions", "responses"],
+            // The page has no ChatGPT component of its own, so a consumer account falls back to
+            // the whole-page roll-up rather than reporting on an API surface it never touches.
+            .chatgpt: []
+        ]
+    )
+
+    static let github = ServiceStatusSource(
+        id: "github",
+        pageURL: URL(string: "https://www.githubstatus.com")!,
+        componentPrefixes: [
+            .copilot: ["copilot"]
+        ]
+    )
+
+    static let cursor = ServiceStatusSource(
+        id: "cursor",
+        pageURL: URL(string: "https://status.cursor.com")!,
+        componentPrefixes: [
+            .cursor: ["cli", "ide", "cloud agents"]
+        ]
+    )
+
+    /// The sources that can say anything about these providers, so a check only calls the pages
+    /// whose answer someone is actually going to see.
+    static func sources(covering providers: Set<Provider>) -> [ServiceStatusSource] {
+        all.filter { source in
+            source.componentPrefixes.keys.contains(where: providers.contains)
+        }
+    }
+}

--- a/Sources/Toki/Models/ServiceStatus.swift
+++ b/Sources/Toki/Models/ServiceStatus.swift
@@ -91,6 +91,11 @@ struct ServiceStatus: Hashable, Sendable, Identifiable {
 
     var id: String { provider.rawValue }
 
+    /// What the card, the tooltip and the event all lead with, e.g. "Claude Code is down".
+    var headline: String {
+        "\(provider.displayName) \(level.eventPhrase)"
+    }
+
     /// One line for a tooltip or a card row: the affected components when the page names them,
     /// falling back to the page's own wording.
     var detail: String {
@@ -113,8 +118,6 @@ struct ServiceStatusSource: Sendable {
     var summaryURL: URL {
         pageURL.appendingPathComponent("api/v2/summary.json")
     }
-
-    var providers: [Provider] { Array(componentPrefixes.keys) }
 
     static let all: [ServiceStatusSource] = [claude, openai, github, cursor]
 

--- a/Sources/Toki/Models/ServiceStatus.swift
+++ b/Sources/Toki/Models/ServiceStatus.swift
@@ -96,11 +96,17 @@ struct ServiceStatus: Hashable, Sendable, Identifiable {
         "\(provider.displayName) \(level.eventPhrase)"
     }
 
-    /// One line for a tooltip or a card row: the affected components when the page names them,
-    /// falling back to the page's own wording.
+    /// The second line under the headline: which of the provider's components are in trouble.
+    ///
+    /// A component named after the provider itself is dropped, because "Claude Code is down"
+    /// followed by "Claude Code" says one thing twice and reads like a rendering bug. When that
+    /// leaves nothing, the page's own wording stands in.
     var detail: String {
-        guard !affectedComponents.isEmpty else { return pageDescription }
-        return affectedComponents.joined(separator: ", ")
+        let informative = affectedComponents.filter {
+            $0.compare(provider.displayName, options: .caseInsensitive) != .orderedSame
+        }
+        guard !informative.isEmpty else { return pageDescription }
+        return informative.joined(separator: ", ")
     }
 }
 

--- a/Sources/Toki/Models/UsageState.swift
+++ b/Sources/Toki/Models/UsageState.swift
@@ -267,6 +267,7 @@ enum TokiEventKind: String, Codable {
     case notification
     case refresh
     case reset
+    case serviceStatus
 }
 
 struct TokiEvent: Codable, Identifiable, Hashable {

--- a/Sources/Toki/Store/UsageStore+Refresh.swift
+++ b/Sources/Toki/Store/UsageStore+Refresh.swift
@@ -59,6 +59,7 @@ extension UsageStore {
             snapshots = sorted
             lastUpdated = Date()
             updateDerivedState(for: sorted)
+            refreshServiceStatus(for: sorted)
         }
     }
 

--- a/Sources/Toki/Store/UsageStore+ServiceStatus.swift
+++ b/Sources/Toki/Store/UsageStore+ServiceStatus.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+extension UsageStore {
+    /// Status pages change far more slowly than quota does, and they are shared infrastructure
+    /// rather than a per-account API, so they are polled on their own longer clock instead of
+    /// once per usage refresh.
+    static let serviceStatusRefreshInterval: TimeInterval = 5 * 60
+
+    /// Checks the status pages of the providers this install actually uses.
+    ///
+    /// Providers are taken from the accounts on screen plus whatever agents are running, so a
+    /// Claude-only install never calls OpenAI's page, and no call is made at all for a provider
+    /// that publishes no status page Toki reads.
+    func refreshServiceStatus(for snapshots: [AccountSnapshot], force: Bool = false) {
+        guard isNetworkAvailable, !isCheckingServiceStatus else { return }
+        let now = Date()
+        if !force, let last = serviceStatusCheckedAt,
+           now.timeIntervalSince(last) < Self.serviceStatusRefreshInterval {
+            return
+        }
+        let tracked = Set(snapshots.map(\.provider)).union(activeAgents.map(\.provider))
+        let sources = ServiceStatusSource.sources(covering: tracked)
+        guard !sources.isEmpty else { return }
+
+        isCheckingServiceStatus = true
+        serviceStatusCheckedAt = now
+        Task {
+            defer { isCheckingServiceStatus = false }
+            let fetched = await ServiceStatusClient.fetch(sources: sources, checkedAt: now)
+            // Every page failed: keep the last answer rather than reporting a provider as
+            // healthy just because Toki could not ask.
+            guard !fetched.isEmpty else { return }
+            let previous = serviceStatuses
+            serviceStatuses = fetched
+            logDebug("Service status: \(disruptionSummary(for: fetched, tracked: tracked))")
+            recordServiceStatusEvents(previous: previous, current: fetched, tracked: tracked, at: now)
+        }
+    }
+
+    /// Service health for an account's provider, and only when it is worth showing - an
+    /// operational provider says nothing the card does not already say.
+    func disruptedServiceStatus(for provider: Provider) -> ServiceStatus? {
+        guard let status = serviceStatuses[provider], status.level.isDisrupted else { return nil }
+        return status
+    }
+
+    private func recordServiceStatusEvents(
+        previous: [Provider: ServiceStatus],
+        current: [Provider: ServiceStatus],
+        tracked: Set<Provider>,
+        at date: Date
+    ) {
+        for provider in tracked.sorted(by: { $0.rawValue < $1.rawValue }) {
+            guard let status = current[provider] else { continue }
+            let previousLevel = previous[provider]?.level
+            let host = status.pageURL.host ?? status.pageURL.absoluteString
+
+            if status.level.isDisrupted, previousLevel != status.level {
+                appendEvent(
+                    kind: .serviceStatus,
+                    title: "\(provider.displayName) \(status.level.eventPhrase)",
+                    detail: "\(status.detail) (\(host))",
+                    deliveredNotification: false,
+                    at: date
+                )
+            } else if !status.level.isDisrupted, let previousLevel, previousLevel.isDisrupted {
+                appendEvent(
+                    kind: .recovered,
+                    title: "\(provider.displayName) is back up",
+                    detail: "\(status.pageDescription) (\(host))",
+                    deliveredNotification: false,
+                    at: date
+                )
+            }
+        }
+    }
+
+    private func disruptionSummary(for statuses: [Provider: ServiceStatus], tracked: Set<Provider>) -> String {
+        let disrupted = tracked
+            .compactMap { statuses[$0] }
+            .filter { $0.level.isDisrupted }
+            .sorted { $0.provider.rawValue < $1.provider.rawValue }
+        guard !disrupted.isEmpty else { return "all clear" }
+        return disrupted
+            .map { "\($0.provider.displayName) \($0.level.label.lowercased())" }
+            .joined(separator: ", ")
+    }
+}

--- a/Sources/Toki/Store/UsageStore+ServiceStatus.swift
+++ b/Sources/Toki/Store/UsageStore+ServiceStatus.swift
@@ -6,6 +6,13 @@ extension UsageStore {
     /// once per usage refresh.
     static let serviceStatusRefreshInterval: TimeInterval = 5 * 60
 
+    /// How long a status is worth repeating after the last time Toki could confirm it.
+    ///
+    /// Six checks' worth. A page that has been unreachable that long, or a Mac that has been off
+    /// the network that long, means Toki no longer knows - and an outage dot that outlives the
+    /// outage is worse than no dot, because nothing on the card says it is a memory.
+    static let serviceStatusStaleAfter: TimeInterval = 30 * 60
+
     /// Checks the status pages of the providers this install actually uses.
     ///
     /// Providers are taken from the accounts on screen plus whatever agents are running, so a
@@ -27,20 +34,35 @@ extension UsageStore {
         Task {
             defer { isCheckingServiceStatus = false }
             let fetched = await ServiceStatusClient.fetch(sources: sources, checkedAt: now)
-            // Every page failed: keep the last answer rather than reporting a provider as
-            // healthy just because Toki could not ask.
-            guard !fetched.isEmpty else { return }
-            let previous = serviceStatuses
-            serviceStatuses = fetched
-            logDebug("Service status: \(disruptionSummary(for: fetched, tracked: tracked))")
-            recordServiceStatusEvents(previous: previous, current: fetched, tracked: tracked, at: now)
+            applyServiceStatuses(fetched, tracked: tracked, at: now)
         }
     }
 
-    /// Service health for an account's provider, and only when it is worth showing - an
-    /// operational provider says nothing the card does not already say.
-    func disruptedServiceStatus(for provider: Provider) -> ServiceStatus? {
+    /// Folds a round of checks into what is already known, and records what changed.
+    ///
+    /// Pages are fetched independently and any one of them can fail, so a provider missing from
+    /// this round means "not asked" rather than "healthy": its last answer stands until it goes
+    /// stale. Dropping it instead would clear the dot on a provider that is still down, which
+    /// reads exactly like a recovery that never happened.
+    func applyServiceStatuses(_ fetched: [Provider: ServiceStatus], tracked: Set<Provider>, at date: Date) {
+        var merged = fetched
+        for (provider, previous) in serviceStatuses where merged[provider] == nil {
+            guard date.timeIntervalSince(previous.checkedAt) < Self.serviceStatusStaleAfter else { continue }
+            merged[provider] = previous
+        }
+
+        let previous = serviceStatuses
+        serviceStatuses = merged
+        logDebug("Service status: \(disruptionSummary(for: merged, tracked: tracked))")
+        recordServiceStatusEvents(previous: previous, current: merged, tracked: tracked, at: date)
+    }
+
+    /// Service health for an account's provider, and only when it is worth showing: an
+    /// operational provider says nothing the card does not already say, and an answer Toki has
+    /// not been able to confirm for half an hour is no longer worth repeating.
+    func disruptedServiceStatus(for provider: Provider, now: Date = Date()) -> ServiceStatus? {
         guard let status = serviceStatuses[provider], status.level.isDisrupted else { return nil }
+        guard now.timeIntervalSince(status.checkedAt) < Self.serviceStatusStaleAfter else { return nil }
         return status
     }
 
@@ -58,7 +80,7 @@ extension UsageStore {
             if status.level.isDisrupted, previousLevel != status.level {
                 appendEvent(
                     kind: .serviceStatus,
-                    title: "\(provider.displayName) \(status.level.eventPhrase)",
+                    title: status.headline,
                     detail: "\(status.detail) (\(host))",
                     deliveredNotification: false,
                     at: date

--- a/Sources/Toki/Store/UsageStore.swift
+++ b/Sources/Toki/Store/UsageStore.swift
@@ -31,6 +31,7 @@ final class UsageStore: ObservableObject {
         severity: .neutral
     )
     @Published var statusEntries: [MenuBarStatusEntry] = menuBarPlaceholderEntries()
+    @Published var serviceStatuses: [Provider: ServiceStatus] = [:]
     @Published var detectedProviders: [DetectedProvider] = []
     @Published var isScanningProviders = false
     @Published private(set) var needsOnboarding = false
@@ -64,6 +65,8 @@ final class UsageStore: ObservableObject {
     let connectivityMonitor = ConnectivityMonitor()
     var connectivityGeneration = 0
     var refreshAfterReconnect = false
+    var serviceStatusCheckedAt: Date?
+    var isCheckingServiceStatus = false
 
     init() {
         reloadConfig()

--- a/Sources/Toki/Views/AccountCard.swift
+++ b/Sources/Toki/Views/AccountCard.swift
@@ -82,6 +82,16 @@ struct AccountCard: View {
                                 .offset(x: 4, y: -1)
                         }
                     }
+                    // Opposite corner to the session count, so an account that is both busy
+                    // and on a struggling provider still shows each signal in full.
+                    .overlay(alignment: .bottomTrailing) {
+                        if let serviceStatus {
+                            ServiceStatusDot(level: serviceStatus.level)
+                                .offset(x: 2, y: 1)
+                                .help("\(serviceStatus.provider.displayName) \(serviceStatus.level.eventPhrase): \(serviceStatus.detail)")
+                                .accessibilityLabel("\(serviceStatus.provider.displayName) \(serviceStatus.level.eventPhrase)")
+                        }
+                    }
 
                 VStack(alignment: .leading, spacing: 2) {
                     aliasEditor
@@ -168,6 +178,12 @@ struct AccountCard: View {
                         // provider a custom alias maps to.
                         ProviderPill(provider: snapshot.provider)
                     }
+                }
+
+                // The provider being down explains a stalled agent or a failing refresh, so it
+                // sits above the metrics rather than under them.
+                if let serviceStatus {
+                    ServiceStatusRow(status: serviceStatus)
                 }
 
                 // Sessions only make sense for a connected account; when the account is
@@ -364,6 +380,12 @@ struct AccountCard: View {
                 .pointerOnHover()
             }
         }
+    }
+
+    /// Set only while this account's provider reports trouble - an operational provider has
+    /// nothing to add to a card that is already showing its quota.
+    private var serviceStatus: ServiceStatus? {
+        store.disruptedServiceStatus(for: snapshot.provider)
     }
 
     private var accountIdentifier: String {

--- a/Sources/Toki/Views/AccountCard.swift
+++ b/Sources/Toki/Views/AccountCard.swift
@@ -88,8 +88,8 @@ struct AccountCard: View {
                         if let serviceStatus {
                             ServiceStatusDot(level: serviceStatus.level)
                                 .offset(x: 2, y: 1)
-                                .help("\(serviceStatus.provider.displayName) \(serviceStatus.level.eventPhrase): \(serviceStatus.detail)")
-                                .accessibilityLabel("\(serviceStatus.provider.displayName) \(serviceStatus.level.eventPhrase)")
+                                .help("\(serviceStatus.headline): \(serviceStatus.detail)")
+                                .accessibilityLabel(serviceStatus.headline)
                         }
                     }
 

--- a/Sources/Toki/Views/Components.swift
+++ b/Sources/Toki/Views/Components.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 // MARK: - UpdateAvailableBanner
@@ -469,6 +470,72 @@ struct AccountBadge: View {
             }
         }
         .frame(width: size, height: size)
+    }
+}
+
+// MARK: - Service status
+
+extension ServiceStatusLevel {
+    var tint: Color {
+        switch self {
+        case .operational: return .green
+        case .maintenance: return .blue
+        case .degraded: return .yellow
+        case .partialOutage: return .orange
+        case .majorOutage: return .red
+        }
+    }
+}
+
+/// The dot that rides on an account's logo while its provider reports trouble.
+///
+/// Drawn with a ring in the card's own background colour so it stays legible against the logo
+/// it overlaps, the way a badge does.
+struct ServiceStatusDot: View {
+    var level: ServiceStatusLevel
+    var size: CGFloat = 8
+
+    var body: some View {
+        Circle()
+            .fill(level.tint)
+            .frame(width: size, height: size)
+            .overlay(Circle().stroke(Color(nsColor: .windowBackgroundColor), lineWidth: 1.5))
+    }
+}
+
+/// The expanded card's line about the provider being down, with a way to go read the detail.
+struct ServiceStatusRow: View {
+    var status: ServiceStatus
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 6) {
+            ServiceStatusDot(level: status.level, size: 7)
+                .alignmentGuide(.firstTextBaseline) { $0[.bottom] }
+            VStack(alignment: .leading, spacing: 1) {
+                Text("\(status.provider.displayName) \(status.level.eventPhrase)")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(status.level.tint)
+                Text(status.detail)
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 6)
+            Button {
+                NSWorkspace.shared.open(status.pageURL)
+            } label: {
+                Image(systemName: "arrow.up.forward.square")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+            .help("Open \(status.pageURL.host ?? "the provider status page")")
+            .accessibilityLabel("Open the provider status page")
+            .pointerOnHover()
+        }
+        .padding(.vertical, 5)
+        .padding(.horizontal, 7)
+        .background(status.level.tint.opacity(0.08), in: RoundedRectangle(cornerRadius: 7, style: .continuous))
     }
 }
 

--- a/Sources/Toki/Views/Components.swift
+++ b/Sources/Toki/Views/Components.swift
@@ -480,8 +480,10 @@ extension ServiceStatusLevel {
         switch self {
         case .operational: return .green
         case .maintenance: return .blue
-        case .degraded: return .yellow
-        case .partialOutage: return .orange
+        // The app's severity palette is green/orange/red, with no yellow anywhere else: orange
+        // reads as slow, red as down, and the wording carries the rest.
+        case .degraded: return .orange
+        case .partialOutage: return .red
         case .majorOutage: return .red
         }
     }

--- a/Sources/Toki/Views/Components.swift
+++ b/Sources/Toki/Views/Components.swift
@@ -512,7 +512,7 @@ struct ServiceStatusRow: View {
             ServiceStatusDot(level: status.level, size: 7)
                 .alignmentGuide(.firstTextBaseline) { $0[.bottom] }
             VStack(alignment: .leading, spacing: 1) {
-                Text("\(status.provider.displayName) \(status.level.eventPhrase)")
+                Text(status.headline)
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(status.level.tint)
                 Text(status.detail)

--- a/Sources/Toki/Views/EventPanel.swift
+++ b/Sources/Toki/Views/EventPanel.swift
@@ -89,6 +89,7 @@ struct EventPanel: View {
         case .notification: return event.deliveredNotification ? "bell.fill" : "bell.slash"
         case .refresh: return "arrow.clockwise"
         case .reset: return "arrow.counterclockwise"
+        case .serviceStatus: return "bolt.horizontal.circle.fill"
         }
     }
 
@@ -101,6 +102,7 @@ struct EventPanel: View {
         case .notification: return event.deliveredNotification ? .blue : .secondary
         case .refresh: return .secondary
         case .reset: return .teal
+        case .serviceStatus: return .orange
         }
     }
 }

--- a/Tests/TokiTests/ServiceStatusDownTests.swift
+++ b/Tests/TokiTests/ServiceStatusDownTests.swift
@@ -1,0 +1,195 @@
+import Foundation
+import XCTest
+@testable import Toki
+
+/// What a user actually sees when a provider is down: the card asks the store what to draw, and
+/// the Events tab reads what was recorded. These drive that path with a real `UsageStore`, from a
+/// downed status page through to the text on screen.
+@MainActor
+final class ServiceStatusDownTests: XCTestCase {
+    private var directory: URL!
+
+    override func setUpWithError() throws {
+        directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("toki-service-status-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        setenv("TOKI_STATE", directory.appendingPathComponent("state.json").path, 1)
+        setenv("TOKI_CONFIG", directory.appendingPathComponent("config.json").path, 1)
+    }
+
+    override func tearDownWithError() throws {
+        unsetenv("TOKI_STATE")
+        unsetenv("TOKI_CONFIG")
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    private let downPage = """
+    {
+      "status": {"indicator": "major", "description": "Partial System Outage"},
+      "components": [
+        {"name": "claude.ai", "status": "operational"},
+        {"name": "Claude API (api.anthropic.com)", "status": "degraded_performance"},
+        {"name": "Claude Code", "status": "major_outage"}
+      ]
+    }
+    """
+
+    private func parse(_ json: String, source: ServiceStatusSource, at date: Date) throws -> [Provider: ServiceStatus] {
+        let payload = try JSONSerialization.jsonObject(with: Data(json.utf8))
+        return ServiceStatusClient.parse(summary: payload, source: source, checkedAt: date)
+    }
+
+    func testADownProviderIsWhatTheCardAsksForAndAnOperationalOneIsNot() throws {
+        let now = Date()
+        let store = UsageStore()
+        let statuses = try parse(downPage, source: .claude, at: now)
+
+        store.applyServiceStatuses(statuses, tracked: [.claudeCode, .claude, .anthropic], at: now)
+
+        // What the card draws its dot from, and the words it puts beside it.
+        let shown = try XCTUnwrap(store.disruptedServiceStatus(for: .claudeCode, now: now))
+        XCTAssertEqual(shown.headline, "Claude Code is down")
+        XCTAssertEqual(shown.detail, "Claude Code")
+        XCTAssertEqual(shown.level, .majorOutage)
+        XCTAssertEqual(shown.pageURL.absoluteString, "https://status.claude.com")
+
+        // Degraded is still worth a dot, in its own words.
+        let api = try XCTUnwrap(store.disruptedServiceStatus(for: .anthropic, now: now))
+        XCTAssertEqual(api.headline, "Anthropic is degraded")
+
+        // claude.ai is fine on the same page, so its card stays quiet even though the page as a
+        // whole reads "major".
+        XCTAssertNil(store.disruptedServiceStatus(for: .claude, now: now))
+        // A provider that was never checked draws nothing at all.
+        XCTAssertNil(store.disruptedServiceStatus(for: .codex, now: now))
+        withExtendedLifetime(store) {}
+    }
+
+    func testGoingDownAndComingBackAreBothRecordedInEvents() throws {
+        let wentDown = Date()
+        let cameBack = wentDown.addingTimeInterval(20 * 60)
+        let store = UsageStore()
+        let tracked: Set<Provider> = [.claudeCode, .claude, .anthropic]
+
+        store.applyServiceStatuses(try parse(downPage, source: .claude, at: wentDown), tracked: tracked, at: wentDown)
+
+        let outage = try XCTUnwrap(store.events.first { $0.title == "Claude Code is down" })
+        XCTAssertEqual(outage.kind, .serviceStatus)
+        XCTAssertEqual(outage.detail, "Claude Code (status.claude.com)")
+        XCTAssertFalse(outage.deliveredNotification, "an outage is recorded, never pushed as a notification")
+
+        let healthy = """
+        {
+          "status": {"indicator": "none", "description": "All Systems Operational"},
+          "components": [
+            {"name": "claude.ai", "status": "operational"},
+            {"name": "Claude API (api.anthropic.com)", "status": "operational"},
+            {"name": "Claude Code", "status": "operational"}
+          ]
+        }
+        """
+        store.applyServiceStatuses(try parse(healthy, source: .claude, at: cameBack), tracked: tracked, at: cameBack)
+
+        XCTAssertNil(store.disruptedServiceStatus(for: .claudeCode, now: cameBack), "the dot goes away")
+        let recovery = try XCTUnwrap(store.events.first { $0.title == "Claude Code is back up" })
+        XCTAssertEqual(recovery.kind, .recovered)
+        XCTAssertEqual(recovery.detail, "All Systems Operational (status.claude.com)")
+        withExtendedLifetime(store) {}
+    }
+
+    func testAnOutageThatHasNotChangedIsNotRecordedAgainOnEveryCheck() throws {
+        let first = Date()
+        let store = UsageStore()
+        let tracked: Set<Provider> = [.claudeCode, .claude, .anthropic]
+
+        for minutes in [0, 5, 10] {
+            let at = first.addingTimeInterval(TimeInterval(minutes * 60))
+            store.applyServiceStatuses(try parse(downPage, source: .claude, at: at), tracked: tracked, at: at)
+        }
+
+        XCTAssertEqual(store.events.filter { $0.title == "Claude Code is down" }.count, 1)
+        withExtendedLifetime(store) {}
+    }
+
+    func testAWorseningOutageIsRecordedAgainBecauseTheCardNowSaysSomethingElse() throws {
+        let first = Date()
+        let later = first.addingTimeInterval(5 * 60)
+        let store = UsageStore()
+        let tracked: Set<Provider> = [.codex]
+        let source = ServiceStatusSource.openai
+
+        let degraded = #"{"status": {"indicator": "minor", "description": "Degraded"}, "components": [{"name": "Codex API", "status": "degraded_performance"}]}"#
+        let down = #"{"status": {"indicator": "critical", "description": "Major Outage"}, "components": [{"name": "Codex API", "status": "major_outage"}]}"#
+
+        store.applyServiceStatuses(try parse(degraded, source: source, at: first), tracked: tracked, at: first)
+        store.applyServiceStatuses(try parse(down, source: source, at: later), tracked: tracked, at: later)
+
+        XCTAssertEqual(store.events.filter { $0.kind == .serviceStatus }.map(\.title), [
+            "Codex is down",
+            "Codex is degraded"
+        ], "newest first, and the worsening is its own entry")
+        XCTAssertEqual(store.disruptedServiceStatus(for: .codex, now: later)?.level, .majorOutage)
+        withExtendedLifetime(store) {}
+    }
+
+    func testAPageThatFailsToAnswerLeavesAKnownOutageOnScreen() throws {
+        let wentDown = Date()
+        let nextCheck = wentDown.addingTimeInterval(5 * 60)
+        let store = UsageStore()
+        let tracked: Set<Provider> = [.claudeCode, .codex]
+
+        store.applyServiceStatuses(try parse(downPage, source: .claude, at: wentDown), tracked: tracked, at: wentDown)
+
+        // Claude's page is unreachable this round while OpenAI's answers: a missing provider means
+        // "not asked", so the outage that is still happening keeps its dot.
+        let codexOnly = try parse(
+            #"{"status": {"indicator": "none", "description": "All Systems Operational"}, "components": [{"name": "Codex API", "status": "operational"}]}"#,
+            source: .openai,
+            at: nextCheck
+        )
+        store.applyServiceStatuses(codexOnly, tracked: tracked, at: nextCheck)
+
+        XCTAssertEqual(store.disruptedServiceStatus(for: .claudeCode, now: nextCheck)?.headline, "Claude Code is down")
+        XCTAssertEqual(store.events.filter { $0.title == "Claude Code is back up" }.count, 0, "silence is not a recovery")
+        withExtendedLifetime(store) {}
+    }
+
+    func testAnAnswerNobodyCouldConfirmForHalfAnHourStopsBeingShown() throws {
+        let wentDown = Date()
+        let store = UsageStore()
+
+        store.applyServiceStatuses(try parse(downPage, source: .claude, at: wentDown), tracked: [.claudeCode], at: wentDown)
+
+        XCTAssertNotNil(store.disruptedServiceStatus(for: .claudeCode, now: wentDown.addingTimeInterval(29 * 60)))
+        XCTAssertNil(
+            store.disruptedServiceStatus(for: .claudeCode, now: wentDown.addingTimeInterval(31 * 60)),
+            "past the staleness bound Toki no longer knows, and says nothing rather than guessing"
+        )
+
+        // The same bound drops it from the merge, so it cannot come back on a later round either.
+        let laterCheck = wentDown.addingTimeInterval(45 * 60)
+        store.applyServiceStatuses([:], tracked: [.claudeCode], at: laterCheck)
+        XCTAssertNil(store.serviceStatuses[.claudeCode])
+        withExtendedLifetime(store) {}
+    }
+
+    func testEveryDisruptedLevelReadsAsASentenceOnTheCard() {
+        let headlines = [ServiceStatusLevel.degraded, .partialOutage, .majorOutage, .maintenance].map { level in
+            ServiceStatus(
+                provider: .codex,
+                level: level,
+                pageDescription: "",
+                affectedComponents: [],
+                pageURL: URL(string: "https://status.openai.com")!,
+                checkedAt: Date()
+            ).headline
+        }
+
+        XCTAssertEqual(headlines, [
+            "Codex is degraded",
+            "Codex is partly down",
+            "Codex is down",
+            "Codex is under maintenance"
+        ])
+    }
+}

--- a/Tests/TokiTests/ServiceStatusDownTests.swift
+++ b/Tests/TokiTests/ServiceStatusDownTests.swift
@@ -49,7 +49,7 @@ final class ServiceStatusDownTests: XCTestCase {
         // What the card draws its dot from, and the words it puts beside it.
         let shown = try XCTUnwrap(store.disruptedServiceStatus(for: .claudeCode, now: now))
         XCTAssertEqual(shown.headline, "Claude Code is down")
-        XCTAssertEqual(shown.detail, "Claude Code")
+        XCTAssertEqual(shown.detail, "Partial System Outage", "not the provider name repeated back")
         XCTAssertEqual(shown.level, .majorOutage)
         XCTAssertEqual(shown.pageURL.absoluteString, "https://status.claude.com")
 
@@ -75,7 +75,7 @@ final class ServiceStatusDownTests: XCTestCase {
 
         let outage = try XCTUnwrap(store.events.first { $0.title == "Claude Code is down" })
         XCTAssertEqual(outage.kind, .serviceStatus)
-        XCTAssertEqual(outage.detail, "Claude Code (status.claude.com)")
+        XCTAssertEqual(outage.detail, "Partial System Outage (status.claude.com)")
         XCTAssertFalse(outage.deliveredNotification, "an outage is recorded, never pushed as a notification")
 
         let healthy = """

--- a/Tests/TokiTests/ServiceStatusTests.swift
+++ b/Tests/TokiTests/ServiceStatusTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+import XCTest
+@testable import Toki
+
+final class ServiceStatusTests: XCTestCase {
+    private let checkedAt = ISO8601DateFormatter().date(from: "2026-09-03T12:00:00Z")!
+
+    private func parse(_ json: String, source: ServiceStatusSource) throws -> [Provider: ServiceStatus] {
+        let payload = try JSONSerialization.jsonObject(with: Data(json.utf8))
+        return ServiceStatusClient.parse(summary: payload, source: source, checkedAt: checkedAt)
+    }
+
+    // Component names as status.claude.com publishes them.
+    private func claudePage(claudeCode: String, claudeAI: String = "operational", api: String = "operational", indicator: String = "none", description: String = "All Systems Operational") -> String {
+        """
+        {
+          "page": {"name": "Claude", "url": "https://status.claude.com"},
+          "status": {"indicator": "\(indicator)", "description": "\(description)"},
+          "components": [
+            {"name": "claude.ai", "status": "\(claudeAI)"},
+            {"name": "Claude Console (platform.claude.com)", "status": "operational"},
+            {"name": "Claude API (api.anthropic.com)", "status": "\(api)"},
+            {"name": "Claude Code", "status": "\(claudeCode)"}
+          ]
+        }
+        """
+    }
+
+    func testProviderTakesItsOwnComponentNotTheWholePageRollUp() throws {
+        // The page reads "major" because something else on it is down; Claude Code itself is fine
+        // and must not be reported as down for it.
+        let statuses = try parse(
+            claudePage(claudeCode: "operational", claudeAI: "major_outage", indicator: "major", description: "Partial System Outage"),
+            source: .claude
+        )
+
+        XCTAssertEqual(statuses[.claudeCode]?.level, .operational)
+        XCTAssertEqual(statuses[.claudeCode]?.affectedComponents, [])
+        XCTAssertEqual(statuses[.claude]?.level, .majorOutage)
+        XCTAssertEqual(statuses[.claude]?.affectedComponents, ["claude.ai"])
+        XCTAssertEqual(statuses[.anthropic]?.level, .operational)
+    }
+
+    func testDisruptedComponentIsNamedAndCarriesThePageURL() throws {
+        let statuses = try parse(
+            claudePage(claudeCode: "degraded_performance", indicator: "minor", description: "Degraded Performance"),
+            source: .claude
+        )
+
+        let status = try XCTUnwrap(statuses[.claudeCode])
+        XCTAssertEqual(status.level, .degraded)
+        XCTAssertTrue(status.level.isDisrupted)
+        XCTAssertEqual(status.detail, "Claude Code")
+        XCTAssertEqual(status.pageURL.absoluteString, "https://status.claude.com")
+        XCTAssertEqual(status.checkedAt, checkedAt)
+    }
+
+    func testOperationalProviderFallsBackToThePageWordingForItsDetail() throws {
+        let statuses = try parse(claudePage(claudeCode: "operational"), source: .claude)
+
+        let status = try XCTUnwrap(statuses[.claudeCode])
+        XCTAssertFalse(status.level.isDisrupted)
+        XCTAssertEqual(status.detail, "All Systems Operational")
+    }
+
+    // Component names as status.openai.com publishes them.
+    private func openAIPage(codexAPI: String, codexWeb: String = "operational", chatCompletions: String = "operational", indicator: String = "none") -> String {
+        """
+        {
+          "page": {"name": "OpenAI", "url": "https://status.openai.com/"},
+          "status": {"indicator": "\(indicator)", "description": "Status"},
+          "components": [
+            {"name": "Codex API", "status": "\(codexAPI)"},
+            {"name": "Codex Web", "status": "\(codexWeb)"},
+            {"name": "Codex in ChatGPT Desktop", "status": "operational"},
+            {"name": "Chat Completions", "status": "\(chatCompletions)"},
+            {"name": "Sora", "status": "major_outage"}
+          ]
+        }
+        """
+    }
+
+    func testOneProviderSpansEveryComponentOfItsFamilyAndTakesTheWorst() throws {
+        let statuses = try parse(
+            openAIPage(codexAPI: "degraded_performance", codexWeb: "major_outage"),
+            source: .openai
+        )
+
+        let codex = try XCTUnwrap(statuses[.codex])
+        XCTAssertEqual(codex.level, .majorOutage)
+        // Most severe first, and only the components that are actually disrupted.
+        XCTAssertEqual(codex.affectedComponents, ["Codex Web", "Codex API"])
+        // Sora being down belongs to neither Codex nor the API surface Toki reads.
+        XCTAssertEqual(statuses[.openai]?.level, .operational)
+    }
+
+    func testProviderWithNoComponentOfItsOwnUsesThePageRollUp() throws {
+        let statuses = try parse(openAIPage(codexAPI: "operational", indicator: "critical"), source: .openai)
+
+        let chatgpt = try XCTUnwrap(statuses[.chatgpt])
+        XCTAssertEqual(chatgpt.level, .majorOutage)
+        XCTAssertEqual(chatgpt.affectedComponents, [])
+        // A provider that does have components is unaffected by the roll-up.
+        XCTAssertEqual(statuses[.codex]?.level, .operational)
+    }
+
+    func testMaintenanceLosesToARealFaultOnAnotherComponent() throws {
+        let statuses = try parse(
+            openAIPage(codexAPI: "under_maintenance", codexWeb: "partial_outage"),
+            source: .openai
+        )
+
+        XCTAssertEqual(statuses[.codex]?.level, .partialOutage)
+        XCTAssertLessThan(ServiceStatusLevel.maintenance, ServiceStatusLevel.degraded)
+        XCTAssertLessThan(ServiceStatusLevel.partialOutage, ServiceStatusLevel.majorOutage)
+    }
+
+    func testUnknownComponentStateFallsBackToThePageRollUpRatherThanReportingHealthy() throws {
+        let json = """
+        {
+          "status": {"indicator": "major", "description": "Partial System Outage"},
+          "components": [{"name": "Claude Code", "status": "something_new"}]
+        }
+        """
+
+        let statuses = try parse(json, source: .claude)
+
+        XCTAssertEqual(statuses[.claudeCode]?.level, .partialOutage)
+    }
+
+    func testPayloadWithNothingUsableYieldsNoStatuses() throws {
+        XCTAssertTrue(try parse("{}", source: .claude).isEmpty)
+        XCTAssertTrue(try parse("[]", source: .claude).isEmpty)
+        XCTAssertTrue(try parse(#"{"components": [{"name": "Claude Code"}]}"#, source: .claude).isEmpty)
+    }
+
+    func testOnlyThePagesCoveringTrackedProvidersAreCalled() {
+        let claudeOnly = ServiceStatusSource.sources(covering: [.claudeCode])
+        XCTAssertEqual(claudeOnly.map(\.id), ["claude"])
+
+        let mixed = ServiceStatusSource.sources(covering: [.claudeCode, .codex, .openCode])
+        XCTAssertEqual(Set(mixed.map(\.id)), ["claude", "openai"])
+
+        // Providers that publish no status page Toki reads cost no request at all.
+        XCTAssertTrue(ServiceStatusSource.sources(covering: [.openCode, .pi, .manual]).isEmpty)
+    }
+
+    func testEverySourceAsksItsPageForTheStatuspageSummary() {
+        XCTAssertEqual(
+            ServiceStatusSource.claude.summaryURL.absoluteString,
+            "https://status.claude.com/api/v2/summary.json"
+        )
+        for source in ServiceStatusSource.all {
+            XCTAssertTrue(source.summaryURL.absoluteString.hasSuffix("/api/v2/summary.json"), source.id)
+        }
+    }
+}

--- a/Tests/TokiTests/ServiceStatusTests.swift
+++ b/Tests/TokiTests/ServiceStatusTests.swift
@@ -50,7 +50,8 @@ final class ServiceStatusTests: XCTestCase {
         let status = try XCTUnwrap(statuses[.claudeCode])
         XCTAssertEqual(status.level, .degraded)
         XCTAssertTrue(status.level.isDisrupted)
-        XCTAssertEqual(status.detail, "Claude Code")
+        // The component is named after the provider, so the page wording carries the detail.
+        XCTAssertEqual(status.detail, "Degraded Performance")
         XCTAssertEqual(status.pageURL.absoluteString, "https://status.claude.com")
         XCTAssertEqual(status.checkedAt, checkedAt)
     }
@@ -88,6 +89,7 @@ final class ServiceStatusTests: XCTestCase {
 
         let codex = try XCTUnwrap(statuses[.codex])
         XCTAssertEqual(codex.level, .majorOutage)
+        XCTAssertEqual(codex.detail, "Codex Web, Codex API", "components that add something are kept")
         // Most severe first, and only the components that are actually disrupted.
         XCTAssertEqual(codex.affectedComponents, ["Codex Web", "Codex API"])
         // Sora being down belongs to neither Codex nor the API surface Toki reads.

--- a/docs/features.md
+++ b/docs/features.md
@@ -58,6 +58,12 @@ Toki writes a compact, privacy-safe snapshot (provider labels and percentages on
 
 On by default. The same provider-colored rings render inside the Accounts panel, showing remaining percentage at a glance and revealing the provider and live percentage on hover. Hide them with the button on the panel or the toggle in Settings. The standalone macOS widget above is enabled independently through the system widget gallery.
 
+## Provider outages
+
+When a provider reports trouble on its own status page, the account card says so: a coloured dot on the account logo, and, once the card is open, a line naming what is down with a link to the page. A provider that is operational shows nothing.
+
+Toki reads the public Statuspage summaries that Claude, OpenAI, GitHub, and Cursor publish, unauthenticated and at most once every five minutes, and only for providers you actually have, so a Claude-only install never calls OpenAI's page. Each provider is matched to its own components (Codex covers Codex API, Codex Web, and Codex in ChatGPT Desktop), so an unrelated outage elsewhere on the same page, Sora for instance, is never reported as yours. A provider the page does not break out falls back to that page's overall state. Every change lands in the Events tab.
+
 ## Live in the notch (experimental)
 
 Off by default, notched Macs only. Puts the readout at the display notch instead of the menu bar, in one of three resting positions — hanging below, sideways beside it, or spread around both sides — expanding on hover. Clicking opens the popover anchored to the pill, so it appears on the side you actually clicked.


### PR DESCRIPTION
Closes #151. Targets `release/v3.3.0`.

Toki could say a refresh failed, but not whether the fault was yours or the provider's. Every provider it tracks publishes a Statuspage, and they are all the same shape, so one parser covers Claude, OpenAI, GitHub, and Cursor, and a new page is a table entry in `ServiceStatusSource`.

## What shows up

- A coloured dot on the account logo while the provider reports trouble, in the corner opposite the session count. Orange for degraded, red for partly down or down. Its tooltip carries the reason.
- A tinted row in the opened card: **"Claude Code is down"** with what is affected under it, and a button to the status page.
- An entry in Events each time a provider goes down, gets worse, or comes back. Recorded only, never pushed as a system notification.
- Nothing at all while a provider is operational.

## How it decides

- A provider is matched to **its own components**, not the whole-page roll-up, so Sora being down is not a Codex outage and a page reading "major" does not condemn a healthy Claude Code.
- Matching is by lowercased prefix, so the Codex family (Codex API, Codex Web, Codex in ChatGPT Desktop) is one answer, and a renamed component is likelier to keep matching. The mapping was checked against all four live pages.
- A provider the page does not break out, ChatGPT for one, falls back to the page roll-up.
- Only pages covering providers this install actually has are called: a Claude-only install never calls OpenAI's page. At most once every five minutes, unauthenticated, and skipped entirely when offline.
- Pages are fetched independently, so a provider missing from a round means "not asked" and keeps its last answer rather than losing its dot, which would read as a recovery that never happened. Answers expire after thirty minutes, six checks' worth, so a dot never outlives what Toki can confirm.

## Coverage

| Page | Providers |
|---|---|
| status.claude.com | Claude Code, claude.ai, Claude API |
| status.openai.com | Codex, OpenAI API, ChatGPT (roll-up) |
| githubstatus.com | Copilot |
| status.cursor.com | Cursor |

## Testing

`swift test` (485 tests) and `swift build -Xswiftc -strict-concurrency=complete` are clean.

17 new tests. Ten cover the parse: component-over-roll-up precedence, worst-of-family severity, maintenance losing to a real fault, the roll-up fallback, unknown component states, malformed payloads, and which pages get called for a given provider set. Seven drive a real `UsageStore` through an outage end to end: what the card is handed while a provider is down, that an operational provider on the same page stays quiet, the down and back-up entries in Events, that an unchanged outage is not re-recorded on every check while a worsening one is, that a failed page keeps a known outage on screen, and that an answer nobody could confirm for half an hour stops being shown.

The visuals were checked by rendering the real `AccountCard` views against a seeded outage. That pass found two things, both fixed here: the card said "Claude Code is down" with "Claude Code" repeated underneath, and degraded was the only yellow in an app whose severity palette is green, orange, and red.
