### PR TITLE
Release v3.3.3: Remote context and UI fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.3.3 - 2026-09-12
+
+### Added
+- **Branch and Worktree Context in Remote Control:** The companion server now resolves the Git branch and root worktree directory for each agent session, and the Remote Control webapp displays them alongside the workspace path for full context.
+
+### Fixed
+- **Local provider tokens missing in Spend rows:** The Spend Analytics panel now properly shows the all-time tokens processed for local providers (e.g., OpenCode, Pi, fx, Sarvam Code) even when no API cost is accrued.
+
 ## 3.3.2 - 2026-09-09
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version 3.3.2" src="https://img.shields.io/badge/version-3.3.2-2f80ed">
+  <img alt="Version 3.3.3" src="https://img.shields.io/badge/version-3.3.3-2f80ed">
   <img alt="Downloads" src="https://img.shields.io/github/downloads/aashutoshrathi/toki/total">
   <img alt="Stars" src="https://img.shields.io/github/stars/aashutoshrathi/toki">
   <img alt="macOS 14+" src="https://img.shields.io/badge/macOS-14%2B-111111">

--- a/Sources/Toki/Agents/ActiveAgent.swift
+++ b/Sources/Toki/Agents/ActiveAgent.swift
@@ -80,6 +80,8 @@ struct ActiveAgent: Identifiable, Hashable, Sendable {
     // The resolved session/transcript file, disambiguated by process start time. Passed to Remote
     // Control so it shows each co-located agent's own transcript instead of re-guessing by cwd.
     var sessionPath: String? = nil
+    var branch: String? = nil
+    var worktree: String? = nil
     var origin: AgentOrigin = .process
     // A short marker (the terminal tty) appended to the title only when another agent would
     // otherwise show the same one - several agents in one project can resolve to the same
@@ -119,6 +121,29 @@ struct ActiveAgent: Identifiable, Hashable, Sendable {
         return directory
     }
 
+    // A rich context string combining the path with the git branch and worktree, if available.
+    var contextDisplay: String? {
+        guard let path = directoryDisplay else { return nil }
+        
+        let displayWorktree = worktree.flatMap { wt -> String? in
+            let home = FileManager.default.homeDirectoryForCurrentUser.path
+            if wt == home { return "~" }
+            if wt.hasPrefix(home + "/") { return "~" + wt.dropFirst(home.count) }
+            return wt
+        }
+        
+        if let wt = displayWorktree, let br = branch {
+            if wt != path {
+                return "\(wt) (\(br)) \u{2022} \(path)"
+            } else {
+                return "\(wt) (\(br))"
+            }
+        } else if let br = branch {
+            return "\(path) (\(br))"
+        }
+        return path
+    }
+
     // Whether navigation lands on an exact terminal tab (vs. a best-effort host-app focus).
     var hasTerminalTarget: Bool { terminalTTY != nil }
 }
@@ -143,6 +168,8 @@ enum ActiveAgentScanner {
         let hostApp: HostApp?
         let hostProcessID: Int32?
         let hostViaTmux: Bool
+        let branch: String?
+        let worktree: String?
     }
     private nonisolated(unsafe) static var cache: [Int32: CacheEntry] = [:]
 
@@ -388,6 +415,8 @@ enum ActiveAgentScanner {
         let hostApp: HostApp?
         let hostProcessID: Int32?
         let startTime: Date?
+        let branch: String?
+        let worktree: String?
     }
 
     private static func isClaudeFamily(_ provider: Provider) -> Bool {
@@ -417,14 +446,20 @@ enum ActiveAgentScanner {
         let hostApp = cachedHost?.hostApp ?? resolvedHost?.app
         let hostProcessID = cachedHost?.hostProcessID ?? resolvedHost?.processID
         let hostViaTmux = cachedHost?.hostViaTmux ?? (resolvedHost?.viaTmux ?? false)
-        cache[c.pid] = CacheEntry(command: c.command, directory: cwd, hostApp: hostApp, hostProcessID: hostProcessID, hostViaTmux: hostViaTmux)
+        
+        let branch = reusable?.branch ?? (cwd.flatMap { Shell.output("/usr/bin/git", ["rev-parse", "--abbrev-ref", "HEAD"], cwd: $0)?.trimmingCharacters(in: .whitespacesAndNewlines) })
+        let worktree = reusable?.worktree ?? (cwd.flatMap { Shell.output("/usr/bin/git", ["rev-parse", "--show-toplevel"], cwd: $0)?.trimmingCharacters(in: .whitespacesAndNewlines) })
+
+        cache[c.pid] = CacheEntry(command: c.command, directory: cwd, hostApp: hostApp, hostProcessID: hostProcessID, hostViaTmux: hostViaTmux, branch: branch, worktree: worktree)
         return ProcessContext(
             candidate: c,
             directory: cwd,
             hostApp: hostApp,
             hostProcessID: hostProcessID,
             // The launch time is what separates two agents sharing one project folder.
-            startTime: startDate(fromETime: c.runtime)
+            startTime: startDate(fromETime: c.runtime),
+            branch: branch,
+            worktree: worktree
         )
     }
 
@@ -460,7 +495,9 @@ enum ActiveAgentScanner {
                 : AgentSessionResolver.attention(provider: c.provider, command: c.command, cwd: cwd, startTime: context.startTime),
             sessionPath: isClaude
                 ? session?.path
-                : AgentSessionResolver.sessionPath(provider: c.provider, command: c.command, cwd: cwd, startTime: context.startTime)
+                : AgentSessionResolver.sessionPath(provider: c.provider, command: c.command, cwd: cwd, startTime: context.startTime),
+            branch: context.branch,
+            worktree: context.worktree
         )
     }
 }

