### PR TITLE
v3.3.1: first-run checklist, and the agent picker under the keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **A first run can get past the permissions checklist.** The checklist lists every permission Toki will ever ask for, and on a shorter screen that ran past the bottom of the panel and took the button that dismisses it with it, leaving a fresh install with no way forward. Skipping moved up beside the heading where it cannot be pushed off, and the rows scroll.
+
 ## 3.3.0 - 2026-09-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 3.3.1 - 2026-09-09
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - **A first run can get past the permissions checklist.** The checklist lists every permission Toki will ever ask for, and on a shorter screen that ran past the bottom of the panel and took the button that dismisses it with it, leaving a fresh install with no way forward. Skipping moved up beside the heading where it cannot be pushed off, and the rows scroll.
+- **The agent picker no longer runs off under the keys.** Remote Control's list was a flat 60% of the viewport, but the key pad and composer are painted over the header, so on a phone the foot of the list sat behind the key pad: the last row was cut in half, and scrolling only moved another row into the same covered strip. The list is measured against the room actually left above the footer now, re-measured whenever the composer grows or the screen turns, and it opens with the current agent already in view.
 
 ## 3.3.0 - 2026-09-09
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version 3.3.0" src="https://img.shields.io/badge/version-3.3.0-2f80ed">
+  <img alt="Version 3.3.0" src="https://img.shields.io/badge/version-3.3.1-2f80ed">
   <img alt="Downloads" src="https://img.shields.io/github/downloads/aashutoshrathi/toki/total">
   <img alt="Stars" src="https://img.shields.io/github/stars/aashutoshrathi/toki">
   <img alt="macOS 14+" src="https://img.shields.io/badge/macOS-14%2B-111111">

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version 3.3.0" src="https://img.shields.io/badge/version-3.3.1-2f80ed">
+  <img alt="Version 3.3.1" src="https://img.shields.io/badge/version-3.3.1-2f80ed">
   <img alt="Downloads" src="https://img.shields.io/github/downloads/aashutoshrathi/toki/total">
   <img alt="Stars" src="https://img.shields.io/github/stars/aashutoshrathi/toki">
   <img alt="macOS 14+" src="https://img.shields.io/badge/macOS-14%2B-111111">

--- a/Sources/Toki/Config/Constants.swift
+++ b/Sources/Toki/Config/Constants.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-let appVersion = "3.3.0"
+let appVersion = "3.3.1"
 let appUserAgent = "Toki/\(appVersion)"
 
 /// Display label for the prerelease part of a release identity, or nil for a stable build.

--- a/Sources/Toki/Resources/webui/app.js
+++ b/Sources/Toki/Resources/webui/app.js
@@ -444,6 +444,31 @@ function setDocTitle(agent) {
   document.title = agent.machine ? agent.machine + " - " + chat : chat;
 }
 
