### PR TITLE
Take the deprecated stanza out of the casks, and let the fix travel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,24 +108,29 @@ jobs:
         run: |
           TAP_DIR="$(mktemp -d)"
           git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/aashutoshrathi/homebrew-tap.git" "$TAP_DIR"
-          # First run on a tap that predates the beta cask: seed it from the in-repo
-          # template so update-cask.sh has a file to rewrite. Once the tap carries the
-          # cask this is skipped and the existing file is bumped in place.
-          if [ ! -f "$TAP_DIR/Casks/toki-beta.rb" ]; then
-            mkdir -p "$TAP_DIR/Casks"
-            cp homebrew/toki-beta.rb "$TAP_DIR/Casks/toki-beta.rb"
-          fi
+          mkdir -p "$TAP_DIR/Casks"
+          # The in-repo template is the cask body; update-cask.sh then stamps version and
+          # sha256 onto it. Copying it every release is what makes the template authoritative:
+          # update-cask.sh rewrites only those two lines, so before this, a fix anywhere else
+          # in the cask - a deprecated stanza, a wrong caveat - stayed in this repo and never
+          # reached the tap the users install from.
+          #
+          # A prerelease must not touch the stable cask at all: its body would arrive with the
+          # template's placeholder version, and nothing on this path stamps a real one over it.
           if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
+            cp homebrew/toki-beta.rb "$TAP_DIR/Casks/toki-beta.rb"
             # Prerelease: the cask version is the full tag; the DMG filename carries only
             # the base version, which update-cask.sh handles.
             bash scripts/update-cask.sh "$TAP_DIR/Casks/toki-beta.rb" "${GITHUB_REF_NAME#v}"
           else
+            cp homebrew/toki.rb "$TAP_DIR/Casks/toki.rb"
+            cp homebrew/toki-beta.rb "$TAP_DIR/Casks/toki-beta.rb"
             # Both casks take the same stable version, which is update-cask.sh's default.
             bash scripts/update-cask.sh "$TAP_DIR/Casks/toki.rb"
             bash scripts/update-cask.sh "$TAP_DIR/Casks/toki-beta.rb"
           fi
           cd "$TAP_DIR"
-          # Stage before checking: a freshly seeded Casks/toki-beta.rb is untracked, and
+          # Stage before checking: a cask the tap does not carry yet is untracked, and
           # `git diff --quiet` alone would ignore it and skip the first bootstrap commit.
           git add Casks/
           if git diff --cached --quiet; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - **An outage indicator on the provider cards.** A coloured dot on the account logo when a provider's own status page reports an outage or degraded service, and a line in the opened card naming what is down, with a link to the page. Claude, Codex, Copilot, and Cursor are covered, checked at most every five minutes and only for the providers you actually use, and each change is recorded in Events.
 
+### Fixed
+
+- **`brew` stops warning about Toki's casks on every command.** Both casks used `postflight`, which Homebrew now reports as deprecated and asks the tap to fix, four times over on a single `brew upgrade`. They use the declarative `postflight_steps` instead, which does the same quarantine strip.
+- **A cask fix now reaches the tap people install from.** The release only ever rewrote `version` and `sha256` there, so everything else in a cask stayed behind in this repo: the deprecated stanza survived every release, and the stable cask never picked up the `conflicts_with` that is supposed to keep it and the beta cask mutually exclusive. The cask body is copied from this repo on each release now, then stamped.
+
 ## 3.2.0 - 2026-09-03
 
 ### Added

