### PR TITLE
Show Sarvam's questions on the phone as questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- **Sarvam Code's questions reach your phone as questions.** When Sarvam Code pauses to ask you something, the companion app showed an approval alert carrying raw JSON, whose Approve button blindly submitted whichever option the cursor sat on. The card now renders each question with its tappable options and answers with the option numbers Sarvam's own picker expects.
 - **`brew` stops warning about Toki's casks on every command.** Both casks used `postflight`, which Homebrew now reports as deprecated on every command that touches them. They use the declarative `postflight_steps` instead.
 - **A cask fix now reaches the tap people install from.** The release only ever rewrote `version` and `sha256` there, so a fix anywhere else in a cask stayed behind in this repo. The cask body is copied from here on each release now, then stamped.
 

--- a/Sources/Toki/Resources/toki_remote.py
+++ b/Sources/Toki/Resources/toki_remote.py
@@ -794,6 +794,22 @@ def codex_call_summary(payload):
     return name, ""
 
 
+def sarvam_questions(payload):
+    """Sarvam Code's `request_user_input` carries Claude-shaped questions in the call arguments.
+    Sarvam has no multi-select -- a question is answered by pressing one option's number, which
+    also submits it -- so the multi key asked of normalize_questions is one that never appears."""
+    args = payload.get("arguments")
+    if not isinstance(args, str):
+        return None
+    try:
+        parsed = json.loads(args)
+    except ValueError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return normalize_questions(parsed.get("questions"), "multiSelect")
+
+
 def parse_codex_transcript(path, offset=0):
     entries = []
     try:
@@ -833,9 +849,13 @@ def parse_codex_transcript(path, offset=0):
                         entries.append({"role": "assistant", "text": text})
             elif ptype in ("function_call", "local_shell_call", "custom_tool_call"):
                 name, summary = codex_call_summary(payload)
+                questions = sarvam_questions(payload) if name == "request_user_input" else None
+                if questions:
+                    # The raw arguments are one JSON blob; the question is the readable part.
+                    summary = questions[0].get("question", "")[:160]
                 entries.append({"role": "tool", "tool": name,
                                 "id": payload.get("call_id") or payload.get("id"),
-                                "text": summary, "questions": None})
+                                "text": summary, "questions": questions})
             elif ptype in ("function_call_output", "custom_tool_call_output"):
                 entries.append({"role": "resolved", "id": payload.get("call_id")})
     return entries, offset + consumed
@@ -1034,7 +1054,13 @@ def codex_attention(path):
         elif e["role"] == "resolved":
             pending.pop(e.get("id"), None)
     last = next((pending[i] for i in reversed(order) if i in pending), None)
-    if not last or policy == "never":
+    if not last:
+        return None
+    # A question is not an approval: the policy only auto-answers approvals, so Sarvam's
+    # request_user_input blocks the turn under `never` just the same.
+    if last.get("questions"):
+        return question_attention(last["questions"])
+    if policy == "never":
         return None
     label = last["text"] or last["tool"]
     return {"kind": "permission", "prompt": f"Approve: {label}?", "options": []}

--- a/Sources/Toki/Resources/webui/app.js
+++ b/Sources/Toki/Resources/webui/app.js
@@ -843,6 +843,8 @@ function toggleOption(spec) {
 // OpenCode navigates with arrows/Enter/Tab; Claude selects by number and advances with Tab.
 // Antigravity numbers its options too, but a single-select number both selects and advances (and on
 // the last question submits), while a multi-select number toggles and Enter advances or submits.
+// Sarvam's picker is single-select only and a number alone answers the question and moves on --
+// Enter would resubmit and Tab opens its notes field, so a digit per question is the whole answer.
 function buildKeySequence(provider, questions, sel) {
   const keys = [];
   const anyMulti = questions.some(q => q.multi);
@@ -861,7 +863,7 @@ function buildKeySequence(provider, questions, sel) {
         for (let i = 0, idx = chosen.length ? chosen[0] : 0; i < idx; i++) keys.push("down");
         keys.push("enter");
       }
-    } else if (provider == "antigravity") {
+    } else if (provider == "antigravity" || provider == "sarvam") {
       // The cursor resets to the top of each question, so no inter-question separator: a
       // single-select number carries straight on, and a multi-select needs Enter to move past it.
       chosen.forEach(i => keys.push(String(i + 1)));
@@ -873,7 +875,7 @@ function buildKeySequence(provider, questions, sel) {
     }
   });
   if (provider == "opencode" && (questions.length > 1 || anyMulti)) keys.push("enter");
-  else if (provider != "opencode" && provider != "antigravity" && !isQuickPick(questions)) keys.push("enter");
+  else if (provider != "opencode" && provider != "antigravity" && provider != "sarvam" && !isQuickPick(questions)) keys.push("enter");
   return keys;
 }
 

--- a/Tests/test_remote_control_server.py
+++ b/Tests/test_remote_control_server.py
@@ -442,6 +442,54 @@ class RemoteControlCodexAttentionTests(unittest.TestCase):
         attention = toki_remote.codex_attention(path)
         self.assertEqual(attention["prompt"], "Approve: pnpm test --filter members?")
 