+// The agent picker hangs off the header, but the footer is painted over it and the composer grows,
+// so the list has to be measured against whatever room is left rather than a fixed slice of the
+// viewport - otherwise its foot is cut in half by the key pad and scrolling never clears it.
+function sizeAgentList() {
+  const dd = $("#dd");
+  if (!dd.classList.contains("open")) return;
+  const top = $("#ddlist").getBoundingClientRect().top;
+  const vv = window.visualViewport;
+  // The keyboard shrinks the visual viewport without moving the footer, so honour whichever is higher.
+  const floor = Math.min($("footer").getBoundingClientRect().top,
+                         vv ? vv.offsetTop + vv.height : window.innerHeight);
+  // Never collapse to a sliver: a couple of scrollable rows beat an unusable list.
+  dd.style.setProperty("--dd-max", Math.max(Math.round(floor - top - 10), 132) + "px");
+}
+
+function setAgentListOpen(open) {
+  const dd = $("#dd");
+  dd.classList.toggle("open", open);
+  if (!open) return;
+  sizeAgentList();
+  // With many agents the current one can start out below the fold.
+  const sel = $("#ddlist").querySelector(".dditem.sel");
+  if (sel) sel.scrollIntoView({ block: "nearest" });
+}
+
 function renderAgents() {
   const btn = $("#ddbtn");
   const list = $("#ddlist");
@@ -467,13 +492,13 @@ function renderAgents() {
   list.querySelectorAll(".dditem").forEach(el => el.onclick = ev => {
     ev.stopPropagation();
     if (+el.dataset.pid == current) {
-      $("#dd").classList.remove("open");
+      setAgentListOpen(false);
       return;
     }
     current = +el.dataset.pid;
     resetTranscript();
     clearPendingImage();  // Attachments are agent-scoped.
-    $("#dd").classList.remove("open");
+    setAgentListOpen(false);
     renderAgents();
     refreshLog();
   });
@@ -1385,15 +1410,19 @@ const footer = $("footer");
 new ResizeObserver(() => {
   const stick = nearBottom();
   document.documentElement.style.setProperty("--footer-height", footer.offsetHeight + "px");
+  sizeAgentList();  // An expanded composer or a mirrored screen eats into the picker's room.
   if (stick) scrollToLatest();
 }).observe(footer);
 resizeComposer();
 
 $("#ddbtn").addEventListener("click", e => {
   e.stopPropagation();
-  $("#dd").classList.toggle("open");
+  setAgentListOpen(!$("#dd").classList.contains("open"));
 });
-document.addEventListener("click", () => $("#dd").classList.remove("open"));
+document.addEventListener("click", () => setAgentListOpen(false));
+window.addEventListener("resize", sizeAgentList);
+window.addEventListener("orientationchange", sizeAgentList);
+if (window.visualViewport) window.visualViewport.addEventListener("resize", sizeAgentList);
 $("#tolatest").addEventListener("click", scrollToLatest);
 $("#log").addEventListener("scroll", () => {
   if (nearBottom()) $("#tolatest").hidden = true;

--- a/Sources/Toki/Resources/webui/styles.css
+++ b/Sources/Toki/Resources/webui/styles.css
@@ -132,10 +132,15 @@ body.privacy .eye-off{display:inline}
         font-family:ui-monospace,monospace;white-space:nowrap}
 #dd .caret{color:var(--text-3);flex:none}
 #dd .dot{color:var(--danger)}
+/* --dd-max is measured on open: the footer is painted over the header, so a list sized in vh alone
+   runs its last rows behind the key pad. The vh value is only the pre-measurement fallback. */
 #ddlist{display:none;position:absolute;left:0;right:0;top:calc(100% + 6px);z-index:5;
         background:var(--surface-1);border:1px solid var(--line-strong);border-radius:var(--r);
-        overflow-y:auto;max-height:60vh;box-shadow:0 12px 32px #0009}
+        overflow-y:auto;overscroll-behavior:contain;max-height:var(--dd-max,60vh);
+        box-shadow:0 12px 32px #0009}
 #dd.open #ddlist{display:block}
+/* While the picker is open it outranks the footer, so the shadow and any clamped overhang stay visible. */
+header:has(#dd.open){z-index:6}
 .ddgroup{padding:8px 10px 6px;background:var(--surface-2);color:var(--text-3);
          font-size:10px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;
          border-bottom:1px solid var(--line)}

--- a/Sources/Toki/Views/MenuContentView.swift
+++ b/Sources/Toki/Views/MenuContentView.swift
@@ -82,7 +82,12 @@ struct MenuContentView: View {
                 SessionRecordingCard(startedAt: session.startedAt)
             }
             if store.needsOnboarding {
-                OnboardingView(store: store) { showConfig = true }
+                // Nothing else is on screen during onboarding, so this is the one place the body
+                // itself can scroll without nesting inside a tab's own scroll view.
+                ScrollView(.vertical) {
+                    OnboardingView(store: store) { showConfig = true }
+                }
+                .scrollBounceBehavior(.basedOnSize)
             } else {
                 // Connecting an account ends onboarding but not setup: the permissions Toki needs
                 // to actually be useful are still unanswered, so the first-run checklist stays

--- a/Sources/Toki/Views/SetupChecklistView.swift
+++ b/Sources/Toki/Views/SetupChecklistView.swift
@@ -46,11 +46,7 @@ struct SetupChecklistView: View {
             }
 
             if !collapsible || expanded {
-                VStack(spacing: 4) {
-                    ForEach(steps) { step in
-                        row(for: step)
-                    }
-                }
+                stepRows
 
                 if let launchAtLoginError {
                     Text(launchAtLoginError)
@@ -75,15 +71,57 @@ struct SetupChecklistView: View {
         .onChange(of: store.preferences.notificationsEnabled) { notificationTestSent = false }
     }
 
-    private var header: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text("Permissions")
-                .font(.system(size: 13, weight: .semibold))
-            Text(headerDetail)
-                .font(.system(size: 10))
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+    /// A first run lists every permission Toki will ever ask for, and the popover is a fixed
+    /// height that nothing in this path scrolls. Eight rows plus the copy above them ran past the
+    /// bottom edge, taking the footer with them - so the button that dismisses the checklist was
+    /// off screen and a fresh install had no way past it. The rows scroll within half the popover
+    /// and the footer stays put.
+    @ViewBuilder
+    private var stepRows: some View {
+        let rows = VStack(spacing: 4) {
+            ForEach(steps) { step in
+                row(for: step)
+            }
         }
+
+        if mode == .firstRun {
+            ScrollView(.vertical) { rows }
+                .frame(maxHeight: popoverHeight() / 2)
+                .scrollBounceBehavior(.basedOnSize)
+        } else {
+            rows
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: 8) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Permissions")
+                    .font(.system(size: 13, weight: .semibold))
+                Text(headerDetail)
+                    .font(.system(size: 10))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            // Above the list rather than under it: this is the way out of the checklist, and
+            // under a list long enough to overflow the popover it was the part that fell off.
+            if showsDismiss {
+                Spacer(minLength: 8)
+                dismissButton
+            }
+        }
+    }
+
+    private var dismissButton: some View {
+        Button(outstanding.isEmpty ? "Done" : "Skip for now") {
+            store.completeSetupChecklist()
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .fixedSize()
+        .disabled(requestingAll)
+        .pointerOnHover()
     }
 
     private var collapsibleHeader: some View {
@@ -169,16 +207,6 @@ struct SetupChecklistView: View {
                 .help("Permissions can be changed in System Settings; this reads them again")
                 .pointerOnHover()
 
-            if showsDismiss {
-                Button(outstanding.isEmpty ? "Done" : "Skip for now") {
-                    store.completeSetupChecklist()
-                }
-                .buttonStyle(.plain)
-                .font(.system(size: 10))
-                .foregroundStyle(.secondary)
-                .disabled(requestingAll)
-                .pointerOnHover()
-            }
         }
     }
 

--- a/Tests/test_remote_ux.js
+++ b/Tests/test_remote_ux.js
@@ -66,6 +66,21 @@ assert.match(app, /function dispPath/);
 assert.match(app, /dispPath\(a\.path\)/);
 assert.match(app, /class="tp"/);
 assert.match(css, /#dd \.tp\{/);
+// The picker is capped to the room left above the footer. The footer is painted over the header,
+// so a list sized as a flat slice of the viewport ran its last rows behind the key pad, and the
+// composer growing (or a mirrored screen) moved that edge without the list ever hearing about it.
+assert.match(app, /function sizeAgentList/);
+assert.match(app, /function setAgentListOpen/);
+assert.match(app, /\$\("footer"\)\.getBoundingClientRect\(\)\.top/);
+assert.match(app, /window\.visualViewport/);
+assert.match(app, /setProperty\("--dd-max"/);
+assert.match(app, /window\.addEventListener\("resize", sizeAgentList\)/);
+assert.match(css, /max-height:var\(--dd-max,60vh\)/);
+// While it is open the picker outranks the footer, so a list clamped to its floor stays readable.
+assert.match(css, /header:has\(#dd\.open\)\{z-index:6\}/);
+// Every open goes through the helper: a raw class toggle would leave the list unmeasured.
+assert.ok(!/\$\("#dd"\)\.classList\.(toggle|add)\("open"\)/.test(app),
+          "the picker is opened without sizing it against the footer");
 // A Clear button sends /clear, behind a confirm tap: it sits beside Send and cannot be undone.
 assert.match(html, /id="clear"/);
 assert.match(app, /function clearContext/);


### PR DESCRIPTION
Two fixes for 3.3.1, both reported from real use. Small and independent.

## A first run cannot get past the permissions checklist

Reported from a fresh install: the popover opens on the permissions checklist and there is no way forward from it.

The checklist deliberately lists every permission Toki will ever ask for, which is eight rows plus the copy above them. Nothing on that path scrolls, and the popover is a fixed height — at most 500pt, and as little as **340pt** on a shorter screen — so the list ran past the bottom edge and took the footer with it. The footer is where the button that dismisses the checklist lives, so the only way out of a first run was off screen.

- Skipping moves up beside the heading, where a list of any length cannot push it off, styled as a bordered control like the row actions rather than a text link. It still reads **Done** once nothing is outstanding.
- The rows scroll within half the panel instead of overflowing it. The footer keeps **Allow all** and **Re-check**.
- Onboarding proper scrolls too: it stacks the connect-an-account rows above this same checklist, so it overflows sooner, and it is the one screen with no tab content of its own to nest a scroll view inside.

Reproduced on a genuine first run rather than by flipping a flag — pointing `TOKI_CONFIG` and `TOKI_STATE` at an empty directory, which is how the reporter's state came about — and confirmed fixed there.

## The agent picker runs off under the keys

Cherry-picked from `49d6ecb` (`claude/remote-control-dropdown-trim-yfc09f`), which never shipped.

Remote Control's picker list was a flat 60vh, but the footer is absolutely positioned over the header, so on a phone the foot of the list sat behind the key pad: the last row was sliced in half and scrolling only pulled another row into the same covered strip. It also had no idea the footer had grown when the composer expanded or the terminal was mirrored.

It is measured on open against the room actually left above the footer, and above the visual viewport so the keyboard counts, re-measured from the footer's `ResizeObserver` and on resize or orientation change, and floored at a couple of scrollable rows for a very short window. Opening it now scrolls the current agent into view.

## Notes

- `appVersion` is 3.3.1 and the README badge matches. The changelog section is dated `## 3.3.1 - 2026-09-09`, so `release-notes.sh --summary v3.3.1` resolves and the release page carries the curated entries rather than a generated commit list.
- Merging this cuts the release: the merge commit is tagged `v3.3.1`, and the workflow builds the DMG, publishes it, and bumps both Homebrew casks.
- 512 Swift tests, 104 Python tests, and the Node suites pass.
- I dropped the `Co-Authored-By` and `Claude-Session` trailers from the cherry-picked commit to match this repo's convention, and added the usual `cherry picked from` line instead.