--- a/docs/development.md
+++ b/docs/development.md
@@ -59,6 +59,10 @@ Version ordering is semver-aware (`2.4.3` < `2.5.0-beta.1` < `2.5.0-beta.2` < `2
 
 Two casks live in the tap (`aashutoshrathi/homebrew-tap`): `toki` (stable) and `toki-beta` (prereleases). They conflict with each other — install one.
 
+`homebrew/toki.rb` and `homebrew/toki-beta.rb` in this repo are the cask bodies. The release workflow copies the matching one into the tap on every release and then stamps it, so a change anywhere in a cask is made here, never in the tap: `scripts/update-cask.sh` rewrites only `version` and `sha256`, and anything edited straight in the tap is overwritten at the next release.
+
+A prerelease tag copies and stamps `toki-beta` alone. The stable cask is deliberately left untouched on that path, because its body would arrive carrying the template's placeholder version with nothing to stamp a real one over it.
+
 `scripts/update-cask.sh <cask.rb> [version]` rewrites a cask's version and DMG sha256. The version argument defaults to `appVersion`; prerelease tags must pass the full version (e.g. `3.2.0-beta.1`) because it exists only in the tag. The DMG filename always carries the base version (`Toki_3.2.0_universal.dmg`), which the script and the cask's URL handle.
 
 When Toki was installed by a cask, the in-app updater detects it (`BrewCask.installedCask` — the Caskroom entry is a symlink to the installed bundle) and routes "Install update" through `brew upgrade --cask <toki|toki-beta>` instead of swapping the DMG underneath brew. This keeps brew's receipt in sync with the app on disk; the DMG path would desync it, and the next `brew upgrade` would then clobber the newer build with the cask's older one. Dev builds and manual installs keep the direct DMG path.

--- a/homebrew/toki-beta.rb
+++ b/homebrew/toki-beta.rb
@@ -27,10 +27,8 @@ cask "toki-beta" do
 
   # The release DMG is ad-hoc signed and not notarized, so Gatekeeper quarantines it.
   # Strip the quarantine flag on install so the app opens without a right-click-Open.
-  postflight do
-    system_command "/usr/bin/xattr",
-                   args: ["-dr", "com.apple.quarantine", "#{appdir}/Toki.app"],
-                   sudo: false
+  postflight_steps do
+    run "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "{{appdir}}/Toki.app"]
   end
 
   zap trash: [

--- a/homebrew/toki.rb
+++ b/homebrew/toki.rb
@@ -22,10 +22,8 @@ cask "toki" do
 
   # The release DMG is ad-hoc signed and not notarized, so Gatekeeper quarantines it.
   # Strip the quarantine flag on install so the app opens without a right-click-Open.
-  postflight do
-    system_command "/usr/bin/xattr",
-                   args: ["-dr", "com.apple.quarantine", "#{appdir}/Toki.app"],
-                   sudo: false
+  postflight_steps do
+    run "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "{{appdir}}/Toki.app"]
   end
 
   zap trash: [


### PR DESCRIPTION
Closes #154. Targets `release/v3.3.0`.

## The warning

Homebrew deprecated the free-form `postflight` block in favour of declarative `postflight_steps`, and warns once per cask per command, which is the four warnings in the issue for one `brew upgrade`. Both casks do exactly one thing after install, strip the quarantine flag, and that is a single `run` step.

```ruby
postflight_steps do
  run "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "{{appdir}}/Toki.app"]
end
```

`{{appdir}}` is Homebrew's own template token, expanded for `run` args at execution time (`install_steps.rb`, `CONTENT_PATH_TOKENS`), and it replaces the `#{appdir}` interpolation the Ruby block used.

## Why it survived releases, and what else did

`scripts/update-cask.sh` rewrites `version` and `sha256` in the tap and nothing else, so the rest of a cask body is frozen at whatever was first seeded there. Fixing the stanza only in this repo would have changed nothing for anyone.

Comparing the live tap against this repo's templates turned up the same drift with a worse outcome: the tap's stable cask never picked up `conflicts_with cask: "toki-beta"`, which this repo's template has carried since 3.2.0. The mutual exclusion currently only holds from the beta side.

So the release copies the body from this repo before stamping it, and the template is the cask. A prerelease copies `toki-beta` alone: the stable body would otherwise arrive with the template's placeholder version and nothing on that path to stamp a real one over it.

## Testing

Homebrew 6.0.22 parses the new casks and builds the right artifact, rather than my reading its source and hoping:

```
old: Cask::Artifact::App, Cask::Artifact::PostflightBlock, Cask::Artifact::Zap
new: Cask::Artifact::App, Cask::Artifact::PostflightSteps, Cask::Artifact::Zap
```

and the parsed step plan is the xattr call with its three args and the token intact.

The changed release path was then run for real against a scratch tap:

- **Prerelease (`v3.3.0-beta.1`):** the beta body is replaced from the template and stamped to `3.3.0-beta.1` with sha `c41bc93…`, which matches the digest GitHub reports for that release's DMG. The stable cask is byte-identical before and after.
- **Stable (`3.2.0`):** the stable body is replaced and stamped to sha `b34664f3…`, which is exactly what the live tap's stable cask carries today. The template plus the stamp reproduces the shipped cask.

## Still needs doing, outside this repo

The tap keeps the deprecated stanza until a release rewrites it, and only a stable tag rewrites the stable cask. If the warning should stop before 3.3.0 ships, the same two-line change wants applying to `aashutoshrathi/homebrew-tap` directly.