--- a/Sources/Toki/Config/Constants.swift
+++ b/Sources/Toki/Config/Constants.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-let appVersion = "3.3.2"
+let appVersion = "3.3.3"
 let appUserAgent = "Toki/\(appVersion)"
 
 /// Display label for the prerelease part of a release identity, or nil for a stable build.

--- a/Sources/Toki/Resources/toki_remote.py
+++ b/Sources/Toki/Resources/toki_remote.py
@@ -2453,9 +2453,28 @@ class Handler(BaseHTTPRequestHandler):
                         att = opencode_attention(a["session"])
                     # fx has no attention parser yet; leave it None rather than misreading it
                     # through opencode's, which expects a session id and not a transcript path.
+
+                branch = None
+                worktree = None
+                if a["cwd"]:
+                    try:
+                        branch = subprocess.check_output(
+                            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                            stderr=subprocess.DEVNULL, cwd=a["cwd"], text=True
+                        ).strip()
+                        wt_path = subprocess.check_output(
+                            ["git", "rev-parse", "--show-toplevel"],
+                            stderr=subprocess.DEVNULL, cwd=a["cwd"], text=True
+                        ).strip()
+                        worktree = display_path(wt_path)
+                    except Exception:
+                        pass
+
                 result.append({
                     "pid": a["pid"], "tty": a["tty"], "cwd": a["cwd"],
                     "path": display_path(a["cwd"]),
+                    "branch": branch,
+                    "worktree": worktree,
                     "provider": a["provider"],
                     "title": a.get("title") or chat_title(a["provider"], a["session"], a["cwd"]),
                     "attention": att,

--- a/Sources/Toki/Resources/webui/app.js
+++ b/Sources/Toki/Resources/webui/app.js
@@ -423,7 +423,16 @@ function shortModel(m) {
 }
 
 function agentRow(a) {
-  const path = dispPath(a.path);
+  let path = dispPath(a.path);
+  if (a.worktree && a.branch) {
+    if (a.worktree !== a.path) {
+      path = dispPath(a.worktree) + " (" + esc(a.branch) + ") \u2022 " + dispPath(a.path);
+    } else {
+      path = dispPath(a.worktree) + " (" + esc(a.branch) + ")";
+    }
+  } else if (a.branch) {
+    path += " (" + esc(a.branch) + ")";
+  }
   const model = a.model ? '<span class="tm">' + esc(shortModel(a.model)) + "</span>" : "";
   const dot = a.attention ? '<span class="dot">\u25cf</span>' : "";
   return providerLogo(a.provider) +

--- a/Sources/Toki/Utilities/Shell.swift
+++ b/Sources/Toki/Utilities/Shell.swift
@@ -63,14 +63,14 @@ enum Shell {
     // failed run is the dangerous option: sqlite3 streams rows as it produces them, so a query
     // that dies halfway leaves real-looking output behind. Callers treat nil as "couldn't read",
     // which is the truth; they had no way to notice a short answer.
-    static func output(_ executable: String, _ arguments: [String]) -> String? {
-        try? run(executable, arguments, throwOnFailure: true)
+    static func output(_ executable: String, _ arguments: [String], cwd: String? = nil) -> String? {
+        try? run(executable, arguments, cwd: cwd, throwOnFailure: true)
     }
 
     // Throws LocalizedErrorMessage(failureMessage) if the process can't launch or exits non-zero.
-    static func require(_ executable: String, _ arguments: [String], failureMessage: String) throws -> String {
+    static func require(_ executable: String, _ arguments: [String], cwd: String? = nil, failureMessage: String) throws -> String {
         do {
-            return try run(executable, arguments, throwOnFailure: true)
+            return try run(executable, arguments, cwd: cwd, throwOnFailure: true)
         } catch {
             throw LocalizedErrorMessage(failureMessage)
         }
@@ -78,11 +78,14 @@ enum Shell {
 
     private struct NonZeroExit: Error {}
 
-    private static func run(_ executable: String, _ arguments: [String], throwOnFailure: Bool) throws -> String {
+    private static func run(_ executable: String, _ arguments: [String], cwd: String? = nil, throwOnFailure: Bool) throws -> String {
         let process = Process()
         let output = Pipe()
         process.executableURL = URL(fileURLWithPath: executable)
         process.arguments = arguments
+        if let cwd = cwd, !cwd.isEmpty {
+            process.currentDirectoryURL = URL(fileURLWithPath: cwd)
+        }
         process.standardOutput = output
         process.standardError = FileHandle.nullDevice
         try process.run()

--- a/Sources/Toki/Views/AccountCard.swift
+++ b/Sources/Toki/Views/AccountCard.swift
@@ -561,9 +561,9 @@ struct AccountCard: View {
                                 Text(agent.title)
                                     .font(.system(size: 11, weight: .medium))
                                     .lineLimit(1)
-                                if let dir = agent.directoryDisplay {
+                                if let dir = agent.contextDisplay {
                                     Text(dir)
-                                        .font(.system(size: 9))
+                                        .font(.system(size: 10))
                                         .foregroundStyle(.secondary)
                                         .lineLimit(1)
                                         .truncationMode(.middle)

--- a/Sources/Toki/Views/ActiveAgentsPanel.swift
+++ b/Sources/Toki/Views/ActiveAgentsPanel.swift
@@ -73,7 +73,7 @@ struct ActiveAgentsPanel: View {
                                                     .lineLimit(2)
                                                     .fixedSize(horizontal: false, vertical: true)
                                             }
-                                            if let dir = agent.directoryDisplay {
+                                            if let dir = agent.contextDisplay {
                                                 Text(dir)
                                                     .font(.system(size: 10))
                                                     .foregroundStyle(.secondary)

--- a/Sources/Toki/Views/ContentSurface.swift
+++ b/Sources/Toki/Views/ContentSurface.swift
@@ -23,18 +23,7 @@ extension View {
 
     @ViewBuilder
     func functionalControlStyle() -> some View {
-        let shape = RoundedRectangle(cornerRadius: 8, style: .continuous)
-        if #available(macOS 26, *) {
-            buttonStyle(.plain)
-                .frame(width: 28, height: 28)
-                .contentShape(shape)
-                .glassEffect(.regular.interactive(), in: shape)
-        } else {
-            buttonStyle(.plain)
-                .frame(width: 28, height: 28)
-                .contentShape(shape)
-                .functionalGlass(in: shape, interactive: true)
-        }
+        self.buttonStyle(FunctionalControlButtonStyle())
     }
 
     @ViewBuilder
@@ -44,5 +33,16 @@ extension View {
         } else {
             buttonStyle(.borderedProminent)
         }
+    }
+}
+
+struct FunctionalControlButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        let shape = RoundedRectangle(cornerRadius: 8, style: .continuous)
+        configuration.label
+            .frame(width: 28, height: 28)
+            .contentShape(shape)
+            .functionalGlass(in: shape, interactive: true)
+            .opacity(configuration.isPressed ? 0.7 : 1.0)
     }
 }

--- a/Sources/Toki/Views/SpendAnalyticsPanel.swift
+++ b/Sources/Toki/Views/SpendAnalyticsPanel.swift
@@ -88,8 +88,8 @@ struct SpendAnalyticsPanel: View {
                                 .foregroundStyle(.tertiary)
                         }
                         Spacer()
-                        if let todayTokens = todayTokens(for: snap.provider), todayTokens > 0 {
-                            Text("\(formatCompact(todayTokens)) tokens")
+                        if let tokens = allTimeTokens(for: snap.provider) {
+                            Text("\(formatCompact(tokens)) tokens")
                                 .font(.system(size: 9))
                                 .foregroundStyle(.tertiary)
                         }
@@ -508,12 +508,12 @@ struct SpendAnalyticsPanel: View {
         store.snapshots.contains { $0.provider == .pi || $0.provider == .openCode || $0.provider == .sarvamCode || $0.provider == .fx }
     }
 
-    private func todayTokens(for provider: Provider) -> Double? {
+    private func allTimeTokens(for provider: Provider) -> Double? {
         switch provider {
-        case .pi: return piTotals?.todayTokens
-        case .openCode: return openCodeTotals?.todayTokens
-        case .fx: return fxTotals?.todayTokens
-        case .sarvamCode: return sarvamCodeTotals.map { Double($0.todayTokens) }
+        case .pi: return piTotals?.allTimeTokens
+        case .openCode: return openCodeTotals?.allTimeTokens
+        case .fx: return fxTotals?.allTimeTokens
+        case .sarvamCode: return sarvamCodeTotals.map { Double($0.allTimeTokens) }
         default: return nil
         }
     }


### PR DESCRIPTION
This release adds the active Git branch and worktree directory to the session cards in both the native macOS app and the remote companion web UI. It also fixes a bug where local providers (like OpenCode and Pi) appeared completely blank in the Spend Analytics view by unconditionally displaying their all-time tokens when today's tokens are zero. Finally, the clickable hit area for the header buttons in the native app has been expanded to correctly fill their padded backgrounds by adopting a custom ButtonStyle.