+    SARVAM_ASK = {
+        "type": "function_call", "name": "request_user_input", "call_id": "c3",
+        "arguments": json.dumps({"questions": [{
+            "id": "widget_color", "header": "Color",
+            "question": "Which color should the widget be?",
+            "options": [
+                {"label": "Red", "description": "The widget will use a red color."},
+                {"label": "Blue", "description": "The widget will use a blue color."},
+            ],
+        }]}),
+    }
+
+    def test_pending_request_user_input_is_a_question_not_an_approval(self):
+        path = self._transcript([self.SARVAM_ASK])
+        attention = toki_remote.codex_attention(path)
+        self.assertEqual(attention["kind"], "question")
+        self.assertEqual(attention["prompt"], "Which color should the widget be?")
+        self.assertEqual(attention["options"], ["Red", "Blue"])
+        self.assertEqual(attention["questions"][0]["header"], "Color")
+        self.assertFalse(attention["questions"][0]["multi"])
+
+    def test_an_answered_request_clears_the_question(self):
+        path = self._transcript([self.SARVAM_ASK, {
+            "type": "function_call_output", "call_id": "c3",
+            "output": '{"answers":{"widget_color":{"answers":["Blue"]}}}',
+        }])
+        self.assertIsNone(toki_remote.codex_attention(path))
+
+    def test_a_question_outlives_a_never_approval_policy(self):
+        # `never` silences approvals because the CLI answers them itself; a question has no
+        # such answerer, so the turn is genuinely blocked and the phone must still say so.
+        f = tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False)
+        self.addCleanup(os.unlink, f.name)
+        f.write(json.dumps({"type": "turn_context",
+                            "payload": {"approval_policy": "never"}}) + "\n")
+        f.write(json.dumps({"type": "response_item", "payload": self.SARVAM_ASK}) + "\n")
+        f.close()
+        quiet = time.time() - 60
+        os.utime(f.name, (quiet, quiet))
+        attention = toki_remote.codex_attention(f.name)
+        self.assertEqual(attention["kind"], "question")
+
+    def test_the_transcript_row_reads_as_the_question_not_raw_json(self):
+        path = self._transcript([self.SARVAM_ASK])
+        entries, _ = toki_remote.parse_codex_transcript(path, 0)
+        self.assertEqual(entries[-1]["text"], "Which color should the widget be?")
+        self.assertEqual(len(entries[-1]["questions"]), 1)
+
     def test_dict_arguments_read_as_pairs_not_raw_json(self):
         name, summary = toki_remote.codex_call_summary({
             "type": "function_call", "name": "wait",

--- a/Tests/test_remote_ux.js
+++ b/Tests/test_remote_ux.js
@@ -108,6 +108,10 @@ assert.match(css, /min-height:44px/);
 // accumulated choices into the keystrokes each TUI needs.
 assert.match(app, /function buildKeySequence/);
 assert.match(app, /function toggleOption/);
+// Sarvam's picker submits on the option number itself: no Tab (that opens its notes field) and
+// no trailing Enter (that would resubmit), so it rides Antigravity's digits-only branch.
+assert.match(app, /provider == "antigravity" \|\| provider == "sarvam"/);
+assert.match(app, /provider != "antigravity" && provider != "sarvam"/);
 assert.match(app, /data-submit="1"/);
 assert.match(app, /send\(\{ keys \}\)/);
 // Submit is gated on every question being answered, and the pending answer is keyed by agent pid,


### PR DESCRIPTION
Closes #155.

## What was happening

Sarvam Code's `request_user_input` pauses the turn to ask the user one to three multiple-choice questions. The companion app read the pending call through the generic codex tool path, so the phone showed "Needs your approval" with the call's raw JSON arguments as the prompt. Worse than unreadable: Approve sends Enter, which submits whichever option the picker's cursor sat on, and Reject sends Esc, which interrupts the whole turn.

## The fix

- The codex transcript parser recognises `request_user_input` and lifts its questions through the same normalizer Claude's AskUserQuestion uses; they carry the same shape (`question`, `header`, `options` with `label` and `description`).
- `codex_attention` returns a real question payload for it, so the phone renders tappable options. A question also surfaces under an approval policy of `never`: the policy auto-answers approvals, not questions, and the turn is genuinely blocked.
- Key delivery gets a Sarvam branch: pressing an option's number in its picker both selects and submits the answer and advances to the next question, so a digit per question is the whole sequence. The generic branch would have sent Tab between questions (opens Sarvam's notes field) and a trailing Enter (resubmits).
- The transcript row for the call now reads as the question instead of a JSON blob.

## Verified against the real CLI

Ran `sarvam-code` 0.47.0 in tmux and had it call `request_user_input`:

- Single question: the old code produced `{'kind': 'permission', 'prompt': 'Approve: {"questions":[{"header":"Color",...?'}`; the new code produces a `question` payload with the three options.
- Two questions in one call: `send_sequence(tty, ["2", "1"])`, exactly what the web UI now builds, answered both ("Green", then "Small") and the turn resumed.
- The recorded `function_call_output` resolves the pending call, so the alert clears after answering in either place.

`python3 -m unittest discover -s Tests -p 'test_*.py'` (104 tests) and the Node suites pass.
